### PR TITLE
Remove unnecessary id

### DIFF
--- a/src/Core/src/Eventuous.Subscriptions/TypedEventHandler.cs
+++ b/src/Core/src/Eventuous.Subscriptions/TypedEventHandler.cs
@@ -5,8 +5,6 @@ namespace Eventuous.Subscriptions;
 /// </summary>
 [PublicAPI]
 public abstract class EventHandler : IEventHandler {
-    public abstract string SubscriptionId { get; }
-
     readonly Dictionary<Type, HandleUntypedEvent> _handlersMap = new();
 
     /// <summary>


### PR DESCRIPTION
`SubscriptionId` is no longer needed for event handlers