### PR TITLE
PubSubSubscriptionOptions public properties to be able to modify them when configuring using delegate

### DIFF
--- a/src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/PubSubSubscriptionOptions.cs
+++ b/src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/PubSubSubscriptionOptions.cs
@@ -12,35 +12,35 @@ public record PubSubSubscriptionOptions : SubscriptionOptions {
     /// <summary>
     /// Google Cloud project id
     /// </summary>
-    public string ProjectId { get; init; } = null!;
+    public string ProjectId { get; set; } = null!;
 
     /// <summary>
     /// PubSub topic id
     /// </summary>
-    public string TopicId { get; init; } = null!;
+    public string TopicId { get; set; } = null!;
     
     /// <summary>
     /// Set to true to enable subscription monitoring using <see cref="GooglePubSubGapMeasure"/>
     /// Disabled by default as you can monitor subscriptions using Google Cloud native monitoring tools
     /// </summary>
-    public bool EnableMonitoring { get; init; }
+    public bool EnableMonitoring { get; set; }
 
     /// <summary>
     /// The subscription will try creating a PubSub subscription by default, but it requires extended permissions for PubSub.
     /// If you run the application with lower permissions, you can pre-create the subscription using your DevOps tools,
     /// then set this option to false
     /// </summary>
-    public bool CreateSubscription { get; init; } = true;
+    public bool CreateSubscription { get; set; } = true;
 
     /// <summary>
     /// <see cref="ClientCreationSettings"/> for the <seealso cref="SubscriberClient"/> creation
     /// </summary>
-    public ClientCreationSettings? ClientCreationSettings { get; init; }
+    public ClientCreationSettings? ClientCreationSettings { get; set; }
 
     /// <summary>
     /// <see cref="Settings"/> of the <seealso cref="SubscriberClient"/>
     /// </summary>
-    public Settings? Settings { get; init; }
+    public Settings? Settings { get; set; }
 
     /// <summary>
     /// Custom failure handler, which allows overriding the default behaviour (NACK)
@@ -55,5 +55,5 @@ public record PubSubSubscriptionOptions : SubscriptionOptions {
     /// <summary>
     /// Message attributes for system values like content type and event type
     /// </summary>
-    public PubSubAttributes Attributes { get; init; } = new();
+    public PubSubAttributes Attributes { get; set; } = new();
 }


### PR DESCRIPTION
Not sure if there's another way to use `PubSubSubscriptionOptions` but couldn't find it :) So would be nice to make public properties to be able to modify them when configuring using `Action` delegates.

For example when adding a `Gateway`:
https://github.com/Eventuous/eventuous/blob/dev/src/Gateway/src/Eventuous.Gateway/Registrations/GatewayRegistrations.cs#L44



