### PR TITLE
Get rid of original events in Aggregate/FunctionalCommandService

### DIFF
--- a/src/Core/src/Eventuous.Application/FunctionalCommandService.cs
+++ b/src/Core/src/Eventuous.Application/FunctionalCommandService.cs
@@ -27,7 +27,7 @@ public abstract class FunctionalCommandService<T> : IFuncCommandService<T>, ISta
         GetStreamNameFromCommand<TCommand>  getStreamName,
         Func<TCommand, IEnumerable<object>> action
     ) where TCommand : class {
-        _handlers.AddHandler<TCommand>(ExpectedState.New, (_, _, cmd) => action(cmd));
+        _handlers.AddHandler<TCommand>(ExpectedState.New, (_, cmd) => action(cmd));
         _streamMap.AddCommand(getStreamName);
     }
 
@@ -73,7 +73,7 @@ public abstract class FunctionalCommandService<T> : IFuncCommandService<T>, ISta
             };
 
             var result = await registeredHandler
-                .Handler(loadedState.State, loadedState.Events, command, cancellationToken)
+                .Handler(loadedState.State, command, cancellationToken)
                 .NoContext();
 
             var newEvents = result.ToArray();

--- a/src/Core/src/Eventuous.Application/FunctionalHandlersMap.cs
+++ b/src/Core/src/Eventuous.Application/FunctionalHandlersMap.cs
@@ -5,7 +5,7 @@ namespace Eventuous;
 
 using static Diagnostics.ApplicationEventSource;
 
-delegate ValueTask<IEnumerable<object>> ExecuteUntypedCommand<in T>(T state, object[] events, object command, CancellationToken cancellationToken) where T : State<T>;
+delegate ValueTask<IEnumerable<object>> ExecuteUntypedCommand<in T>(T state, object command, CancellationToken cancellationToken) where T : State<T>;
 
 record RegisteredFuncHandler<T>(ExpectedState ExpectedState, ExecuteUntypedCommand<T> Handler) where T : State<T>;
 
@@ -24,8 +24,8 @@ class FunctionalHandlersMap<T> where T : State<T> {
     }
 
     public void AddHandler<TCommand>(ExpectedState expectedState, ExecuteCommand<T, TCommand> action) where TCommand : class {
-        ValueTask<IEnumerable<object>> Handler(T state, object[] events, object command, CancellationToken token) {
-            var newEvents = action(state, events, (TCommand)command);
+        ValueTask<IEnumerable<object>> Handler(T state, object command, CancellationToken token) {
+            var newEvents = action(state, (TCommand)command);
             return new ValueTask<IEnumerable<object>>(newEvents);
         }
 

--- a/src/Core/src/Eventuous.Application/HandlersMap.cs
+++ b/src/Core/src/Eventuous.Application/HandlersMap.cs
@@ -51,5 +51,5 @@ class HandlersMap<TAggregate> where TAggregate : Aggregate {
         => _typeMap.TryGetValue<TCommand>(out handler);
 }
 
-public delegate IEnumerable<object> ExecuteCommand<in T, in TCommand>(T state, object[] originalEvents, TCommand command)
+public delegate IEnumerable<object> ExecuteCommand<in T, in TCommand>(T state, TCommand command)
     where T : State<T> where TCommand : class;

--- a/src/Core/src/Eventuous.Persistence/StateStore/StateStoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/StateStore/StateStoreFunctions.cs
@@ -9,19 +9,16 @@ public record FoldedEventStream<T> where T : State<T>, new() {
     public FoldedEventStream(StreamName streamName, ExpectedStreamVersion streamVersion, object[] events) {
         StreamName    = streamName;
         StreamVersion = streamVersion;
-        Events        = events;
         State         = events.Aggregate(new T(), (state, o) => state.When(o));
     }
 
     public StreamName            StreamName    { get; }
     public ExpectedStreamVersion StreamVersion { get; }
-    public object[]              Events        { get; }
     public T                     State         { get; init; }
 
-    public void Deconstruct(out StreamName streamName, out ExpectedStreamVersion streamVersion, out object[] events) {
+    public void Deconstruct(out StreamName streamName, out ExpectedStreamVersion streamVersion) {
         streamName    = StreamName;
         streamVersion = StreamVersion;
-        events        = Events;
     }
 }
 

--- a/src/Core/test/Eventuous.Tests.Application/BookingFuncService.cs
+++ b/src/Core/test/Eventuous.Tests.Application/BookingFuncService.cs
@@ -19,7 +19,7 @@ public class BookingFuncService : FunctionalCommandService<BookingState> {
             yield return new RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price);
         }
 
-        static IEnumerable<object> RecordPayment(BookingState state, object[] originalEvents, Commands.RecordPayment cmd) {
+        static IEnumerable<object> RecordPayment(BookingState state, Commands.RecordPayment cmd) {
             if (state.HasPayment(cmd.PaymentId)) yield break;
 
             var registered = new BookingPaymentRegistered(cmd.PaymentId, cmd.Amount.Amount);

--- a/test/Eventuous.Sut.Domain/Booking.cs
+++ b/test/Eventuous.Sut.Domain/Booking.cs
@@ -1,3 +1,6 @@
+// Copyright (C) Ubiquitous AS. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
 using static Eventuous.Sut.Domain.BookingEvents;
 
 namespace Eventuous.Sut.Domain;
@@ -33,7 +36,7 @@ public class Booking : Aggregate<BookingState> {
     }
 
     public bool HasPaymentRecord(string paymentId)
-        => Current.OfType<BookingPaymentRegistered>().Any(x => x.PaymentId == paymentId);
+        => State.HasPayment(paymentId);
 }
 
 public record BookingId(string Value) : Id(Value);


### PR DESCRIPTION
It should not be the Aggregate's or FunctionalCommandService's responsibility to expose an exhaustive event history to consumers.  This won't scale.  Either the state captures a synopsis of the required event information, or the event stream is projected to a separate read model fit for the consumer's purpose.

More to the point, the "Original" event array blocked adding support for loading from a cached snapshot + stream tail (see upcoming PRs).
Maintain OriginalVersion instead.