### PR TITLE
Added original message context to the produced message

### DIFF
--- a/src/Core/src/Eventuous.Producers/ProducedMessage.cs
+++ b/src/Core/src/Eventuous.Producers/ProducedMessage.cs
@@ -3,19 +3,26 @@ using Eventuous.Producers.Diagnostics;
 namespace Eventuous.Producers;
 
 public record ProducedMessage {
-    public ProducedMessage(object message, Metadata? metadata, Guid? messageId = null) {
-        Message     = message;
-        Metadata    = metadata;
-        MessageId   = messageId ?? Guid.NewGuid();
-        MessageType = TypeMap.GetTypeName(message, false);
+    public ProducedMessage(
+        object    message,
+        Metadata? metadata,
+        Metadata? additionalHeaders = null,
+        Guid?     messageId         = null
+    ) {
+        Message           = message;
+        Metadata          = metadata;
+        AdditionalHeaders = additionalHeaders;
+        MessageId         = messageId ?? Guid.NewGuid();
+        MessageType       = TypeMap.GetTypeName(message, false);
     }
 
-    public object               Message     { get; }
-    public Metadata?            Metadata    { get; init; }
-    public Guid                 MessageId   { get; }
-    public string               MessageType { get; }
-    public AcknowledgeProduce?  OnAck       { get; init; }
-    public ReportFailedProduce? OnNack      { get; init; }
+    public object               Message           { get; }
+    public Metadata?            Metadata          { get; init; }
+    public Metadata?            AdditionalHeaders { get; }
+    public Guid                 MessageId         { get; }
+    public string               MessageType       { get; }
+    public AcknowledgeProduce?  OnAck             { get; init; }
+    public ReportFailedProduce? OnNack            { get; init; }
 
     public ValueTask Ack<T>() where T : IEventProducer {
         ProducerEventSource<T>.Log.ProduceAcknowledged(this);

--- a/src/Core/src/Eventuous.Producers/ProducerExtensions.cs
+++ b/src/Core/src/Eventuous.Producers/ProducerExtensions.cs
@@ -10,6 +10,7 @@ public static class ProducerExtensions {
     /// <param name="stream">Stream name where the message should be produced</param>
     /// <param name="message">Message to produce</param>
     /// <param name="metadata"></param>
+    /// <param name="additionalHeaders">Optional items to be used by the producer</param>
     /// <param name="onAck">Function to confirm that the message was produced</param>
     /// <param name="cancellationToken"></param>
     /// <typeparam name="TMessage">Message typ</typeparam>
@@ -19,13 +20,14 @@ public static class ProducerExtensions {
         StreamName          stream,
         TMessage            message,
         Metadata?           metadata,
+        Metadata?           additionalHeaders = null,
         AcknowledgeProduce? onAck             = null,
         CancellationToken   cancellationToken = default
     ) where TMessage : class {
         var producedMessages =
             message is IEnumerable<object> collection
-                ? ConvertMany(collection, metadata, onAck)
-                : ConvertOne(message, metadata, onAck);
+                ? ConvertMany(collection, metadata, additionalHeaders, onAck)
+                : ConvertOne(message, metadata, additionalHeaders, onAck);
 
         return producer.Produce(stream, producedMessages, cancellationToken);
     }
@@ -39,6 +41,7 @@ public static class ProducerExtensions {
     /// <param name="message">Message to produce</param>
     /// <param name="metadata">Message metadata</param>
     /// <param name="options">Produce options</param>
+    /// <param name="additionalHeaders">Optional items to be used by the producer</param>
     /// <param name="onAck">Function to confirm that the message was produced</param>
     /// <param name="cancellationToken"></param>
     /// <typeparam name="TMessage">Message type</typeparam>
@@ -50,13 +53,14 @@ public static class ProducerExtensions {
         TMessage                             message,
         Metadata?                            metadata,
         TProduceOptions                      options,
+        Metadata?                            additionalHeaders = null,
         AcknowledgeProduce?                  onAck             = null,
         CancellationToken                    cancellationToken = default
     ) where TMessage : class where TProduceOptions : class {
         var producedMessages =
             Ensure.NotNull(message) is IEnumerable<object> collection
-                ? ConvertMany(collection, metadata, onAck)
-                : ConvertOne(message, metadata, onAck);
+                ? ConvertMany(collection, metadata, additionalHeaders, onAck)
+                : ConvertOne(message, metadata, additionalHeaders, onAck);
 
         return producer.Produce(stream, producedMessages, options, cancellationToken);
     }
@@ -64,10 +68,16 @@ public static class ProducerExtensions {
     static IEnumerable<ProducedMessage> ConvertMany(
         IEnumerable<object> messages,
         Metadata?           metadata,
+        Metadata?           additionalHeaders,
         AcknowledgeProduce? onAck
     )
-        => messages.Select(x => new ProducedMessage(x, metadata) { OnAck = onAck });
+        => messages.Select(x => new ProducedMessage(x, metadata, additionalHeaders) { OnAck = onAck });
 
-    static IEnumerable<ProducedMessage> ConvertOne(object message, Metadata? metadata, AcknowledgeProduce? onAck)
-        => new[] { new ProducedMessage(message, metadata) { OnAck = onAck } };
+    static IEnumerable<ProducedMessage> ConvertOne(
+        object              message,
+        Metadata?           metadata,
+        Metadata?           additionalHeaders,
+        AcknowledgeProduce? onAck
+    )
+        => new[] { new ProducedMessage(message, metadata, additionalHeaders) { OnAck = onAck } };
 }

--- a/src/Gateway/src/Eventuous.Gateway/GatewayHandler.cs
+++ b/src/Gateway/src/Eventuous.Gateway/GatewayHandler.cs
@@ -39,7 +39,10 @@ class GatewayHandler : BaseEventHandler {
 
         Task ProduceToStream(StreamName streamName, IEnumerable<GatewayMessage> toProduce) {
             var messages = toProduce
-                .Select(x => new ProducedMessage(x.Message, x.GetMeta(context)) { OnAck = onAck });
+                .Select(
+                    x => new ProducedMessage(x.Message, x.GetMeta(context), GatewayMetaHelper.GetContextMeta(context))
+                        { OnAck = onAck }
+                );
 
             return _eventProducer.Produce(streamName, messages, context.CancellationToken);
         }

--- a/src/Gateway/src/Eventuous.Gateway/GatewayHandlerWithOptions.cs
+++ b/src/Gateway/src/Eventuous.Gateway/GatewayHandlerWithOptions.cs
@@ -56,6 +56,7 @@ public class GatewayHandler<TProduceOptions> : BaseEventHandler
                             x.Message,
                             x.GetMeta(context),
                             x.ProduceOptions,
+                            GatewayMetaHelper.GetContextMeta(context),
                             onAck,
                             context.CancellationToken
                         )

--- a/src/Gateway/src/Eventuous.Gateway/GatewayMetaHelper.cs
+++ b/src/Gateway/src/Eventuous.Gateway/GatewayMetaHelper.cs
@@ -8,4 +8,52 @@ static class GatewayMetaHelper {
         var meta = metadata == null ? new Metadata() : new Metadata(metadata);
         return meta.WithCausationId(context.MessageId);
     }
+
+    public static Metadata GetContextMeta(IMessageConsumeContext context) {
+        var headers = new Dictionary<string, object?> {
+            [GatewayContextItems.OriginalMessage]        = context.Message,
+            [GatewayContextItems.OriginalStream]         = context.Stream,
+            [GatewayContextItems.OriginalStreamPosition] = context.StreamPosition,
+            [GatewayContextItems.OriginalGlobalPosition] = context.GlobalPosition,
+            [GatewayContextItems.OriginalMessageId]      = context.MessageId,
+            [GatewayContextItems.OriginalMessageType]    = context.MessageType,
+            [GatewayContextItems.OriginalMessageMeta]    = context.Metadata,
+        };
+
+        return new Metadata(headers);
+    }
+}
+
+[PublicAPI]
+public static class ProducedMessageExtensions {
+    public static Stream? GetOriginalStream(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<Stream>(GatewayContextItems.OriginalStream);
+
+    public static object? GetOriginalMessage(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<object>(GatewayContextItems.OriginalMessage);
+    
+    public static Metadata? GetOriginalMetadata(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<Metadata>(GatewayContextItems.OriginalMessageMeta);
+    
+    public static ulong GetOriginalStreamPosition(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<ulong>(GatewayContextItems.OriginalStreamPosition) ?? default;
+    
+    public static ulong GetOriginalGlobalPosition(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<ulong>(GatewayContextItems.OriginalGlobalPosition) ?? default;
+    
+    public static string? GetOriginalMessageId(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<string>(GatewayContextItems.OriginalMessageId);
+    
+    public static string? GetOriginalMessageType(this ProducedMessage message)
+        => message.AdditionalHeaders?.Get<string>(GatewayContextItems.OriginalMessageType);
+}
+
+public static class GatewayContextItems {
+    public const string OriginalMessageId      = nameof(OriginalMessageId);
+    public const string OriginalMessage        = nameof(OriginalMessage);
+    public const string OriginalMessageType    = nameof(OriginalMessageType);
+    public const string OriginalMessageMeta    = nameof(OriginalMessageMeta);
+    public const string OriginalStream         = nameof(OriginalStream);
+    public const string OriginalStreamPosition = nameof(OriginalStreamPosition);
+    public const string OriginalGlobalPosition = nameof(OriginalGlobalPosition);
 }

--- a/src/Gateway/test/Eventuous.Gateway.Tests/RegistrationTests.cs
+++ b/src/Gateway/test/Eventuous.Gateway.Tests/RegistrationTests.cs
@@ -1,6 +1,4 @@
-﻿using Eventuous.Gateway;
-using Eventuous.Producers;
-using Eventuous.Producers.Diagnostics;
+﻿using Eventuous.Producers;
 using Eventuous.Subscriptions;
 using Eventuous.Subscriptions.Context;
 using Eventuous.Subscriptions.Filters;
@@ -36,8 +34,7 @@ public class RegistrationTests {
     }
 
     class TestTransform : IGatewayTransform {
-        public ValueTask<GatewayMessage[]> RouteAndTransform(IMessageConsumeContext context)
-            => new();
+        public ValueTask<GatewayMessage[]> RouteAndTransform(IMessageConsumeContext context) => new();
     }
 
     record TestOptions : SubscriptionOptions;


### PR DESCRIPTION
For the gateway, it's helpful to have the original message details. I added those as metadata elements in a separate `Metadata` object as a `ProducedMessage.AdditionalHeaders.