### PR TITLE
Support IMemoryCache in AggregateStore

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftWebVer)" />

--- a/src/Core/src/Eventuous.Domain/Snapshot.cs
+++ b/src/Core/src/Eventuous.Domain/Snapshot.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (C) Ubiquitous AS. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+namespace Eventuous;
+
+public record Snapshot(long Version);
+
+public record Snapshot<T> : Snapshot {
+    public T State { get; init; }
+    public Snapshot(T state, long version) : base(version) {
+        State = state;
+    }
+}

--- a/src/Core/src/Eventuous.Persistence/AggregateStore/AggregateStore.cs
+++ b/src/Core/src/Eventuous.Persistence/AggregateStore/AggregateStore.cs
@@ -71,6 +71,7 @@ public class AggregateStore : IAggregateStore {
         try {
             var events = await _eventReader.ReadStream(streamName, new(aggregate.CurrentVersion + 1), failIfNotFound, cancellationToken);
             aggregate.Load(events.Select(x => x.Payload));
+            _memoryCache?.Set(streamName, aggregate.CreateSnapshot());
         }
         catch (StreamNotFound) when (!failIfNotFound) {
             return aggregate;

--- a/src/Core/src/Eventuous.Persistence/AggregateStore/AggregateStore.cs
+++ b/src/Core/src/Eventuous.Persistence/AggregateStore/AggregateStore.cs
@@ -3,6 +3,7 @@
 
 namespace Eventuous;
 
+using Microsoft.Extensions.Caching.Memory;
 using static Diagnostics.PersistenceEventSource;
 
 public class AggregateStore : IAggregateStore {
@@ -10,6 +11,7 @@ public class AggregateStore : IAggregateStore {
     readonly AggregateFactoryRegistry       _factoryRegistry;
     readonly IEventReader                   _eventReader;
     readonly IEventWriter                   _eventWriter;
+    readonly IMemoryCache?                  _memoryCache;
 
     /// <summary>
     /// Creates a new instance of the default aggregate store
@@ -18,16 +20,19 @@ public class AggregateStore : IAggregateStore {
     /// <param name="writer"></param>
     /// <param name="amendEvent"></param>
     /// <param name="factoryRegistry"></param>
+    /// <param name="memoryCache"></param>
     public AggregateStore(
         IEventReader                    reader,
         IEventWriter                    writer,
         Func<StreamEvent, StreamEvent>? amendEvent      = null,
-        AggregateFactoryRegistry?       factoryRegistry = null
+        AggregateFactoryRegistry?       factoryRegistry = null,
+        IMemoryCache?                   memoryCache     = null
     ) {
         _amendEvent      = amendEvent      ?? (x => x);
         _factoryRegistry = factoryRegistry ?? AggregateFactoryRegistry.Instance;
         _eventReader     = Ensure.NotNull(reader);
         _eventWriter     = Ensure.NotNull(writer);
+        _memoryCache     = memoryCache;
     }
 
     /// <summary>
@@ -36,14 +41,19 @@ public class AggregateStore : IAggregateStore {
     /// <param name="eventStore">Event store implementation</param>
     /// <param name="amendEvent"></param>
     /// <param name="factoryRegistry"></param>
+    /// <param name="memoryCache"></param>
     public AggregateStore(
         IEventStore                     eventStore,
         Func<StreamEvent, StreamEvent>? amendEvent      = null,
-        AggregateFactoryRegistry?       factoryRegistry = null
-    ) : this(eventStore, eventStore, amendEvent, factoryRegistry) { }
+        AggregateFactoryRegistry?       factoryRegistry = null,
+        IMemoryCache?                   memoryCache     = null
+    ) : this(eventStore, eventStore, amendEvent, factoryRegistry, memoryCache) { }
 
-    public Task<AppendEventsResult> Store<T>(StreamName streamName, T aggregate, CancellationToken cancellationToken) where T : Aggregate
-        => _eventWriter.Store(streamName, aggregate, _amendEvent, cancellationToken);
+    public Task<AppendEventsResult> Store<T>(StreamName streamName, T aggregate, CancellationToken cancellationToken) where T : Aggregate {
+        var result = _eventWriter.Store(streamName, aggregate, _amendEvent, cancellationToken);
+        _memoryCache?.Set(streamName, aggregate.CreateSnapshot());
+        return result;
+    }
 
     public Task<T> Load<T>(StreamName streamName, CancellationToken cancellationToken) where T : Aggregate
         => LoadInternal<T>(streamName, true, cancellationToken);
@@ -52,10 +62,14 @@ public class AggregateStore : IAggregateStore {
         => LoadInternal<T>(streamName, false, cancellationToken);
 
     async Task<T> LoadInternal<T>(StreamName streamName, bool failIfNotFound, CancellationToken cancellationToken) where T : Aggregate {
+
         var aggregate = _factoryRegistry.CreateInstance<T>();
 
+        if (_memoryCache != null && _memoryCache.TryGetValue(streamName, out Aggregate.Snapshot? snapshot))
+            aggregate.Load(snapshot!);
+
         try {
-            var events = await _eventReader.ReadStream(streamName, StreamReadPosition.Start, failIfNotFound, cancellationToken);
+            var events = await _eventReader.ReadStream(streamName, new(aggregate.CurrentVersion + 1), failIfNotFound, cancellationToken);
             aggregate.Load(events.Select(x => x.Payload));
         }
         catch (StreamNotFound) when (!failIfNotFound) {

--- a/src/Core/src/Eventuous.Persistence/AggregateStore/AggregateStore.cs
+++ b/src/Core/src/Eventuous.Persistence/AggregateStore/AggregateStore.cs
@@ -65,7 +65,7 @@ public class AggregateStore : IAggregateStore {
 
         var aggregate = _factoryRegistry.CreateInstance<T>();
 
-        if (_memoryCache != null && _memoryCache.TryGetValue(streamName, out Aggregate.Snapshot? snapshot))
+        if (_memoryCache != null && _memoryCache.TryGetValue(streamName, out Snapshot? snapshot))
             aggregate.Load(snapshot!);
 
         try {

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -53,7 +53,7 @@ public static class StoreFunctions {
         Ensure.NotNull(aggregate);
 
         try {
-            return await eventWriter.Store(streamName, aggregate.OriginalVersion, aggregate.Changes, amendEvent, cancellationToken).NoContext();
+            return await eventWriter.Store(streamName, (int)aggregate.OriginalVersion, aggregate.Changes, amendEvent, cancellationToken).NoContext();
         }
         catch (OptimisticConcurrencyException e) {
             Log.UnableToStoreAggregate<T>(streamName, e);

--- a/src/Core/src/Eventuous.Persistence/Eventuous.Persistence.csproj
+++ b/src/Core/src/Eventuous.Persistence/Eventuous.Persistence.csproj
@@ -13,6 +13,9 @@
         <Using Include="Eventuous.Tools" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    </ItemGroup>
+    <ItemGroup>
         <ProjectReference Include="..\Eventuous.Diagnostics\Eventuous.Diagnostics.csproj" />
         <ProjectReference Include="..\Eventuous.Domain\Eventuous.Domain.csproj" />
         <ProjectReference Include="..\Eventuous.Serialization\Eventuous.Serialization.csproj" />

--- a/src/Core/test/Eventuous.Tests.Application/BookingFuncService.cs
+++ b/src/Core/test/Eventuous.Tests.Application/BookingFuncService.cs
@@ -3,12 +3,13 @@
 
 using Eventuous.Sut.App;
 using Eventuous.Sut.Domain;
+using Microsoft.Extensions.Caching.Memory;
 using static Eventuous.Sut.Domain.BookingEvents;
 
 namespace Eventuous.Tests.Application;
 
 public class BookingFuncService : FunctionalCommandService<BookingState> {
-    public BookingFuncService(IEventStore store, TypeMapper? typeMap = null) : base(store, typeMap) {
+    public BookingFuncService(IEventStore store, TypeMapper? typeMap = null, IMemoryCache? memoryCache = null) : base(store, typeMap, memoryCache) {
         OnNew<Commands.BookRoom>(cmd => GetStream(cmd.BookingId), BookRoom);
         OnExisting<Commands.RecordPayment>(cmd => GetStream(cmd.BookingId), RecordPayment);
 

--- a/src/Core/test/Eventuous.Tests.Application/Eventuous.Tests.Application.csproj
+++ b/src/Core/test/Eventuous.Tests.Application/Eventuous.Tests.Application.csproj
@@ -6,6 +6,5 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     </ItemGroup>
 </Project>

--- a/src/Core/test/Eventuous.Tests.Application/Eventuous.Tests.Application.csproj
+++ b/src/Core/test/Eventuous.Tests.Application/Eventuous.Tests.Application.csproj
@@ -5,4 +5,7 @@
         <IncludeSutApp>true</IncludeSutApp>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    </ItemGroup>
 </Project>

--- a/src/Core/test/Eventuous.Tests.Application/FunctionalServiceTests.cs
+++ b/src/Core/test/Eventuous.Tests.Application/FunctionalServiceTests.cs
@@ -5,8 +5,6 @@ using Eventuous.Sut.App;
 using Eventuous.Sut.Domain;
 using Eventuous.TestHelpers;
 using Eventuous.TestHelpers.Fakes;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Eventuous.Tests.Application;
@@ -22,7 +20,7 @@ public class FunctionalServiceTests : IDisposable {
 
     public FunctionalServiceTests(ITestOutputHelper output) {
         _store    = new InMemoryEventStore();
-        _service  = new BookingFuncService(_store, memoryCache: new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
+        _service  = new BookingFuncService(_store, memoryCache: Caching.CreateMemoryCache());
         _listener = new TestEventListener(output);
     }
 

--- a/src/Core/test/Eventuous.Tests.Application/FunctionalServiceTests.cs
+++ b/src/Core/test/Eventuous.Tests.Application/FunctionalServiceTests.cs
@@ -5,6 +5,8 @@ using Eventuous.Sut.App;
 using Eventuous.Sut.Domain;
 using Eventuous.TestHelpers;
 using Eventuous.TestHelpers.Fakes;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Eventuous.Tests.Application;
@@ -20,7 +22,7 @@ public class FunctionalServiceTests : IDisposable {
 
     public FunctionalServiceTests(ITestOutputHelper output) {
         _store    = new InMemoryEventStore();
-        _service  = new BookingFuncService(_store);
+        _service  = new BookingFuncService(_store, memoryCache: new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
         _listener = new TestEventListener(output);
     }
 

--- a/src/Core/test/Eventuous.Tests.Application/StateWithIdTests.cs
+++ b/src/Core/test/Eventuous.Tests.Application/StateWithIdTests.cs
@@ -1,37 +1,49 @@
+// Copyright (C) Ubiquitous AS. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
 using Eventuous.Sut.App;
 using Eventuous.Sut.Domain;
+using Eventuous.TestHelpers;
 using Eventuous.TestHelpers.Fakes;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Eventuous.Tests.Application;
 
 public class StateWithIdTests {
+    readonly IEventStore    _store;
     readonly BookingService _service;
     readonly AggregateStore _aggregateStore;
 
     public StateWithIdTests() {
-        var store = new InMemoryEventStore();
-        _aggregateStore = new AggregateStore(store, memoryCache: new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
+        _store          = new InMemoryEventStore();
+        _aggregateStore = new AggregateStore(_store, memoryCache: Caching.CreateMemoryCache());
         _service        = new BookingService(_aggregateStore);
+        TypeMap.RegisterKnownEventTypes(typeof(BookingEvents).Assembly);
     }
 
     [Fact]
     public async Task ShouldGetIdForNew() {
-        var map   = new StreamNameMap();
-        var id    = Guid.NewGuid().ToString();
-        var state = await Seed(id);
-
-        var bookingId = new BookingId(id);
+        var map       = new StreamNameMap();
+        var bookingId = new BookingId(Guid.NewGuid().ToString());
+        var result    = await Seed(bookingId);
 
         // Ensure that the id was set when the aggregate was created
-        state.State!.Id.Should().Be(bookingId);
+        result.State!.Id.Should().Be(bookingId);
 
         var instance = await _aggregateStore.Load<Booking, BookingState, BookingId>(map, bookingId, default);
 
         // Ensure that the id was set when the aggregate was loaded
         instance.State.Id.Should().Be(bookingId);
+    }
+
+    [Fact]
+    public async Task ExpectedEventsForBookingAndPayment() {
+        var bookingId = new BookingId(Guid.NewGuid().ToString());
+        var result    = await Seed(bookingId);
+        result.Changes.Should().HaveCount(1);
+
+        result = await _service.Handle(new Commands.RecordPayment(bookingId, "payment1", new(100), DateTimeOffset.Now), default);
+        result.Changes.Should().HaveCount(3);
     }
 
     async Task<Result<BookingState>> Seed(string id) {

--- a/src/Core/test/Eventuous.Tests.Application/StateWithIdTests.cs
+++ b/src/Core/test/Eventuous.Tests.Application/StateWithIdTests.cs
@@ -1,6 +1,8 @@
 using Eventuous.Sut.App;
 using Eventuous.Sut.Domain;
 using Eventuous.TestHelpers.Fakes;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Eventuous.Tests.Application;
@@ -11,7 +13,7 @@ public class StateWithIdTests {
 
     public StateWithIdTests() {
         var store = new InMemoryEventStore();
-        _aggregateStore = new AggregateStore(store);
+        _aggregateStore = new AggregateStore(store, memoryCache: new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
         _service        = new BookingService(_aggregateStore);
     }
 

--- a/src/Core/test/Eventuous.Tests/Eventuous.Tests.csproj
+++ b/src/Core/test/Eventuous.Tests/Eventuous.Tests.csproj
@@ -6,6 +6,7 @@
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Core/test/Eventuous.Tests/Fixtures/NaiveFixture.cs
+++ b/src/Core/test/Eventuous.Tests/Fixtures/NaiveFixture.cs
@@ -1,7 +1,6 @@
 using Eventuous.Sut.App;
+using Eventuous.TestHelpers;
 using Eventuous.TestHelpers.Fakes;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 
 namespace Eventuous.Tests.Fixtures;
 
@@ -12,7 +11,7 @@ public class NaiveFixture {
 
     protected NaiveFixture() {
         EventStore     = new InMemoryEventStore();
-        AggregateStore = new AggregateStore(EventStore, memoryCache: new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
+        AggregateStore = new AggregateStore(EventStore, memoryCache: Caching.CreateMemoryCache());
     }
 
     protected Commands.BookRoom CreateBookRoomCommand() => new(

--- a/src/Core/test/Eventuous.Tests/Fixtures/NaiveFixture.cs
+++ b/src/Core/test/Eventuous.Tests/Fixtures/NaiveFixture.cs
@@ -1,5 +1,7 @@
 using Eventuous.Sut.App;
 using Eventuous.TestHelpers.Fakes;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 
 namespace Eventuous.Tests.Fixtures;
 
@@ -10,7 +12,7 @@ public class NaiveFixture {
 
     protected NaiveFixture() {
         EventStore     = new InMemoryEventStore();
-        AggregateStore = new AggregateStore(EventStore);
+        AggregateStore = new AggregateStore(EventStore, memoryCache: new MemoryCache(Options.Create<MemoryCacheOptions>(new())));
     }
 
     protected Commands.BookRoom CreateBookRoomCommand() => new(

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/MappedCommandTests.cs
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/MappedCommandTests.cs
@@ -120,4 +120,5 @@ record ImportBookingHttp3(string BookingId, string RoomId, LocalDate CheckIn, Lo
 
 class Brooking : Aggregate {
     public override void Load(IEnumerable<object?> events) { }
+    public override void Load(Snapshot snapshot) => throw new NotImplementedException();
 }

--- a/test/Eventuous.Sut.Domain/Booking.cs
+++ b/test/Eventuous.Sut.Domain/Booking.cs
@@ -1,3 +1,6 @@
+// Copyright (C) Ubiquitous AS. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
 using static Eventuous.Sut.Domain.BookingEvents;
 
 namespace Eventuous.Sut.Domain;
@@ -33,7 +36,7 @@ public class Booking : Aggregate<BookingState> {
     }
 
     public bool HasPaymentRecord(string paymentId)
-        => Current.OfType<BookingPaymentRegistered>().Any(x => x.PaymentId == paymentId);
+        => State.HasPayment(paymentId);
 }
 
 public record BookingId(string Value) : Id(Value);

--- a/test/Eventuous.TestHelpers/Caching.cs
+++ b/test/Eventuous.TestHelpers/Caching.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (C) Ubiquitous AS. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Eventuous.TestHelpers {
+    public static class Caching {
+        public static IMemoryCache CreateMemoryCache() => new MemoryCache(Options.Create<MemoryCacheOptions>(new()));
+    }
+}

--- a/test/Eventuous.TestHelpers/Eventuous.TestHelpers.csproj
+++ b/test/Eventuous.TestHelpers/Eventuous.TestHelpers.csproj
@@ -4,6 +4,7 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="xunit.abstractions" />
         <PackageReference Include="Xunit.Extensions.Logging" />


### PR DESCRIPTION
This builds on #218 and #219, and adds support for IMemoryCache in AggregateStore, using StreamName as key and Aggregate<T>.Snapshot as value.

Edit: also added to FunctionalCommandService.  I'm not using this myself, but it was fairly straightforward.
In general, the repo needs aligning on int vs long/ulong for versions/positions.