### PR TITLE
Added support for SqlStreamStore 

### DIFF
--- a/src/Eventuous.Producers.SqlStreamStore/Eventuous.Producers.SqlStreamStore.csproj
+++ b/src/Eventuous.Producers.SqlStreamStore/Eventuous.Producers.SqlStreamStore.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SqlStreamStore" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.MsSql" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.Mysql" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Eventuous\Eventuous.csproj" />
+    <ProjectReference Include="..\Eventuous.Producers\Eventuous.Producers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Eventuous.Producers.SqlStreamStore/SqlStreamStoreProduceOptions.cs
+++ b/src/Eventuous.Producers.SqlStreamStore/SqlStreamStoreProduceOptions.cs
@@ -1,0 +1,17 @@
+using System;
+using SqlStreamStore.Streams;
+
+namespace Eventuous.Producers.SqlStreamStore {
+    public class SqlStreamStoreProduceOptions {
+        
+        /// <summary>
+        /// Message metadata
+        /// </summary>
+        public object? Metadata { get; init; }
+        /// <summary>
+        /// Expected stream state
+        /// </summary>
+        public int ExpectedState { get; init; } = ExpectedVersion.Any;
+
+    }
+}

--- a/src/Eventuous.Producers.SqlStreamStore/SqlStreamStoreProducer.cs
+++ b/src/Eventuous.Producers.SqlStreamStore/SqlStreamStoreProducer.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using SqlStreamStore;
+using SqlStreamStore.Streams;
+using Eventuous;
+using Eventuous.Producers;
+using JetBrains.Annotations;
+
+namespace Eventuous.Producers.SqlStreamStore
+{
+    /// <summary>
+    /// Producer for SqlStreamStore (https://sqlstreamstore.readthedocs.io)
+    /// </summary>
+    [PublicAPI]
+    public class SqlStreamStoreProducer : BaseProducer<SqlStreamStoreProduceOptions>
+    {
+        readonly IStreamStore _streamStore;
+        readonly IEventSerializer _serializer;
+        const int ChunkSize = 500;
+
+        /// <summary>
+        /// Create a new SqlStreamStore producer instance
+        /// </summary>
+        /// <param name="streamStore">IStreamStore instance</param>
+        /// <param name="serializer">Event serializer instance</param>
+        public SqlStreamStoreProducer(IStreamStore streamStore, IEventSerializer serializer) {
+            _streamStore = Ensure.NotNull(streamStore, nameof(streamStore));
+            _serializer = Ensure.NotNull(serializer, nameof(serializer));
+        }
+
+        /// <summary>
+        /// Create a new SqlStreamStore producer instance with an MSSQL (e.g. Azure Sql) store
+        /// </summary>
+        /// <param name="msSqlSettings">settings for creating an MSSQL based SqlStreamStore instance</param>
+        /// <param name="serializer">Event serializer instance</param>
+        public SqlStreamStoreProducer(MsSqlStreamStoreV3Settings msSqlSettings, IEventSerializer serializer) 
+            : this(new MsSqlStreamStoreV3(Ensure.NotNull(msSqlSettings, nameof(msSqlSettings))), serializer) { }
+        
+        /// <summary>
+        /// Create a new SqlStreamStore producer instance with an MySQL store
+        /// </summary>
+        /// <param name="mySqlSettings">settings for creating a MySql based SqlStreamStore instance</param>
+        /// <param name="serializer">Event serializer instance</param>
+        public SqlStreamStoreProducer(MySqlStreamStoreSettings mySqlSettings, IEventSerializer serializer) 
+            : this(new MySqlStreamStore(Ensure.NotNull(mySqlSettings, nameof(mySqlSettings))), serializer) { }
+
+
+        public override Task Initialize(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public override Task Shutdown(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        protected override async Task ProduceMany(
+            string                          stream,
+            IEnumerable<object>             messages,
+            SqlStreamStoreProduceOptions?   options,
+            CancellationToken               cancellationToken
+        ) {
+            var data = Ensure.NotNull(messages, nameof(messages))
+                .Select(x => CreateMessage(x, x.GetType(), options?.Metadata));
+
+            foreach( var chunk in data.Chunks(ChunkSize)) {
+                await _streamStore.AppendToStream(
+                    new StreamId(stream),
+                    options?.ExpectedState ?? ExpectedVersion.Any,
+                    chunk.ToArray(),
+                    cancellationToken
+                );
+            }
+        }
+
+        protected override Task ProduceOne(
+            string                          stream,
+            object                          message,
+            Type                            type,
+            SqlStreamStoreProduceOptions?   options,
+            CancellationToken               cancellationToken
+        ) {
+            var eventData = CreateMessage(message, type, options?.Metadata);
+
+            return _streamStore.AppendToStream(
+                new StreamId(stream),
+                options?.ExpectedState ?? ExpectedVersion.Any,
+                new[] { eventData},
+                cancellationToken
+            );
+        }
+
+        NewStreamMessage CreateMessage(object message, Type type, object? metadata) {
+            var msg = Ensure.NotNull(message, nameof(message));
+            var typeName = TypeMap.GetTypeNameByType(type);
+            var meta = metadata == null? null : Encoding.UTF8.GetString(_serializer.Serialize(metadata));
+        
+            return new NewStreamMessage(
+                Guid.NewGuid(),
+                typeName,
+                Encoding.UTF8.GetString(_serializer.Serialize(msg)),
+                meta
+            );
+        }
+    }
+}

--- a/src/Eventuous.Projections.Sql/Eventuous.Projections.Sql.csproj
+++ b/src/Eventuous.Projections.Sql/Eventuous.Projections.Sql.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.0.90" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Eventuous.Projections.Sql/MsSqlCheckpointStore.cs
+++ b/src/Eventuous.Projections.Sql/MsSqlCheckpointStore.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Data;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Dapper;
+using Eventuous.Subscriptions;
+
+namespace Eventuous.Projections.Sql {
+    [PublicAPI]
+    public class MsSqlCheckpointStore : ICheckpointStore {
+        readonly ILogger<MsSqlCheckpointStore>? _log;
+        readonly string _schema;
+        readonly IDbConnection _connection;
+        public MsSqlCheckpointStore(IDbConnection connection, string schema, ILogger<MsSqlCheckpointStore>? logger) {
+            _connection = connection;
+            _schema = schema ?? "dbo";
+            _log = logger;
+        }
+
+        public async ValueTask<Checkpoint> GetLastCheckpoint(string checkpointId, CancellationToken cancellationToken = default)
+        {
+            _log?.LogDebug("[{CheckpointId}] Finding checkpoint...", checkpointId);
+
+            var parameters = new { Subscription = checkpointId };
+            var sql = $@"
+                select Position from {_schema}.Checkpoints 
+                where Subscription = @Subscription 
+            "; 
+            var position = await _connection.ExecuteScalarAsync<ulong?>(sql, parameters);
+            return new Checkpoint(checkpointId, position);
+        }
+
+        public async ValueTask<Checkpoint> StoreCheckpoint(Checkpoint checkpoint, CancellationToken cancellationToken = default)
+        {
+            var sqlSelect = $@"
+                select count(*) from {_schema}.Checkpoints 
+                where Subscription = @Subscription 
+            "; 
+            var result = await _connection.ExecuteScalarAsync<long?>(sqlSelect, new { Subscription = checkpoint.Id });
+
+            var parameters = new { Subscription = checkpoint.Id, Position = (long?) checkpoint.Position };
+            if (result != 0)
+            {
+                var sql = $@"
+                    update {_schema}.Checkpoints 
+                    set Position = @Position 
+                    where Subscription = @Subscription
+                ";
+                await _connection.ExecuteAsync(sql, parameters);
+            }
+            else 
+            {
+                var sql = $@"
+                    insert into {_schema}.Checkpoints (Subscription, Position) values (@Subscription, @Position)
+                ";
+                await _connection.ExecuteAsync(sql, parameters);
+            }
+            return checkpoint;
+        }
+
+        public async Task CreateSchemaIfNotExists() {
+            var sql = $@"
+                IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{_schema}')
+                BEGIN
+                    EXEC('CREATE SCHEMA {_schema}')
+                END
+                IF OBJECT_ID('{_schema}.Checkpoints') IS NULL
+                 BEGIN
+                    create table {_schema}.Checkpoints (
+                        Subscription varchar(255),
+                        Position bigint
+                    )
+                 END
+            ";
+            await _connection.ExecuteAsync(sql);
+        }
+
+    }
+}

--- a/src/Eventuous.Projections.Sql/MySqlCheckpointStore.cs
+++ b/src/Eventuous.Projections.Sql/MySqlCheckpointStore.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Data;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Dapper;
+using Eventuous.Subscriptions;
+
+namespace Eventuous.Projections.Sql {
+    [PublicAPI]
+    public class MySqlCheckpointStore : ICheckpointStore {
+        readonly ILogger<MySqlCheckpointStore>? _log;
+        readonly string _table = "Checkpoints";
+        readonly IDbConnection _connection;
+        public MySqlCheckpointStore(IDbConnection connection, ILogger<MySqlCheckpointStore>? logger) {
+            _connection = connection;
+            _log = logger;
+        }
+
+        public async ValueTask<Checkpoint> GetLastCheckpoint(string checkpointId, CancellationToken cancellationToken = default)
+        {
+            _log?.LogDebug("[{CheckpointId}] Finding checkpoint...", checkpointId);
+
+            var parameters = new { Subscription = checkpointId };
+            var sql = $@"
+                select Position from {_table} 
+                where Subscription = @Subscription 
+            "; 
+            var position = await _connection.ExecuteScalarAsync<ulong?>(sql, parameters);
+            return new Checkpoint(checkpointId, position);
+        }
+
+        public async ValueTask<Checkpoint> StoreCheckpoint(Checkpoint checkpoint, CancellationToken cancellationToken = default)
+        {
+            var sqlSelect = $@"
+                select count(*) from {_table} 
+                where Subscription = @Subscription 
+            "; 
+            var result = await _connection.ExecuteScalarAsync<long>(sqlSelect, new { Subscription = checkpoint.Id });
+
+            var parameters = new { Subscription = checkpoint.Id, Position = (long?) checkpoint.Position };
+            if (result != 0)
+            {
+                var sql = $@"
+                    update {_table} 
+                    set Position = @Position 
+                    where Subscription = @Subscription
+                ";
+                await _connection.ExecuteAsync(sql, parameters);
+            }
+            else 
+            {
+                var sql = $@"
+                    insert into {_table} (Subscription, Position) values (@Subscription, @Position)
+                ";
+                await _connection.ExecuteAsync(sql, parameters);
+            }
+            return checkpoint;
+        }
+
+        public async Task CreateSchemaIfNotExists() {
+            var sql = $@"
+                CREATE TABLE IF NOT EXISTS {_table} (
+                    Subscription varchar(255),
+                    Position bigint
+                );
+            ";
+            await _connection.ExecuteAsync(sql);
+        }
+
+    }
+}

--- a/src/Eventuous.Projections.Sql/PostgresCheckpointStore.cs
+++ b/src/Eventuous.Projections.Sql/PostgresCheckpointStore.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Data;
+using Microsoft.Extensions.Logging;
+using Dapper;
+using Eventuous.Subscriptions;
+using JetBrains.Annotations;
+
+namespace Eventuous.Projections.Sql {
+    [PublicAPI]
+    public class PostgresCheckpointStore : ICheckpointStore {
+        readonly ILogger<PostgresCheckpointStore>? _log;
+        readonly string _schema;
+        readonly string _table = "Checkpoints";
+        readonly IDbConnection _connection;
+        public PostgresCheckpointStore(IDbConnection connection, string schema, ILogger<PostgresCheckpointStore>? logger) {
+            _connection = connection;
+            _schema = schema ?? "public";
+            _log = logger;
+        }
+
+        public async ValueTask<Checkpoint> GetLastCheckpoint(string checkpointId, CancellationToken cancellationToken = default)
+        {
+            _log?.LogDebug("[{CheckpointId}] Finding checkpoint...", checkpointId);
+
+            var parameters = new { Subscription = checkpointId };
+            var sql = $@"
+                select Position from {_schema}.{_table} 
+                where Subscription = @Subscription 
+            "; 
+            var position = await _connection.ExecuteScalarAsync<ulong?>(sql, parameters);
+            return new Checkpoint(checkpointId, position);
+        }
+
+        public async ValueTask<Checkpoint> StoreCheckpoint(Checkpoint checkpoint, CancellationToken cancellationToken = default)
+        {
+            var sqlSelect = $@"
+                select count(*) from {_schema}.{_table} 
+                where Subscription = @Subscription 
+            "; 
+            var result = await _connection.ExecuteScalarAsync<long>(sqlSelect, new { Subscription = checkpoint.Id });
+
+            var parameters = new { Subscription = checkpoint.Id, Position = (long?) checkpoint.Position };
+            if (result != 0)
+            {
+                var sql = $@"
+                    update {_schema}.{_table} 
+                    set Position = @Position 
+                    where Subscription = @Subscription
+                ";
+                await _connection.ExecuteAsync(sql, parameters);
+            }
+            else 
+            {
+                var sql = $@"
+                    insert into {_schema}.{_table} (Subscription, Position) values (@Subscription, @Position)
+                ";
+                await _connection.ExecuteAsync(sql, parameters);
+            }
+            return checkpoint;
+        }
+
+        public async Task CreateSchemaIfNotExists() {
+            var sql = $@"
+                CREATE TABLE IF NOT EXISTS {_schema}.{_table} (
+                    Subscription varchar(255),
+                    Position bigint
+                );
+            ";
+            await _connection.ExecuteAsync(sql);
+        }
+
+    }
+}

--- a/src/Eventuous.Projections.Sql/SqlProjection.cs
+++ b/src/Eventuous.Projections.Sql/SqlProjection.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Dapper;
+using Eventuous.Subscriptions;
+
+namespace Eventuous.Projections.Sql
+{
+    [PublicAPI]
+    public abstract class SqlProjection : IEventHandler 
+    {
+        readonly ILogger? _log;
+        readonly Func<IDbConnection> _getConnection;
+        protected SqlProjection(Func<IDbConnection> getConnection, string subscriptionGroup, ILoggerFactory? loggerFactory) {
+            _getConnection = getConnection;
+            var log = loggerFactory?.CreateLogger(GetType());
+            _log = log?.IsEnabled(LogLevel.Debug) == true ? log : null;
+            SubscriptionId = Ensure.NotEmptyString(subscriptionGroup, nameof(subscriptionGroup));
+        }
+
+        public string SubscriptionId { get; }
+        public async Task HandleEvent(object evt, long? position, CancellationToken cancellationToken) {
+            var operation = GetUpdate(evt);
+
+            if (operation == null) {
+                _log?.LogDebug("No handler for {Event}", evt.GetType().Name);
+                return;
+            }
+
+            _log?.LogDebug("Projecting {Event}", evt.GetType().Name);            
+
+            await _getConnection().ExecuteAsync(operation.sql, operation.parameters);
+        }
+        protected abstract Operation GetUpdate(object evt);
+    }
+
+    public record Operation(object parameters, string sql);
+}

--- a/src/Eventuous.SqlStreamStore/Eventuous.SqlStreamStore.csproj
+++ b/src/Eventuous.SqlStreamStore/Eventuous.SqlStreamStore.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\Eventuous\Eventuous.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SqlStreamStore" Version="1.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/Eventuous.SqlStreamStore/SqlEventStore.cs
+++ b/src/Eventuous.SqlStreamStore/SqlEventStore.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SqlStreamStore;
+using SqlStreamStore.Streams;
+using JetBrains.Annotations;
+using Eventuous;
+
+namespace Eventuous.SqlStreamStore {
+    [PublicAPI]
+    public class SqlEventStore : IEventStore {
+        readonly IStreamStore _streamStore;        
+        const int PageSize = 500;
+        const string ContentType = "application/json";
+        public SqlEventStore(IStreamStore streamStore) => _streamStore = streamStore;
+        
+        public async Task AppendEvents(
+            string                           stream,
+            ExpectedStreamVersion            expectedVersion,
+            IReadOnlyCollection<StreamEvent> events,
+            CancellationToken                cancellationToken
+        )
+        {
+            var proposedEvents = events.Select(ToStreamMessage).ToArray();
+
+            Task resultTask;
+
+            if (expectedVersion == ExpectedStreamVersion.NoStream)
+                resultTask = _streamStore.AppendToStream(
+                    new StreamId(stream),
+                    ExpectedVersion.NoStream,
+                    proposedEvents,
+                    cancellationToken
+                );
+            else if (expectedVersion == ExpectedStreamVersion.Any)
+                resultTask = _streamStore.AppendToStream(
+                    new StreamId(stream),
+                    ExpectedVersion.Any,
+                    proposedEvents,
+                    cancellationToken
+                );
+            else
+                resultTask = _streamStore.AppendToStream(
+                    new StreamId(stream),
+                    (int)expectedVersion.Value,
+                    proposedEvents,
+                    cancellationToken
+                );
+
+            await resultTask.Ignore();
+
+            static NewStreamMessage ToStreamMessage(StreamEvent streamEvent)
+                => new(
+                    Guid.NewGuid(),
+                    streamEvent.EventType,
+                    Encoding.UTF8.GetString(streamEvent.Data)
+                );
+        }
+
+        public async Task<StreamEvent[]> ReadEvents(
+            string              stream, 
+            StreamReadPosition  start, 
+            int                 count, 
+            CancellationToken   cancellationToken)
+        {
+            try {
+                var page = await _streamStore.ReadStreamForwards(new StreamId(stream), (int)start.Value, count, true, cancellationToken);
+                return ToStreamEvents(page.Messages);
+            }
+            catch (InvalidOperationException) {
+                throw new Exceptions.StreamNotFound(stream);
+            }
+        }
+
+        public async Task<StreamEvent[]> ReadEventsBackwards(
+            string              stream,
+            int                 count,
+            CancellationToken   cancellationToken
+        )
+        {
+            try {
+                var page = await _streamStore.ReadStreamBackwards(new StreamId(stream), StreamVersion.End, count, true, cancellationToken); 
+                return ToStreamEvents(page.Messages);
+            }
+            catch (InvalidOperationException) {
+                throw new Exceptions.StreamNotFound(stream);
+            }
+        }
+
+        public async Task ReadStream(
+            string              stream,
+            StreamReadPosition  start,
+            Action<StreamEvent> callback,
+            CancellationToken   cancellationToken
+        )
+        {
+            var startVersion = (int) start.Value;
+            var streamId = new StreamId(stream);
+            try {
+                do {
+                    var page = await _streamStore.ReadStreamForwards(streamId, (int) start.Value, PageSize);
+                    startVersion = page.NextStreamVersion;
+                    foreach (var message in page.Messages) {
+                        callback(await ToStreamEvent(message));
+                    }
+                    if (page.IsEnd) break;
+                } while (true);
+            }
+            catch (InvalidOperationException) {
+                throw new Exceptions.StreamNotFound(stream);
+            }
+        }
+
+        static async Task<StreamEvent> ToStreamEvent(StreamMessage streamMessage)
+            => new(
+                streamMessage.Type,
+                Encoding.UTF8.GetBytes(await streamMessage.GetJsonData()),
+                Encoding.UTF8.GetBytes(streamMessage.JsonMetadata),
+                ContentType
+            );
+
+        static StreamEvent[] ToStreamEvents(StreamMessage[] streamMessages)
+        {
+            var tasks = streamMessages.Select(ToStreamEvent);
+            Task.WhenAll(tasks);
+            return tasks.Select(task => task.Result).ToArray();
+        }
+       
+    }
+}

--- a/src/Eventuous.Subscriptions.SqlStreamStore/AllStreamSubscription.cs
+++ b/src/Eventuous.Subscriptions.SqlStreamStore/AllStreamSubscription.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using SqlStreamStore;
+using SqlStreamStore.Streams;
+using SqlStreamStore.Subscriptions;
+using Eventuous;
+using Eventuous.Subscriptions;
+
+namespace Eventuous.Subscriptions.SqlStreamStore {
+    /// <summary>
+    /// Catch-up subscription for SqlStreamStore (https://sqlstreamstore.readthedocs.io), using the $all global stream
+    /// </summary>
+    [PublicAPI]
+    public class AllStreamSubscription : SqlStreamStoreSubscriptionService {
+        readonly AllStreamSubscriptionOptions _options;
+        const string ContentType = "application/json";
+
+        /// <summary>
+        /// Creates SqlStreamStore catch-up subscription service for $all
+        /// </summary>
+        /// <param name="streamStore">SqlStreamStore instance</param>
+        /// <param name="subscriptionId">Subscription ID</param>
+        /// <param name="checkpointStore">Checkpoint store instance</param>
+        /// <param name="eventHandlers">Collection of event handlers</param>
+        /// <param name="eventSerializer">Event serializer instance</param>
+        /// <param name="loggerFactory">Optional: logger factory</param>
+        /// <param name="measure">Optional: gap measurement for metrics</param>
+
+        public AllStreamSubscription(
+            IStreamStore                streamStore,
+            string                      subscriptionId,
+            ICheckpointStore            checkpointStore,
+            IEnumerable<IEventHandler>  eventHandlers,
+            IEventSerializer?           eventSerializer = null,
+            ILoggerFactory?             loggerFactory   = null,
+            ISubscriptionGapMeasure?    measure         = null
+        ) : this(
+            streamStore,
+            new AllStreamSubscriptionOptions { SubscriptionId = subscriptionId},
+            checkpointStore,
+            eventHandlers,
+            eventSerializer,
+            loggerFactory,
+            measure
+        ) { }
+
+        /// <summary>
+        /// Creates SqlStreamStore catch-up subscription service for $all
+        /// </summary>
+        /// <param name="streamStore">SqlStreamStore instance</param>
+        /// <param name="options">Options for the subscription (includes the subscription id)</param>
+        /// <param name="checkpointStore">Checkpoint store instance</param>
+        /// <param name="eventHandlers">Collection of event handlers</param>
+        /// <param name="eventSerializer">Event serializer instance</param>
+        /// <param name="loggerFactory">Optional: logger factory</param>
+        /// <param name="measure">Optional: gap measurement for metrics</param>
+
+        public AllStreamSubscription(
+            IStreamStore streamStore,
+            AllStreamSubscriptionOptions options,
+            ICheckpointStore checkpointStore,
+            IEnumerable<IEventHandler> eventHandlers,
+            IEventSerializer?          eventSerializer = null,
+            ILoggerFactory?            loggerFactory   = null,
+            ISubscriptionGapMeasure?   measure         = null
+        ) : base(
+            streamStore,
+            options,
+            checkpointStore,
+            eventHandlers,
+            eventSerializer,
+            loggerFactory,
+            measure
+        ) { 
+            _options = options;
+        }
+
+        protected override Task<EventSubscription> Subscribe(
+            Checkpoint checkpoint,
+            CancellationToken cancellationToken
+        ) {
+            var subscription = StreamStore.SubscribeToAll(
+                (long?) checkpoint.Position,
+                HandleEvent,
+                HandleDrop
+            );
+
+            return Task.FromResult(new EventSubscription(SubscriptionId, new Stoppable(() => subscription.Dispose())));
+        }
+
+        async Task HandleEvent(
+            IAllStreamSubscription subscription,
+            StreamMessage streamMessage,
+            CancellationToken cancellationToken
+        )
+            => await Handler(await AsReceivedEvent(streamMessage), cancellationToken);
+
+        void HandleDrop(
+            IAllStreamSubscription subscription,
+            SubscriptionDroppedReason reason,
+            Exception ex
+        ) 
+            => Dropped(SqlStreamStoreMappings.AsDropReason(reason), ex);
+
+        async Task<ReceivedEvent> AsReceivedEvent(StreamMessage streamMessage) {
+            var jsonData = await streamMessage.GetJsonData();
+            var byteData = Encoding.UTF8.GetBytes(jsonData);
+            
+            var evt = DeserializeData(
+                ContentType,
+                streamMessage.Type,
+                byteData,
+                streamMessage.StreamId,
+                (ulong) streamMessage.Position
+            );
+
+            return new ReceivedEvent(
+                streamMessage.MessageId.ToString(),
+                streamMessage.Type,
+                ContentType,
+                (ulong) streamMessage.Position,
+                (ulong) streamMessage.Position,
+                streamMessage.StreamId,
+                (ulong) streamMessage.Position,
+                streamMessage.CreatedUtc,
+                evt
+            );
+        }
+    }
+}

--- a/src/Eventuous.Subscriptions.SqlStreamStore/Eventuous.Subscriptions.SqlStreamStore.csproj
+++ b/src/Eventuous.Subscriptions.SqlStreamStore/Eventuous.Subscriptions.SqlStreamStore.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Eventuous\Eventuous.csproj" />
+    <ProjectReference Include="..\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SqlStreamStore" Version="1.2.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Eventuous.Subscriptions.SqlStreamStore/Options.cs
+++ b/src/Eventuous.Subscriptions.SqlStreamStore/Options.cs
@@ -1,0 +1,16 @@
+using SqlStreamStore;
+using Eventuous;
+
+namespace Eventuous.Subscriptions.SqlStreamStore {
+    public abstract class SqlStreamStoreSubscriptionOptions : SubscriptionOptions {
+
+    }
+
+    public class StreamSubscriptionOptions : SqlStreamStoreSubscriptionOptions {
+        public string StreamName { get; init; } = null!;
+    }
+
+    public class AllStreamSubscriptionOptions : SqlStreamStoreSubscriptionOptions {
+
+    }
+}

--- a/src/Eventuous.Subscriptions.SqlStreamStore/SqlStreamStoreMappings.cs
+++ b/src/Eventuous.Subscriptions.SqlStreamStore/SqlStreamStoreMappings.cs
@@ -1,0 +1,15 @@
+using System;
+using SqlStreamStore.Subscriptions;
+
+namespace Eventuous.Subscriptions.SqlStreamStore {
+    static class SqlStreamStoreMappings {
+        public static DropReason AsDropReason(SubscriptionDroppedReason reason)
+            => reason switch {
+                SubscriptionDroppedReason.Disposed => DropReason.Stopped,
+                SubscriptionDroppedReason.StreamStoreError => DropReason.ServerError,
+                SubscriptionDroppedReason.SubscriberError => DropReason.SubscriptionError,
+                _ => throw new ArgumentOutOfRangeException(nameof(reason), reason, null)
+            };
+
+    }
+}

--- a/src/Eventuous.Subscriptions.SqlStreamStore/SqlStreamStoreSubscriptionService.cs
+++ b/src/Eventuous.Subscriptions.SqlStreamStore/SqlStreamStoreSubscriptionService.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Eventuous;
+using Eventuous.Subscriptions;
+using SqlStreamStore;
+using SqlStreamStore.Streams;
+
+namespace Eventuous.Subscriptions.SqlStreamStore
+{
+    [PublicAPI]
+    public abstract class SqlStreamStoreSubscriptionService : SubscriptionService {
+        protected IStreamStore StreamStore { get; }
+
+        protected SqlStreamStoreSubscriptionService(
+            IStreamStore streamStore,
+            SqlStreamStoreSubscriptionOptions options,
+            ICheckpointStore checkpointStore,
+            IEnumerable<IEventHandler> eventHandlers,
+            IEventSerializer? eventSerializer = null,
+            ILoggerFactory?  loggerFactory = null,
+            ISubscriptionGapMeasure? measure = null
+        ) : base(options, checkpointStore, eventHandlers, eventSerializer, loggerFactory, measure) {
+            StreamStore = Ensure.NotNull(streamStore, nameof(streamStore));
+        }
+
+        protected override async Task<EventPosition> GetLastEventPosition(CancellationToken cancellationToken) {
+            var page = await StreamStore.ReadAllBackwards(
+                Position.End,
+                1,
+                true,
+                cancellationToken
+            );
+            return new EventPosition((ulong) page.Messages[0].Position, page.Messages[0].CreatedUtc);
+        }
+    }
+}

--- a/src/Eventuous.Subscriptions.SqlStreamStore/StreamSubscription.cs
+++ b/src/Eventuous.Subscriptions.SqlStreamStore/StreamSubscription.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using SqlStreamStore;
+using SqlStreamStore.Streams;
+using SqlStreamStore.Subscriptions;
+using Eventuous;
+using Eventuous.Subscriptions;
+
+namespace Eventuous.Subscriptions.SqlStreamStore {
+    /// <summary>
+    /// Catch-up subscription for SqlStreamStore (https://sqlstreamstore.readthedocs.io), for a specific stream
+    /// </summary>
+    [PublicAPI]
+    public class StreamSubscription : SqlStreamStoreSubscriptionService {
+        readonly StreamSubscriptionOptions _options;
+        const string ContentType = "application/json";
+
+        /// <summary>
+        /// Creates a SqlStreamStore catch-up subscription service for a given stream
+        /// </summary>
+        /// <param name="streamStore">SqlStreamStore instance</param>
+        /// <param name="streamName">Name of the stream to receive events from</param>
+        /// <param name="subscriptionId">Subscription ID</param>
+        /// <param name="checkpointStore">Checkpoint store instance</param>
+        /// <param name="eventHandlers">Collection of event handlers</param>
+        /// <param name="eventSerializer">Event serializer instance</param>
+        /// <param name="loggerFactory">Optional: logger factory</param>
+        /// <param name="measure">Optional: gap measurement for metrics</param>
+        /// <param name="throwOnError"></param>
+        public StreamSubscription(
+            IStreamStore                streamStore,
+            string                      streamName,
+            string                      subscriptionId,
+            ICheckpointStore            checkpointStore,
+            IEnumerable<IEventHandler>  eventHandlers,
+            IEventSerializer?           eventSerializer = null,
+            ILoggerFactory?             loggerFactory   = null,
+            ISubscriptionGapMeasure?    measure         = null,
+            bool                        throwOnError = false
+        ) : this(
+            streamStore,
+            new StreamSubscriptionOptions { 
+                StreamName = streamName,
+                SubscriptionId = subscriptionId,
+                ThrowOnError = throwOnError
+            },
+            checkpointStore,
+            eventHandlers,
+            eventSerializer,
+            loggerFactory,
+            measure
+        ) { }
+
+        /// <summary>
+        /// Creates a SqlStreamStore catch-up subscription service for a given stream
+        /// </summary>
+        /// <param name="streamStore">SqlStreamStore instance</param>
+        /// <param name="options">Options for the subscription (includes the name of the stream to receive events from, and the subscription id)</param>
+        /// <param name="subscriptionId">Subscription ID</param>
+        /// <param name="checkpointStore">Checkpoint store instance</param>
+        /// <param name="eventHandlers">Collection of event handlers</param>
+        /// <param name="eventSerializer">Event serializer instance</param>
+        /// <param name="loggerFactory">Optional: logger factory</param>
+        /// <param name="measure">Optional: gap measurement for metrics</param>
+        /// <param name="throwOnError"></param>
+        public StreamSubscription(
+            IStreamStore                streamStore,
+            StreamSubscriptionOptions   options,
+            ICheckpointStore            checkpointStore,
+            IEnumerable<IEventHandler>  eventHandlers,
+            IEventSerializer?           eventSerializer = null,
+            ILoggerFactory?             loggerFactory   = null,
+            ISubscriptionGapMeasure?    measure         = null
+        ) : base(
+            streamStore,
+            options,
+            checkpointStore,
+            eventHandlers,
+            eventSerializer,
+            loggerFactory,
+            measure
+        ) { 
+            _options = options;
+        }
+
+        protected override Task<EventSubscription> Subscribe(
+            Checkpoint checkpoint,
+            CancellationToken cancellationToken
+        ) {
+            var subscription = StreamStore.SubscribeToStream(
+                new StreamId(_options.StreamName),
+                (int?) checkpoint.Position,
+                HandleEvent,
+                HandleDrop
+            );
+            return Task.FromResult(new EventSubscription(SubscriptionId, new Stoppable(() => subscription.Dispose())));
+        }
+
+        async Task HandleEvent(
+            IStreamSubscription subscription,
+            StreamMessage streamMessage,
+            CancellationToken cancellationToken
+        )
+            => await Handler(await AsReceivedEvent(streamMessage), cancellationToken);
+
+        void HandleDrop(
+            IStreamSubscription subscription,
+            SubscriptionDroppedReason reason,
+            Exception ex
+        ) 
+            => Dropped(SqlStreamStoreMappings.AsDropReason(reason), ex);
+
+        async Task<ReceivedEvent> AsReceivedEvent(StreamMessage streamMessage) {
+            var jsonData = await streamMessage.GetJsonData();
+            var byteData = Encoding.UTF8.GetBytes(jsonData);
+            
+            var evt = DeserializeData(
+                ContentType,
+                streamMessage.Type,
+                byteData,
+                streamMessage.StreamId,
+                (ulong) streamMessage.Position
+            );
+
+            return new ReceivedEvent(
+                streamMessage.MessageId.ToString(),
+                streamMessage.Type,
+                ContentType,
+                (ulong) streamMessage.Position,
+                (ulong) streamMessage.Position,
+                streamMessage.StreamId,
+                (ulong) streamMessage.Position,
+                streamMessage.CreatedUtc,
+                evt
+            );
+        }
+    }
+}

--- a/test/Eventuous.Tests.Projections.Sql/CreateMsSqlCheckpoints.cs
+++ b/test/Eventuous.Tests.Projections.Sql/CreateMsSqlCheckpoints.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Eventuous.Subscriptions;
+using Eventuous.Projections.Sql;
+using FluentAssertions;
+
+namespace Eventuous.Tests.SQLStreamStore
+{
+    public class CreateMsSqlCheckpoints
+    {
+        readonly MsSqlCheckpointStore _checkpointStore;
+        public CreateMsSqlCheckpoints()
+        {
+            var connectionString = "Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;";
+            var schema = "checkpoints";
+            var connection = new SqlConnection(connectionString);
+            _checkpointStore = new MsSqlCheckpointStore(connection, schema, null);
+            var task = _checkpointStore.CreateSchemaIfNotExists();
+            task.Wait();
+        }
+
+        [Fact]
+        public async Task GetExistingCheckpoint()
+        {
+            var checkpointId = "subscription";
+            ulong position = 1;
+            var checkpoint = new Checkpoint(checkpointId, position);
+            await _checkpointStore.StoreCheckpoint(checkpoint);
+            var retrievedCheckpoint = await _checkpointStore.GetLastCheckpoint(checkpointId);
+            retrievedCheckpoint.Should().BeEquivalentTo(checkpoint);
+        }        
+
+        [Fact]
+        public async Task CheckpointDoesntExist()
+        {
+            var checkpointId = "random";
+            var checkpoint = await _checkpointStore.GetLastCheckpoint(checkpointId);
+            checkpoint.Id.Should().BeEquivalentTo(checkpointId);
+            checkpoint.Position.Should().Be(null);
+        }        
+    }
+
+}

--- a/test/Eventuous.Tests.Projections.Sql/CreateMySqlCheckpoints.cs
+++ b/test/Eventuous.Tests.Projections.Sql/CreateMySqlCheckpoints.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using MySql.Data.MySqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Eventuous.Subscriptions;
+using Eventuous.Projections.Sql;
+using FluentAssertions;
+
+namespace Eventuous.Tests.SQLStreamStore
+{
+    public class CreateMySqlCheckpoints
+    {
+        readonly MySqlCheckpointStore _checkpointStore;
+        public CreateMySqlCheckpoints()
+        {
+            var connectionString = "Server=localhost;Database=myDataBase;Uid=root;Pwd=myPassword;";
+            var connection = new MySqlConnection(connectionString);
+            _checkpointStore = new MySqlCheckpointStore(connection, null);
+            var task = _checkpointStore.CreateSchemaIfNotExists();
+            task.Wait();
+        }
+
+        [Fact]
+        public async Task GetExistingCheckpoint()
+        {
+            var checkpointId = "subscription";
+            ulong position = 1;
+            var checkpoint = new Checkpoint(checkpointId, position);
+            await _checkpointStore.StoreCheckpoint(checkpoint);
+            var retrievedCheckpoint = await _checkpointStore.GetLastCheckpoint(checkpointId);
+            retrievedCheckpoint.Should().BeEquivalentTo(checkpoint);
+        }        
+
+        [Fact]
+        public async Task CheckpointDoesntExist()
+        {
+            var checkpointId = "random";
+            var checkpoint = await _checkpointStore.GetLastCheckpoint(checkpointId);
+            checkpoint.Id.Should().BeEquivalentTo(checkpointId);
+            checkpoint.Position.Should().Be(null);
+        }        
+    }
+
+}

--- a/test/Eventuous.Tests.Projections.Sql/CreatePostgresCheckpoints.cs
+++ b/test/Eventuous.Tests.Projections.Sql/CreatePostgresCheckpoints.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Eventuous.Subscriptions;
+using Eventuous.Projections.Sql;
+using FluentAssertions;
+using Npgsql;
+
+namespace Eventuous.Tests.SQLStreamStore
+{
+    public class CreatePostgresCheckpoints
+    {
+        readonly PostgresCheckpointStore _checkpointStore;
+        public CreatePostgresCheckpoints()
+        {
+            var connectionString = "User ID=postgres;Password=myPassword;Host=localhost;Port=5432;Database=mydatabase";
+            var schema = "checkpoints";
+            var connection = new NpgsqlConnection(connectionString);
+            _checkpointStore = new PostgresCheckpointStore(connection, schema, null);
+            var task = _checkpointStore.CreateSchemaIfNotExists();
+            task.Wait();
+        }
+
+        [Fact]
+        public async Task GetExistingCheckpoint()
+        {
+            var checkpointId = "subscription";
+            ulong position = 1;
+            var checkpoint = new Checkpoint(checkpointId, position);
+            await _checkpointStore.StoreCheckpoint(checkpoint);
+            var retrievedCheckpoint = await _checkpointStore.GetLastCheckpoint(checkpointId);
+            retrievedCheckpoint.Should().BeEquivalentTo(checkpoint);
+        }        
+
+        [Fact]
+        public async Task CheckpointDoesntExist()
+        {
+            var checkpointId = "random";
+            var checkpoint = await _checkpointStore.GetLastCheckpoint(checkpointId);
+            checkpoint.Id.Should().BeEquivalentTo(checkpointId);
+            checkpoint.Position.Should().Be(null);
+        }        
+    }
+
+}

--- a/test/Eventuous.Tests.Projections.Sql/Eventuous.Tests.Projections.Sql.csproj
+++ b/test/Eventuous.Tests.Projections.Sql/Eventuous.Tests.Projections.Sql.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="MySql.Data" Version="8.0.25" />
+    <PackageReference Include="Npgsql" Version="5.0.5" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Eventuous.Projections.Sql\Eventuous.Projections.Sql.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/Events.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/Events.cs
@@ -1,0 +1,16 @@
+using System;
+using Eventuous;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub {
+    public static class Events {
+        public record AccountCreated(Guid AccountNumber);
+        public record AmountLodged(decimal Amount);
+        public record AmountWithdrawn(decimal Amount);
+        
+        public static void MapEvents() {
+            TypeMap.AddType<AccountCreated>("AccountCreated");
+            TypeMap.AddType<AmountLodged>("AmountLodged");
+            TypeMap.AddType<AmountWithdrawn>("AmountWithdrawn");
+        }
+    }
+}

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/Eventuous.Tests.SqlStreamStore.PubSub.csproj
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/Eventuous.Tests.SqlStreamStore.PubSub.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="SQLStreamStore" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.MsSql" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8" />
+    <PackageReference Include="Npgsql" Version="5.0.5" />
+    <PackageReference Include="Dapper" Version="2.0.90" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="NodaTime" Version="3.0.5" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
+    <PackageReference Include="SqlStreamStore.Mysql" Version="1.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Eventuous\Eventuous.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.Producers\Eventuous.Producers.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.Producers.SqlStreamStore\Eventuous.Producers.SqlStreamStore.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.Subscriptions.SqlStreamStore\Eventuous.Subscriptions.SqlStreamStore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/Fakes/InMemoryCheckpointStore.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/Fakes/InMemoryCheckpointStore.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Eventuous.Subscriptions;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub {
+    public class InMemoryCheckpointStore : ICheckpointStore {
+        ulong? _position;
+        public InMemoryCheckpointStore(ulong? position = null) => _position = position;
+        public ValueTask<Checkpoint> GetLastCheckpoint(
+            string            checkpointId,
+            CancellationToken cancellationToken = default
+        )
+            => new(new Checkpoint(checkpointId, _position));
+
+        public ValueTask<Checkpoint> StoreCheckpoint(
+            Checkpoint        checkpoint,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _position = checkpoint.Position;
+            return ValueTask.FromResult(new Checkpoint(checkpoint.Id, _position));
+        }
+    }
+}

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/Fixtures/InMemoryFixture.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/Fixtures/InMemoryFixture.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using System.Text.Json;
+using SqlStreamStore;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub
+{
+    public class InMemoryFixture {
+        protected IStreamStore StreamStore { get; }
+        protected IEventSerializer Serializer { get; } = new DefaultEventSerializer(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)
+        );
+
+        public InMemoryFixture() {
+            StreamStore = new InMemoryStreamStore();
+        }
+
+        public Task CleanUp() => Task.CompletedTask;
+    }    
+}

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/Fixtures/MsSqlFixture.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/Fixtures/MsSqlFixture.cs
@@ -1,0 +1,42 @@
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using System.Text.Json;
+using SqlStreamStore;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+using Dapper;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub
+{
+    public class MsSqlFixture {
+        protected IStreamStore StreamStore { get; }
+        protected IEventSerializer Serializer { get; } = new DefaultEventSerializer(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)
+        );
+
+        readonly string connectionString = "Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;";
+        readonly string schema = "test";
+
+        public MsSqlFixture() {
+
+            StreamStore = new MsSqlStreamStoreV3(
+                new MsSqlStreamStoreV3Settings(connectionString)
+                {
+                    Schema = schema
+                }
+            );
+            ((MsSqlStreamStoreV3)StreamStore).CreateSchemaIfNotExists().Wait();
+        }
+
+        public async Task CleanUp() {
+            var connection = new SqlConnection(connectionString);
+            var sql = $@"
+                delete from {schema}.messages;
+                delete from {schema}.streams;
+            ";
+            await connection.ExecuteAsync(sql);            
+        }
+
+    }    
+}

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/Fixtures/MySqlFixture.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/Fixtures/MySqlFixture.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading.Tasks;
+using System.Text.Json;
+using SqlStreamStore;
+using System.Data.SqlClient;
+using MySql.Data.MySqlClient;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+using Dapper;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub
+{
+    public class MySqlFixture {
+        protected IStreamStore StreamStore { get; }
+        protected IEventSerializer Serializer { get; } = new DefaultEventSerializer(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)
+        );
+        readonly string connectionString = "Server=localhost;Database=myDataBase;Uid=root;Pwd=myPassword;";
+
+        public MySqlFixture() {
+            StreamStore = new MySqlStreamStore(
+                new MySqlStreamStoreSettings(connectionString)
+            );
+
+            ((MySqlStreamStore)StreamStore).CreateSchemaIfNotExists().Wait();
+        }
+
+        public async Task CleanUp() {
+            var connection = new MySqlConnection(connectionString);
+            var sql = $@"
+                delete from messages;
+                delete from streams;
+            ";
+            await connection.ExecuteAsync(sql);            
+        }
+
+    }    
+}

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/MockEventHandler.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/MockEventHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Eventuous.Subscriptions;
+using Eventuous.Producers.SqlStreamStore;
+using Eventuous.Subscriptions.SqlStreamStore;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub
+{
+    public class MockEventHandler : IEventHandler
+    {
+        public List<object> ReceivedEvents = new List<object>(); 
+        public string SubscriptionId { get; }
+        public MockEventHandler(string subscriptionId) => SubscriptionId = subscriptionId;
+        public Task HandleEvent(object evt, long? position, CancellationToken cancellationToken) {
+            ReceivedEvents.Add(evt);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Eventuous.Tests.SqlStreamStore.PubSub/PubSubStreams.cs
+++ b/test/Eventuous.Tests.SqlStreamStore.PubSub/PubSubStreams.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Text.Json;
+using SqlStreamStore;
+using Eventuous.Subscriptions;
+using Eventuous.Producers.SqlStreamStore;
+using Eventuous.Subscriptions.SqlStreamStore;
+using Xunit;
+using FluentAssertions;
+using static Eventuous.Tests.SqlStreamStore.PubSub.Events;
+
+namespace Eventuous.Tests.SqlStreamStore.PubSub
+{
+    public class PubSubStreams: InMemoryFixture, IDisposable {
+
+        readonly SqlStreamStoreProducer producer; 
+        readonly AllStreamSubscription allStreamSubscription;
+        readonly StreamSubscription streamSubscription; 
+        readonly string stream = "stream";
+        readonly string subscription = "subscription";
+        readonly MockEventHandler eventHandler; 
+        object[] expectedEvents = {
+            new AccountCreated(Guid.NewGuid()),
+            new AmountLodged(100), 
+            new AmountWithdrawn(20)
+        };
+
+        public PubSubStreams(): base() {
+            producer = new SqlStreamStoreProducer(StreamStore, Serializer);
+            eventHandler = new MockEventHandler(subscription);
+
+            streamSubscription = new StreamSubscription(
+                StreamStore, 
+                stream, 
+                subscription, 
+                new InMemoryCheckpointStore(), 
+                new[] {eventHandler},
+                Serializer
+            );
+
+            allStreamSubscription = new AllStreamSubscription(
+                StreamStore,
+                subscription,
+                new InMemoryCheckpointStore(),
+                new[] {eventHandler},
+                Serializer
+            );
+
+            MapEvents();
+        }
+
+        [Fact]
+        public async Task PublishMultipleStreams_SubscribeAllStreams()
+        {
+            // arrange
+            await producer.Initialize();
+            await allStreamSubscription.StartAsync(CancellationToken.None);
+
+            // act
+            await producer.Produce("stream1", expectedEvents);
+            await producer.Produce("stream2", expectedEvents);
+            await Task.Delay(5000);
+            var events = eventHandler.ReceivedEvents.ToArray();
+
+            // assert
+            events.Length.Should().Be(6);
+            events.Should().BeEquivalentTo(expectedEvents.Concat(expectedEvents));
+
+            // clean
+            await allStreamSubscription.StopAsync(CancellationToken.None);
+            await CleanUp();
+        }
+
+        [Fact]
+        public async Task PublishSingleStream_SubscribeSingleStream()
+        {
+            // arrange
+            await producer.Initialize();
+            await streamSubscription.StartAsync(CancellationToken.None);
+
+            // act
+            await producer.Produce(stream, expectedEvents);
+            await Task.Delay(5000);
+            var events = eventHandler.ReceivedEvents.ToArray();
+
+            // assert
+            events.Should().Equal(expectedEvents);
+
+            // clean
+            await streamSubscription.StopAsync(CancellationToken.None);
+            await CleanUp();
+        }
+
+        public void Dispose() => CleanUp().Wait();
+    }
+
+}

--- a/test/Eventuous.Tests.SqlStreamStore/Events.cs
+++ b/test/Eventuous.Tests.SqlStreamStore/Events.cs
@@ -1,0 +1,16 @@
+using System;
+using Eventuous;
+
+namespace Eventuous.Tests.SqlStreamStore {
+    public static class Events {
+        public record AccountCreated(Guid AccountNumber);
+        public record AmountLodged(decimal Amount);
+        public record AmountWithdrawn(decimal Amount);
+        
+        public static void MapEvents() {
+            TypeMap.AddType<AccountCreated>("AccountCreated");
+            TypeMap.AddType<AmountLodged>("AmountLodged");
+            TypeMap.AddType<AmountWithdrawn>("AmountWithdrawn");
+        }
+    }
+}

--- a/test/Eventuous.Tests.SqlStreamStore/Eventuous.Tests.SqlStreamStore.csproj
+++ b/test/Eventuous.Tests.SqlStreamStore/Eventuous.Tests.SqlStreamStore.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="SQLStreamStore" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.MsSql" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.MySql" Version="1.2.0" />
+    <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="NodaTime" Version="3.0.5" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Eventuous\Eventuous.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.SQLStreamStore\Eventuous.SQLStreamStore.csproj" />
+    <ProjectReference Include="..\..\src\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Eventuous.Tests.SqlStreamStore/Fixtures/InMemoryFixture.cs
+++ b/test/Eventuous.Tests.SqlStreamStore/Fixtures/InMemoryFixture.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using SqlStreamStore;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+using Eventuous.SqlStreamStore;
+
+namespace Eventuous.Tests.SqlStreamStore
+{
+    public class InMemoryFixture {
+        protected IEventStore EventStore { get; }
+        protected IEventSerializer Serializer { get; } = new DefaultEventSerializer(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)
+        );
+
+        public InMemoryFixture() {
+            EventStore = new SqlEventStore(new InMemoryStreamStore());
+        }
+
+    }    
+}

--- a/test/Eventuous.Tests.SqlStreamStore/Fixtures/MsSqlFixture.cs
+++ b/test/Eventuous.Tests.SqlStreamStore/Fixtures/MsSqlFixture.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using SqlStreamStore;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+using Eventuous.SqlStreamStore;
+
+namespace Eventuous.Tests.SqlStreamStore
+{
+    public class MsSqlFixture {
+        protected IEventStore EventStore { get; }
+        protected IEventSerializer Serializer { get; } = new DefaultEventSerializer(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)
+        );
+
+        public MsSqlFixture() {
+            string connectionString = "Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;";
+            string schema = "events";
+            EventStore = new SqlEventStore(new MsSqlStreamStoreV3(
+                new MsSqlStreamStoreV3Settings(connectionString)
+                {
+                    Schema = schema
+                }
+            ));
+        }
+
+    }    
+}

--- a/test/Eventuous.Tests.SqlStreamStore/Fixtures/MySqlFixture.cs
+++ b/test/Eventuous.Tests.SqlStreamStore/Fixtures/MySqlFixture.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using SqlStreamStore;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+using Eventuous.SqlStreamStore;
+
+namespace Eventuous.Tests.SqlStreamStore
+{
+    public class MySqlFixture {
+        protected IEventStore EventStore { get; }
+        protected IEventSerializer Serializer { get; } = new DefaultEventSerializer(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureForNodaTime(DateTimeZoneProviders.Tzdb)
+        );
+
+        public MySqlFixture() {
+            string connectionString = "Server=localhost;Database=myDataBase;Uid=root;Pwd=myPassword;";
+            EventStore = new SqlEventStore(new MySqlStreamStore(
+                new MySqlStreamStoreSettings(connectionString)
+            ));
+        }
+
+    }    
+}

--- a/test/Eventuous.Tests.SqlStreamStore/StoringEvents.cs
+++ b/test/Eventuous.Tests.SqlStreamStore/StoringEvents.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Eventuous;
+using FluentAssertions;
+using static Eventuous.Tests.SqlStreamStore.Events;
+
+namespace Eventuous.Tests.SqlStreamStore
+{
+    public class StoringEvents: InMemoryFixture
+    {
+        object[] expectedEvents = {
+            new AccountCreated(Guid.NewGuid()),
+            new AmountLodged(100), 
+            new AmountWithdrawn(20)
+        };
+        string stream = "account";
+
+        public StoringEvents() : base(){
+            MapEvents();
+        }
+
+        [Fact]
+        public async Task AppendEventsWithNoStreamVersion_ReadEventsForward()
+        {
+            await EventStore.AppendEvents(stream, ExpectedStreamVersion.NoStream, ToStreamEvents(expectedEvents), new CancellationToken());
+
+            var streamEvents = await EventStore.ReadEvents(stream, StreamReadPosition.Start, 3, new CancellationToken());
+            var events = ToEvents(streamEvents);
+
+            events.Should().Equal(expectedEvents);
+        }
+
+        [Fact]
+        public async Task AppendEventsWithNoStreamVersion_ReadEventsBackwards()
+        {
+            await EventStore.AppendEvents(stream, ExpectedStreamVersion.NoStream, ToStreamEvents(expectedEvents), new CancellationToken());
+
+            var streamEvents = await EventStore.ReadEventsBackwards(stream, 3, new CancellationToken());
+            var events = ToEvents(streamEvents).Reverse().ToArray();
+
+            events.Should().Equal(expectedEvents);
+        }
+
+        [Fact]
+        public async Task AppendEventsWithNoStreamVersion_ReadStream()
+        {
+            List<StreamEvent> streamEvents = new List<StreamEvent>();
+
+            await EventStore.AppendEvents(stream, ExpectedStreamVersion.NoStream, ToStreamEvents(expectedEvents), new CancellationToken());
+
+            Action<StreamEvent> eventReceived = (streamEvent) => streamEvents.Add(streamEvent);
+
+            await EventStore.ReadStream(stream, StreamReadPosition.Start, eventReceived, new CancellationToken());
+
+            var events = ToEvents(streamEvents.ToArray());
+
+            events.ToArray().Should().Equal(expectedEvents);
+        }
+
+        [Fact]
+        public async Task AppendEventsWithAnyStreamVersion_ReadEventsForward()
+        {
+            await EventStore.AppendEvents(stream, ExpectedStreamVersion.Any, ToStreamEvents(expectedEvents), new CancellationToken());
+
+            var streamEvents = await EventStore.ReadEvents(stream, StreamReadPosition.Start, 3, new CancellationToken());
+            var events = ToEvents(streamEvents);
+
+            events.Should().Equal(expectedEvents);
+        }
+
+        [Fact]
+        public async Task AppendEventsMultipleTimes_ReadEventsForward()
+        {
+            object[] additionalEvents = {
+                new AccountCreated(Guid.NewGuid()),
+                new AmountLodged(100), 
+                new AmountWithdrawn(20)
+            };
+
+            await EventStore.AppendEvents(stream, ExpectedStreamVersion.Any, ToStreamEvents(expectedEvents), new CancellationToken());
+
+            await EventStore.AppendEvents(stream, new ExpectedStreamVersion(2), ToStreamEvents(additionalEvents), new CancellationToken());
+
+            var allStreamEvents = await EventStore.ReadEvents(stream, StreamReadPosition.Start, 6, new CancellationToken());
+            var allEvents = ToEvents(allStreamEvents);
+            var allExpectedEvents = expectedEvents.Concat(additionalEvents);
+
+            allEvents.Should().BeEquivalentTo(allExpectedEvents);
+        }
+
+        StreamEvent[] ToStreamEvents(object[] events)
+            => events.Select<object, StreamEvent>( @event => new(
+                TypeMap.GetTypeName(@event),
+                Serializer.Serialize(@event),
+                null,
+                Serializer.ContentType
+            )).ToArray();
+
+        object[] ToEvents(StreamEvent[] streamEvents)
+            => streamEvents.Select(e => Serializer.Deserialize(e.Data, e.EventType)).ToArray();
+
+    }
+}


### PR DESCRIPTION
Added support for event sourcing using a regular SQL database as the store, based on SqlStreamStore library.
Databases supported by SqlStreamStore:
- MSSQL (including Azure Sql)
- MySql
Included in the PR are:
- event store implementation based on SqlStreamStore
- producer and subscriptions (single stream, all streams) based on SqlStreamStore
- projections to a SQL database (including checkpoints for MSSQL, MySql and Postgres)
- tests 