### PR TITLE
Pubsub fix obsolete settings

### DIFF
--- a/src/Core/src/Eventuous.Persistence/ExpectedStreamVersion.cs
+++ b/src/Core/src/Eventuous.Persistence/ExpectedStreamVersion.cs
@@ -3,13 +3,13 @@
 
 namespace Eventuous;
 
-public record ExpectedStreamVersion(long Value) {
+public record struct ExpectedStreamVersion(long Value) {
     public static readonly ExpectedStreamVersion NoStream = new(-1);
     public static readonly ExpectedStreamVersion Any      = new(-2);
 }
 
-public record StreamReadPosition(long Value) {
+public record struct StreamReadPosition(long Value) {
     public static readonly StreamReadPosition Start = new(0L);
 }
 
-public record StreamTruncatePosition(long Value);
+public record struct StreamTruncatePosition(long Value);

--- a/src/Core/src/Eventuous.Subscriptions/Logging/Logger.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Logging/Logger.cs
@@ -33,18 +33,17 @@ public static class Logger {
 
 [SuppressMessage("Usage", "CA2254:Template should be a static expression")]
 public class LogContext {
-    internal string  SubscriptionId { get; }
-    readonly ILogger _logger;
-
-    public InternalLogger? TraceLog { get; }
-    public InternalLogger? DebugLog { get; }
-    public InternalLogger? InfoLog  { get; }
-    public InternalLogger? WarnLog  { get; }
-    public InternalLogger? ErrorLog { get; }
+    internal string          SubscriptionId { get; }
+    public   ILogger         Logger         { get; }
+    public   InternalLogger? TraceLog       { get; }
+    public   InternalLogger? DebugLog       { get; }
+    public   InternalLogger? InfoLog        { get; }
+    public   InternalLogger? WarnLog        { get; }
+    public   InternalLogger? ErrorLog       { get; }
 
     public LogContext(string subscriptionId, ILoggerFactory loggerFactory) {
         SubscriptionId = subscriptionId;
-        _logger        = loggerFactory.CreateLogger("Eventuous.Subscription");
+        Logger         = loggerFactory.CreateLogger("Eventuous.Subscription");
         TraceLog       = GetLogger(LogLevel.Trace);
         DebugLog       = GetLogger(LogLevel.Debug);
         InfoLog        = GetLogger(LogLevel.Information);
@@ -52,6 +51,6 @@ public class LogContext {
         ErrorLog       = GetLogger(LogLevel.Error);
 
         InternalLogger? GetLogger(LogLevel logLevel)
-            => _logger.IsEnabled(logLevel) ? new InternalLogger(_logger, logLevel, SubscriptionId) : null;
+            => Logger.IsEnabled(logLevel) ? new InternalLogger(Logger, logLevel, SubscriptionId) : null;
     }
 }

--- a/src/EventStore/src/Eventuous.EventStore/Producers/EventStoreProducer.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Producers/EventStoreProducer.cs
@@ -47,6 +47,13 @@ public class EventStoreProducer : BaseProducer<EventStoreProduceOptions> {
         ProduceOperation = "append"
     };
 
+    /// <summary>
+    /// Appends a batch of messages to a stream
+    /// </summary>
+    /// <param name="stream">Stream name</param>
+    /// <param name="messages">Batch of messages</param>
+    /// <param name="produceOptions">Options for the produce operation</param>
+    /// <param name="cancellationToken"></param>
     protected override async Task ProduceMessages(
         StreamName                   stream,
         IEnumerable<ProducedMessage> messages,

--- a/src/EventStore/src/Eventuous.EventStore/StreamRevisionExtensions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/StreamRevisionExtensions.cs
@@ -1,12 +1,30 @@
-namespace Eventuous.EventStore; 
+namespace Eventuous.EventStore;
 
+/// <summary>
+/// Internal conversions between Event Store and Eventuous types for stream positions and revisions
+/// </summary>
 public static class StreamRevisionExtensions {
+    /// <summary>
+    /// Converts <see cref="StreamRevision"/> to <see cref="ExpectedStreamVersion"/>
+    /// </summary>
+    /// <param name="version">Stream version</param>
+    /// <returns></returns>
     public static StreamRevision AsStreamRevision(this ExpectedStreamVersion version)
         => StreamRevision.FromInt64(version.Value);
 
+    /// <summary>
+    /// Converts <see cref="StreamTruncatePosition"/> to <see cref="ExpectedStreamVersion"/>
+    /// </summary>
+    /// <param name="position">Position for stream truncation</param>
+    /// <returns></returns>
     public static StreamPosition AsStreamPosition(this StreamTruncatePosition position)
         => StreamPosition.FromInt64(position.Value);
-        
+
+    /// <summary>
+    /// Converts <see cref="StreamReadPosition"/> to <see cref="StreamPosition"/>
+    /// </summary>
+    /// <param name="position">Position for stream reads</param>
+    /// <returns></returns>
     public static StreamPosition AsStreamPosition(this StreamReadPosition position)
         => StreamPosition.FromInt64(position.Value);
 }

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/ConsumePipeExtensions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/ConsumePipeExtensions.cs
@@ -5,7 +5,15 @@ using Eventuous.Subscriptions.Filters;
 
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Extensions for <see cref="ConsumePipe"/>
+/// </summary>
 public static class ConsumePipeExtensions {
+    /// <summary>
+    /// Adds a filter to ignore EventStoreDB system events
+    /// </summary>
+    /// <param name="pipe"></param>
+    /// <returns></returns>
     public static ConsumePipe AddSystemEventsFilter(this ConsumePipe pipe)
         => pipe.AddFilterLast(new MessageFilter(x => !x.MessageType.StartsWith("$")));
 }

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/EventStoreCatchUpSubscriptionBase.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/EventStoreCatchUpSubscriptionBase.cs
@@ -6,10 +6,22 @@ using Eventuous.Subscriptions.Filters;
 
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Base class for EventStoreDB catch-up subscriptions
+/// </summary>
+/// <typeparam name="T"></typeparam>
 [PublicAPI]
 public abstract class EventStoreCatchUpSubscriptionBase<T> : EventSubscriptionWithCheckpoint<T>
     where T : CatchUpSubscriptionOptions {
 
+    /// <summary>
+    /// Catch-up subscription base class constructor
+    /// </summary>
+    /// <param name="eventStoreClient">EventStoreDB client instance</param>
+    /// <param name="options">Subscription options</param>
+    /// <param name="checkpointStore">Checkpoint store</param>
+    /// <param name="consumePipe">Consume pipe, usually provided by the subscription builder</param>
+    /// <param name="loggerFactory">Optional logger factory</param>
     protected EventStoreCatchUpSubscriptionBase(
         EventStoreClient eventStoreClient,
         T                options,
@@ -19,8 +31,15 @@ public abstract class EventStoreCatchUpSubscriptionBase<T> : EventSubscriptionWi
     ) : base(Ensure.NotNull(options), checkpointStore, consumePipe, options.ConcurrencyLimit, loggerFactory)
         => EventStoreClient = eventStoreClient;
 
+    /// <summary>
+    /// EventStoreDB client instance
+    /// </summary>
     protected EventStoreClient EventStoreClient { get; }
 
+    /// <summary>
+    /// Stops the subscription
+    /// </summary>
+    /// <param name="cancellationToken"></param>
     protected override async ValueTask Unsubscribe(CancellationToken cancellationToken) {
         try {
             Stopping.Cancel(false);
@@ -32,5 +51,8 @@ public abstract class EventStoreCatchUpSubscriptionBase<T> : EventSubscriptionWi
         }
     }
 
+    /// <summary>
+    /// Underlying EventStoreDB subscription
+    /// </summary>
     protected global::EventStore.Client.StreamSubscription? Subscription { get; set; }
 }

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/AllPersistentSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/AllPersistentSubscriptionOptions.cs
@@ -1,3 +1,6 @@
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Options for <see cref="AllPersistentSubscription"/>
+/// </summary>
 public record AllPersistentSubscriptionOptions : PersistentSubscriptionOptions;

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/AllStreamSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/AllStreamSubscriptionOptions.cs
@@ -1,5 +1,8 @@
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Options for <see cref="AllStreamSubscription"/>
+/// </summary>
 [PublicAPI]
 public record AllStreamSubscriptionOptions : CatchUpSubscriptionOptions {
     /// <summary>

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/CatchUpSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/CatchUpSubscriptionOptions.cs
@@ -1,5 +1,14 @@
+using Eventuous.Subscriptions.Filters;
+
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Base class for catch-up subscription options
+/// </summary>
 public record CatchUpSubscriptionOptions : EventStoreSubscriptionOptions {
+    /// <summary>
+    /// Number of parallel consumers. Defaults to 1.
+    /// Don't set this value if you use partitioned subscriptions with <see cref="PartitioningFilter"/>.
+    /// </summary>
     public int ConcurrencyLimit { get; set; } = 1;
 }

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/EventStoreSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/EventStoreSubscriptionOptions.cs
@@ -1,5 +1,8 @@
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Base class for EventStoreDB subscription options
+/// </summary>
 public abstract record EventStoreSubscriptionOptions : SubscriptionOptions {
     /// <summary>
     /// User credentials

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/PersistentSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/PersistentSubscriptionOptions.cs
@@ -1,5 +1,8 @@
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Base class for persistent subscription options
+/// </summary>
 [PublicAPI]
 public abstract record PersistentSubscriptionOptions : EventStoreSubscriptionOptions {
     /// <summary>
@@ -12,6 +15,9 @@ public abstract record PersistentSubscriptionOptions : EventStoreSubscriptionOpt
     /// </summary>
     public int BufferSize { get; set; } = 10;
 
+    /// <summary>
+    /// Deadline for gRPC calls. Default is set by EventStoreDB client (10 sec).
+    /// </summary>
     public TimeSpan? Deadline { get; set; }
 
     // public uint ConcurrencyLevel { get; set; } = 1;

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/StreamPersistentSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/StreamPersistentSubscriptionOptions.cs
@@ -1,5 +1,8 @@
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Options for <see cref="StreamPersistentSubscription"/>
+/// </summary>
 [PublicAPI]
 public record StreamPersistentSubscriptionOptions : PersistentSubscriptionOptions {
     /// <summary>

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/StreamSubscriptionOptions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/Options/StreamSubscriptionOptions.cs
@@ -1,5 +1,8 @@
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Options for <see cref="StreamSubscription"/>
+/// </summary>
 public record StreamSubscriptionOptions : CatchUpSubscriptionOptions {
     /// <summary>
     /// WHen set to true, all events of type that starts with '$' will be ignored. Default is true.

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/StreamSubscription.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/StreamSubscription.cs
@@ -69,6 +69,10 @@ public class StreamSubscription
     ) : base(client, options, checkpointStore, consumePipe, loggerFactory)
         => Ensure.NotEmptyString(options.StreamName);
 
+    /// <summary>
+    /// Starts a catch-up subscription
+    /// </summary>
+    /// <param name="cancellationToken"></param>
     protected override async ValueTask Subscribe(CancellationToken cancellationToken) {
         var (_, position) = await GetCheckpoint(cancellationToken).NoContext();
 
@@ -140,10 +144,19 @@ public class StreamSubscription
 
     ulong _sequence;
 
+    /// <summary>
+    /// Returns a measure delegate for this subscription
+    /// </summary>
+    /// <returns></returns>
     public GetSubscriptionEndOfStream GetMeasure()
         => new StreamSubscriptionMeasure(Options.SubscriptionId, Options.StreamName, EventStoreClient)
             .GetEndOfStream;
 
+    /// <summary>
+    /// Gets position from the context
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns>Message position converted to <see cref="EventPosition"/></returns>
     protected override EventPosition GetPositionFromContext(IMessageConsumeContext context)
         => EventPosition.FromContext(context);
 }

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/SubscriptionBuilderExtensions.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/SubscriptionBuilderExtensions.cs
@@ -6,7 +6,18 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Eventuous.EventStore.Subscriptions;
 
+/// <summary>
+/// Extensions for <see cref="SubscriptionBuilder"/>
+/// </summary>
 public static class SubscriptionBuilderExtensions {
+    /// <summary>
+    /// Use non-default checkpoint store
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <typeparam name="TSubscription">Subscription type</typeparam>
+    /// <typeparam name="TOptions">Subscription options type</typeparam>
+    /// <typeparam name="T">Checkpoint store type</typeparam>
+    /// <returns></returns>
     public static SubscriptionBuilder<TSubscription, TOptions> UseCheckpointStore<TSubscription, TOptions, T>(
         this SubscriptionBuilder<TSubscription, TOptions> builder
     )
@@ -22,11 +33,23 @@ public static class SubscriptionBuilderExtensions {
             : builder.AddParameterMap<ICheckpointStore, T>();
     }
 
+    /// <summary>
+    /// Use non-default checkpoint store
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <typeparam name="T">Checkpoint store type</typeparam>
+    /// <returns></returns>
     public static SubscriptionBuilder<StreamSubscription, StreamSubscriptionOptions> UseCheckpointStore<T>(
         this SubscriptionBuilder<StreamSubscription, StreamSubscriptionOptions> builder
     ) where T : class, ICheckpointStore
         => builder.UseCheckpointStore<StreamSubscription, StreamSubscriptionOptions, T>();
 
+    /// <summary>
+    /// Use non-default checkpoint store
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <typeparam name="T">Checkpoint store type</typeparam>
+    /// <returns></returns>
     public static SubscriptionBuilder<AllStreamSubscription, AllStreamSubscriptionOptions> UseCheckpointStore<T>(
         this SubscriptionBuilder<AllStreamSubscription, AllStreamSubscriptionOptions> builder
     ) where T : class, ICheckpointStore

--- a/src/Gateway/test/Eventuous.Gateway.Tests/Eventuous.Gateway.Tests.csproj
+++ b/src/Gateway/test/Eventuous.Gateway.Tests/Eventuous.Gateway.Tests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <IsTestProject>true</IsTestProject>
         <IncludeTestHost>true</IncludeTestHost>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(LocalRoot)\Eventuous.Gateway\Eventuous.Gateway.csproj" />

--- a/src/GooglePubSub/src/Eventuous.GooglePubSub/Producers/GooglePubSubProducer.cs
+++ b/src/GooglePubSub/src/Eventuous.GooglePubSub/Producers/GooglePubSubProducer.cs
@@ -24,21 +24,18 @@ public class GooglePubSubProducer : BaseProducer<PubSubProduceOptions>, IHostedP
     /// </summary>
     /// <param name="projectId">GCP project ID</param>
     /// <param name="serializer">Optional event serializer. Will use the default instance if missing.</param>
-    /// <param name="settings"></param>
-    /// <param name="clientCreationSettings"></param>
     /// <param name="log">Optional logger instance</param>
+    /// <param name="configureClient">Publisher client configuration action</param>
     public GooglePubSubProducer(
-        string                         projectId,
-        IEventSerializer?              serializer             = null,
-        ILogger<GooglePubSubProducer>? log                    = null,
-        ClientCreationSettings?        clientCreationSettings = null,
-        Settings?                      settings               = null
+        string                          projectId,
+        IEventSerializer?               serializer      = null,
+        ILogger<GooglePubSubProducer>?  log             = null,
+        Action<PublisherClientBuilder>? configureClient = null
     )
         : this(
             new PubSubProducerOptions {
                 ProjectId              = Ensure.NotEmptyString(projectId),
-                Settings               = settings,
-                ClientCreationSettings = clientCreationSettings
+                ConfigureClientBuilder = configureClient
             },
             serializer,
             log

--- a/src/GooglePubSub/src/Eventuous.GooglePubSub/Producers/PubSubProducerOptions.cs
+++ b/src/GooglePubSub/src/Eventuous.GooglePubSub/Producers/PubSubProducerOptions.cs
@@ -1,6 +1,7 @@
 // Copyright (C) Ubiquitous AS. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using Grpc.Core;
 using static Google.Cloud.PubSub.V1.PublisherClient;
 
 namespace Eventuous.GooglePubSub.Producers; 
@@ -11,16 +12,11 @@ public class PubSubProducerOptions {
     /// Google Cloud project id
     /// </summary>
     public string ProjectId { get; init; } = null!;
-        
-    /// <summary>
-    /// <see cref="ClientCreationSettings"/> for the <seealso cref="Publisher.PublisherClient"/> creation
-    /// </summary>
-    public ClientCreationSettings? ClientCreationSettings { get; init; }
 
     /// <summary>
-    /// <see cref="PublisherClient.Settings"/> of the <seealso cref="PublisherClient"/>
+    /// Additional configuration for the client builder. Don't set the <code>TopicName</code> property.
     /// </summary>
-    public Settings? Settings { get; init; }
+    public Action<PublisherClientBuilder>? ConfigureClientBuilder { get; init; }
 
     /// <summary>
     /// Message attributes for system values like content type and event type

--- a/src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/PubSubSubscriptionOptions.cs
+++ b/src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/PubSubSubscriptionOptions.cs
@@ -28,14 +28,9 @@ public record PubSubSubscriptionOptions : SubscriptionOptions {
     public bool CreateSubscription { get; set; } = true;
 
     /// <summary>
-    /// <see cref="ClientCreationSettings"/> for the <seealso cref="SubscriberClient"/> creation
+    /// Configure the <seealso cref="SubscriberClientBuilder"/> before the <seealso cref="SubscriberClient"/> is created
     /// </summary>
-    public ClientCreationSettings? ClientCreationSettings { get; set; }
-
-    /// <summary>
-    /// <see cref="Settings"/> of the <seealso cref="SubscriberClient"/>
-    /// </summary>
-    public Settings? Settings { get; set; }
+    public Action<SubscriberClientBuilder>? ConfigureClientBuilder { get; set; }
 
     /// <summary>
     /// Custom failure handler, which allows overriding the default behaviour (NACK)


### PR DESCRIPTION
Setting classes for publisher and subscription clients are now obsolete.
The suggested way is to use client builders.

As those builders have a lot of settings, it makes no sense to copy them all to Eventuous options. SO, this PR adds a possibility to configure the builders directly by providing a function in the options object.