### PR TITLE
Added parameterless ctor for PostgresCheckpointStoreOptions

### DIFF
--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresCheckpointStore.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresCheckpointStore.cs
@@ -11,18 +11,20 @@ namespace Eventuous.Postgresql.Subscriptions;
 using Extensions;
 
 public class PostgresCheckpointStoreOptions {
+    public PostgresCheckpointStoreOptions() 
+        : this(Postgresql.Schema.DefaultSchema)
+    {
+    }
+
     // ReSharper disable once ConvertToPrimaryConstructor
     public PostgresCheckpointStoreOptions(string schema)
         => Schema = schema;
-
-    public PostgresCheckpointStoreOptions() {
-    }
 
     /// <summary>
     /// Override the default schema name.
     /// The property is mutable to allow using ASP.NET Core configuration.
     /// </summary>
-    public string Schema { get; set; } = Postgresql.Schema.DefaultSchema;
+    public string Schema { get; set; }
 }
 
 /// <summary>

--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresCheckpointStore.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresCheckpointStore.cs
@@ -12,14 +12,17 @@ using Extensions;
 
 public class PostgresCheckpointStoreOptions {
     // ReSharper disable once ConvertToPrimaryConstructor
-    public PostgresCheckpointStoreOptions(string schema = Postgresql.Schema.DefaultSchema)
+    public PostgresCheckpointStoreOptions(string schema)
         => Schema = schema;
+
+    public PostgresCheckpointStoreOptions() {
+    }
 
     /// <summary>
     /// Override the default schema name.
     /// The property is mutable to allow using ASP.NET Core configuration.
     /// </summary>
-    public string Schema { get; set; }
+    public string Schema { get; set; } = Postgresql.Schema.DefaultSchema;
 }
 
 /// <summary>


### PR DESCRIPTION
`PostgresCheckpointStoreOptions` lacked a parameterless ctor which is required to work with asp.net's `IOptions<>` pattern.  Moved the default schema assignment to the property and added additional empty ctor for compatibility.