### PR TITLE
don't throw if key already exists in the dictionary

### DIFF
--- a/src/Core/src/Eventuous/Meta/Metadata.cs
+++ b/src/Core/src/Eventuous/Meta/Metadata.cs
@@ -23,7 +23,7 @@ public class Metadata : Dictionary<string, object?> {
     public T? Get<T>(string key) => TryGetValue(key, out var value) && value is T v ? v : default;
 
     public Metadata AddNotNull(string key, string? value) {
-        if (!string.IsNullOrEmpty(value)) TryAdd(key, value);
+        if (!string.IsNullOrEmpty(value)) this[key] = value;
         return this;
     }
 }

--- a/src/Core/src/Eventuous/Meta/Metadata.cs
+++ b/src/Core/src/Eventuous/Meta/Metadata.cs
@@ -23,7 +23,7 @@ public class Metadata : Dictionary<string, object?> {
     public T? Get<T>(string key) => TryGetValue(key, out var value) && value is T v ? v : default;
 
     public Metadata AddNotNull(string key, string? value) {
-        if (!string.IsNullOrEmpty(value)) Add(key, value);
+        if (!string.IsNullOrEmpty(value)) TryAdd(key, value);
         return this;
     }
 }


### PR DESCRIPTION
Producing messages to GooglePub from esdb (using a gateway) getting error:
`System.ArgumentException: An item with the same key has already been added. Key: trace-id`

Not sure why but anyway that method shouldn't throw, either it replaces the value or just ignores it. What do yo think?