### PR TITLE
Event type attribute

### DIFF
--- a/src/Eventuous/TypeMap.cs
+++ b/src/Eventuous/TypeMap.cs
@@ -1,28 +1,62 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Eventuous {
     [PublicAPI]
     public static class TypeMap {
+        static readonly List<Assembly> Assemblies = new();
+
         static readonly Dictionary<string, Type> ReverseMap = new();
         static readonly Dictionary<Type, string> Map        = new();
 
         public static string GetTypeName<T>() => Map[typeof(T)];
-        
+
         public static string GetTypeName(object o) => Map[o.GetType()];
-        
+
         public static string GetTypeNameByType(Type type) => Map[type];
 
         public static Type GetType(string typeName) => ReverseMap[typeName];
-        
-        public static bool TryGetType(string typeName, out Type? type) => ReverseMap.TryGetValue(typeName, out type);
 
-        public static void AddType<T>(string name) {
-            ReverseMap[name] = typeof(T);
-            Map[typeof(T)]   = name;
+        public static bool TryGetType(string typeName, out Type? type) {
+            return ReverseMap.TryGetValue(typeName, out type);
+        }
+
+        public static void AddType<T>(string name) => AddType(typeof(T), name);
+
+        static void AddType(Type type, string name) {
+            ReverseMap[name] = type;
+            Map[type]   = name;
         }
 
         public static bool IsTypeRegistered<T>() => Map.ContainsKey(typeof(T));
+
+        public static void RegisterKnownEventTypes(params Assembly[] assemblies) {
+            foreach (var assembly in assemblies) {
+                RegisterAssemblyEventTypes(assembly);
+            }
+        }
+
+        static Type _attributeType = typeof(EventTypeAttribute);
+
+        static void RegisterAssemblyEventTypes(Assembly assembly) {
+            var decoratedTypes = assembly.DefinedTypes.Where(
+                x => x.IsClass && x.CustomAttributes.Any(a => a.AttributeType == _attributeType)
+            );
+
+            foreach (var type in decoratedTypes) {
+                var attr = (EventTypeAttribute)Attribute.GetCustomAttribute(type, _attributeType)!;
+                AddType(type, attr.EventType);
+            }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class EventTypeAttribute : Attribute {
+        public string EventType { get; }
+
+        public EventTypeAttribute(string eventType) => EventType = eventType;
     }
 }

--- a/test/Eventuous.Tests/Model/BookingEvents.cs
+++ b/test/Eventuous.Tests/Model/BookingEvents.cs
@@ -8,6 +8,7 @@ namespace Eventuous.Tests.Model {
 
         public record BookingFullyPaid(string BookingId);
 
+        [EventType(BookingCancelledTypeName)]
         public record BookingCancelled(string BookingId);
 
         public record BookingImported(string BookingId, string RoomId, LocalDate CheckIn, LocalDate CheckOut);
@@ -15,8 +16,9 @@ namespace Eventuous.Tests.Model {
         public static void MapBookingEvents() {
             TypeMap.AddType<RoomBooked>("RoomBooked");
             TypeMap.AddType<BookingPaymentRegistered>("BookingPaymentRegistered");
-            TypeMap.AddType<BookingCancelled>("BookingCancelled");
             TypeMap.AddType<BookingImported>("BookingImported");
         }
+
+        public const string BookingCancelledTypeName = "V1.BookingCancelled";
     }
 }

--- a/test/Eventuous.Tests/TypeRegistrationTests.cs
+++ b/test/Eventuous.Tests/TypeRegistrationTests.cs
@@ -1,0 +1,15 @@
+using FluentAssertions;
+using Xunit;
+using static Eventuous.Tests.Model.BookingEvents;
+
+namespace Eventuous.Tests {
+    public class TypeRegistrationTests {
+        [Fact]
+        public void ShouldResolveDecoratedEvent() {
+            TypeMap.RegisterKnownEventTypes(typeof(RoomBooked).Assembly);
+
+            TypeMap.GetTypeName<BookingCancelled>().Should().Be(BookingCancelledTypeName);
+            TypeMap.GetType(BookingCancelledTypeName).Should().Be<BookingCancelled>();
+        }
+    }
+}


### PR DESCRIPTION
The attribute allows decorating event classes with the event type name attribute. So, instead of mapping it somewhere in a static method, it is enough to make a call:

```csharp
TypeMap.RegisterKnownEventTypes(typeof(SomeEvent).Assembly);
```

The method accepts multiple assemblies.

Remedy for #4