### PR TITLE
Abstract "Result" in OpenAPI "Produces" claim 

### DIFF
--- a/src/Extensions/src/Eventuous.AspNetCore.Web/Http/HttpCommandMapping.cs
+++ b/src/Extensions/src/Eventuous.AspNetCore.Web/Http/HttpCommandMapping.cs
@@ -152,7 +152,7 @@ public static partial class RouteBuilderExtensions {
                 }
             )
             .Accepts<TContract>(false, "application/json")
-            .Produces<Result>()
+            .Produces<Eventuous.OkResult>()
             .Produces<ErrorResult>(StatusCodes.Status404NotFound)
             .Produces<ErrorResult>(StatusCodes.Status409Conflict)
             .Produces<ErrorResult>(StatusCodes.Status400BadRequest);
@@ -224,7 +224,7 @@ public static partial class RouteBuilderExtensions {
                     }
                 )
                 .Accepts(type, false, "application/json")
-                .Produces<Result>()
+                .Produces<Eventuous.OkResult>()
                 .Produces<ErrorResult>(StatusCodes.Status404NotFound)
                 .Produces<ErrorResult>(StatusCodes.Status409Conflict)
                 .Produces<ErrorResult>(StatusCodes.Status400BadRequest);


### PR DESCRIPTION
The claim causes incorrect OpenAPI client to be generated.
The client fails on any call with "cannot instantiate abstract class"