### PR TITLE
fix(rabbitmq): use test queue for subscription id.

### DIFF
--- a/test/Eventuous.Tests.RabbitMq/PubSubTests.cs
+++ b/test/Eventuous.Tests.RabbitMq/PubSubTests.cs
@@ -31,7 +31,7 @@ namespace Eventuous.Tests.RabbitMq {
             var loggerFactory =
                 LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Debug).AddXunit(outputHelper));
 
-            _handler = new Handler();
+            _handler = new Handler(queue);
 
             _producer = new RabbitMqProducer(RabbitMqFixture.ConnectionFactory);
 
@@ -78,7 +78,11 @@ namespace Eventuous.Tests.RabbitMq {
         record TestEvent(string Data, int Number);
 
         class Handler : IEventHandler {
-            public string SubscriptionId => "queue";
+            public Handler(string queue) {
+                SubscriptionId = queue;
+            }
+
+            public string SubscriptionId { get; }
 
             public ConcurrentBag<object> ReceivedEvents { get; } = new();
 


### PR DESCRIPTION
Fixes the rabbit-mq integration tests, currently failing because of this filter: https://github.com/Eventuous/eventuous/blob/8dabf542d78a5625b0e8e0114a3a9f9bf8bdbe26/src/Eventuous.Subscriptions/SubscriptionService.cs#L45-L47