### PR TITLE
Handle dropped connection in PostgreSQL subscriptions

### DIFF
--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresSubscriptionBase.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresSubscriptionBase.cs
@@ -83,9 +83,8 @@ public abstract class PostgresSubscriptionBase<T> : EventSubscriptionWithCheckpo
                 retryDelay *= 2;
             }
             catch (Exception e) {
-                IsDropped = true;
-                Log.WarnLog?.Log(e, "Dropped");
-                throw;
+                Dropped(DropReason.ServerError, e);
+                break;
             }
         }
     }


### PR DESCRIPTION
Resolves #225 by calling the *Dropped* method from the base class when the PostgreSQL connection is dropped, like the EventStore subscription already does.
