### PR TITLE
Get all parameters at once to avoid conflicts in parallel testing

### DIFF
--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
@@ -14,17 +14,17 @@ using Context;
 using Filters;
 
 public abstract class SubscriptionBuilder {
-    public string SubscriptionId { get; }
+    public string             SubscriptionId { get; }
     public IServiceCollection Services { get; }
 
     protected SubscriptionBuilder(IServiceCollection services, string subscriptionId) {
         SubscriptionId = subscriptionId;
-        Services = services;
+        Services       = services;
     }
 
     readonly List<ResolveHandler> _handlers = new();
 
-    protected ConsumePipe Pipe { get; } = new();
+    protected ConsumePipe     Pipe            { get; }      = new();
     protected ResolveConsumer ResolveConsumer { get; set; } = null!;
 
     protected IEventHandler[] ResolveHandlers(IServiceProvider sp)
@@ -127,11 +127,11 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
     where T : EventSubscription<TOptions>
     where TOptions : SubscriptionOptions {
     public SubscriptionBuilder(IServiceCollection services, string subscriptionId) : base(services, subscriptionId) {
-        ResolveConsumer = ResolveDefaultConsumer;
+        ResolveConsumer  = ResolveDefaultConsumer;
         ConfigureOptions = options => options.SubscriptionId = subscriptionId;
     }
 
-    T? _resolvedSubscription;
+    T?                _resolvedSubscription;
     IMessageConsumer? _resolvedConsumer;
 
     public Action<TOptions> ConfigureOptions { get; private set; }
@@ -185,8 +185,7 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 
         var consumer = GetConsumer(sp);
 
-        if (EventuousDiagnostics.Enabled)
-        {
+        if (EventuousDiagnostics.Enabled) {
             Pipe.AddFilterLast(new TracingFilter(consumer.GetType().Name));
         }
 
@@ -194,8 +193,7 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 
         var constructors = typeof(T).GetConstructors<TOptions>();
 
-        switch (constructors.Length)
-        {
+        switch (constructors.Length) {
             case > 1:
                 throw new ArgumentOutOfRangeException(
                     typeof(T).Name,
@@ -206,8 +204,7 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
                 break;
         }
 
-        if (constructors.Length == 0)
-        {
+        if (constructors.Length == 0) {
             throw new ArgumentOutOfRangeException(
                 typeof(T).Name,
                 "Subscription type must have at least one constructor with options or subscription id argument"
@@ -224,10 +221,8 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
         return instance;
 
         object? CreateArg(ParameterInfo parameterInfo) {
-            if (parameterInfo == parameter)
-            {
-                if (parameter.Name == subscriptionIdParameterName)
-                {
+            if (parameterInfo == parameter) {
+                if (parameter.Name == subscriptionIdParameterName) {
                     return SubscriptionId;
                 }
 
@@ -241,14 +236,12 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 
             // ReSharper disable once ConvertIfStatementToReturnStatement
             // ReSharper disable once InvertIf
-            if (parameterInfo.ParameterType == typeof(ConsumePipe))
-            {
+            if (parameterInfo.ParameterType == typeof(ConsumePipe)) {
                 return Pipe;
             }
 
             // ReSharper disable once ConvertIfStatementToReturnStatement
-            if (ParametersMap.TryGetResolver(parameterInfo.ParameterType, out var resolver))
-            {
+            if (ParametersMap.TryGetResolver(parameterInfo.ParameterType, out var resolver)) {
                 return resolver!(sp);
             }
 

--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
@@ -15,7 +15,7 @@ using Filters;
 
 public abstract class SubscriptionBuilder {
     public string             SubscriptionId { get; }
-    public IServiceCollection Services { get; }
+    public IServiceCollection Services       { get; }
 
     protected SubscriptionBuilder(IServiceCollection services, string subscriptionId) {
         SubscriptionId = subscriptionId;
@@ -253,18 +253,19 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 static class TypeExtensionsForRegistrations {
     public static (ConstructorInfo Ctor, ParameterInfo[] parameters, ParameterInfo? Options)[] GetConstructors<T>(
         this Type type,
-        string? name = null
+        string?   name = null
     )
         => type
             .GetConstructors()
             .Select(
                 x => (
                     Ctor: x,
-                Parameters: x.GetParameters()
+                    Parameters: x.GetParameters()
                 ))
-            .Select(x => (
-                x.Ctor,
-                x.Parameters,
+            .Select(
+                x => (
+                    x.Ctor,
+                    x.Parameters,
                     Options: x.Parameters
                         .SingleOrDefault(
                             y => y.ParameterType == typeof(T) && (name == null || y.Name == name)

--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
@@ -14,17 +14,17 @@ using Context;
 using Filters;
 
 public abstract class SubscriptionBuilder {
-    public string             SubscriptionId { get; }
-    public IServiceCollection Services       { get; }
+    public string SubscriptionId { get; }
+    public IServiceCollection Services { get; }
 
     protected SubscriptionBuilder(IServiceCollection services, string subscriptionId) {
         SubscriptionId = subscriptionId;
-        Services       = services;
+        Services = services;
     }
 
     readonly List<ResolveHandler> _handlers = new();
 
-    protected ConsumePipe     Pipe            { get; }      = new();
+    protected ConsumePipe Pipe { get; } = new();
     protected ResolveConsumer ResolveConsumer { get; set; } = null!;
 
     protected IEventHandler[] ResolveHandlers(IServiceProvider sp)
@@ -127,11 +127,11 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
     where T : EventSubscription<TOptions>
     where TOptions : SubscriptionOptions {
     public SubscriptionBuilder(IServiceCollection services, string subscriptionId) : base(services, subscriptionId) {
-        ResolveConsumer  = ResolveDefaultConsumer;
+        ResolveConsumer = ResolveDefaultConsumer;
         ConfigureOptions = options => options.SubscriptionId = subscriptionId;
     }
 
-    T?                _resolvedSubscription;
+    T? _resolvedSubscription;
     IMessageConsumer? _resolvedConsumer;
 
     public Action<TOptions> ConfigureOptions { get; private set; }
@@ -185,7 +185,8 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 
         var consumer = GetConsumer(sp);
 
-        if (EventuousDiagnostics.Enabled) {
+        if (EventuousDiagnostics.Enabled)
+        {
             Pipe.AddFilterLast(new TracingFilter(consumer.GetType().Name));
         }
 
@@ -193,7 +194,8 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 
         var constructors = typeof(T).GetConstructors<TOptions>();
 
-        switch (constructors.Length) {
+        switch (constructors.Length)
+        {
             case > 1:
                 throw new ArgumentOutOfRangeException(
                     typeof(T).Name,
@@ -204,16 +206,17 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
                 break;
         }
 
-        if (constructors.Length == 0) {
+        if (constructors.Length == 0)
+        {
             throw new ArgumentOutOfRangeException(
                 typeof(T).Name,
                 "Subscription type must have at least one constructor with options or subscription id argument"
             );
         }
 
-        var (ctor, parameter) = constructors[0];
+        var (ctor, parameters, parameter) = constructors[0];
 
-        var args = ctor.GetParameters().Select(CreateArg).ToArray();
+        var args = parameters.Select(CreateArg).ToArray();
 
         if (ctor.Invoke(args) is not T instance) throw new InvalidOperationException($"Unable to instantiate {typeof(T)}");
 
@@ -221,8 +224,10 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
         return instance;
 
         object? CreateArg(ParameterInfo parameterInfo) {
-            if (parameterInfo == parameter) {
-                if (parameter.Name == subscriptionIdParameterName) {
+            if (parameterInfo == parameter)
+            {
+                if (parameter.Name == subscriptionIdParameterName)
+                {
                     return SubscriptionId;
                 }
 
@@ -236,12 +241,14 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 
             // ReSharper disable once ConvertIfStatementToReturnStatement
             // ReSharper disable once InvertIf
-            if (parameterInfo.ParameterType == typeof(ConsumePipe)) {
+            if (parameterInfo.ParameterType == typeof(ConsumePipe))
+            {
                 return Pipe;
             }
 
             // ReSharper disable once ConvertIfStatementToReturnStatement
-            if (ParametersMap.TryGetResolver(parameterInfo.ParameterType, out var resolver)) {
+            if (ParametersMap.TryGetResolver(parameterInfo.ParameterType, out var resolver))
+            {
                 return resolver!(sp);
             }
 
@@ -251,16 +258,21 @@ public class SubscriptionBuilder<T, TOptions> : SubscriptionBuilder
 }
 
 static class TypeExtensionsForRegistrations {
-    public static (ConstructorInfo Ctor, ParameterInfo? Options)[] GetConstructors<T>(
+    public static (ConstructorInfo Ctor, ParameterInfo[] parameters, ParameterInfo? Options)[] GetConstructors<T>(
         this Type type,
-        string?   name = null
+        string? name = null
     )
         => type
             .GetConstructors()
             .Select(
                 x => (
                     Ctor: x,
-                    Options: x.GetParameters()
+                Parameters: x.GetParameters()
+                ))
+            .Select(x => (
+                x.Ctor,
+                x.Parameters,
+                    Options: x.Parameters
                         .SingleOrDefault(
                             y => y.ParameterType == typeof(T) && (name == null || y.Name == name)
                         )


### PR DESCRIPTION
This PR should hopefully close #181.
A testing branch was created [here](https://github.com/diegosasw/eventuous/tree/issues/parallel-testing) to check the scenario.

As #181 explains, this problem arises when tests are being executed in parallel, randomly throwing `ArgumentNullException` in the `AllStreamSubscription` constructor.
After debugging this case, this was narrowed down to the `SubscriptionBuilder.ResolveSubscription` method. Although I still don't know exactly why, the execution goes as follows.
First, the `GetConstructors<TOptions>` extension method is called, returning the constructors that have `TOptions` as a parameter.
https://github.com/Eventuous/eventuous/blob/3209ab37dafee320fc563620665e0c06f6c15be1/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs#L194
This extension method returns the constructor and also the `TOptions` `ParameterInfo` in a tuple.
Then, in line 216, `GetParameters` is called again to get this constructor parameters and map them to their correct value.
https://github.com/Eventuous/eventuous/blob/3209ab37dafee320fc563620665e0c06f6c15be1/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs#L216
Finally, in line 224, a check is run to see if the parameter being mapped to its correct value is the options parameter, to get them from the IMonitorOptions.
https://github.com/Eventuous/eventuous/blob/3209ab37dafee320fc563620665e0c06f6c15be1/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs#L224

For some reason, when working in parallel, although they refer to the same parameter, they are completely different instances and don't match, omitting this check and returning null. To fix it, this PR returns only one array with the parameters of the constructor, avoiding the second call.
In the testing branch mentioned earlier, this behaviour can be replicated with ease. If line 220 is uncommented, test will start to fail, as now the `GetParameters()` method is returning different instances of the parameter.
Also, a `System.Diagnostics.Debugger.Launch()` is set in line 252 to debug this problem. 