### PR TITLE
Changing PostgresStreamSubscriptionOptions.Stream to be mutable

### DIFF
--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresStreamSubscription.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresStreamSubscription.cs
@@ -69,4 +69,9 @@ public class PostgresStreamSubscription : PostgresSubscriptionBase<PostgresStrea
         => EventPosition.FromContext(context);
 }
 
-public record PostgresStreamSubscriptionOptions(StreamName Stream) : PostgresSubscriptionBaseOptions;
+public record PostgresStreamSubscriptionOptions : PostgresSubscriptionBaseOptions {
+    /// <summary>
+    /// Stream name to subscribe for
+    /// </summary>
+    public StreamName Stream { get; set; }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Fixtures/SubscriptionFixture.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Fixtures/SubscriptionFixture.cs
@@ -49,7 +49,8 @@ public abstract class SubscriptionFixture<T> : IAsyncLifetime
             !subscribeToAll
                 ? new PostgresStreamSubscription(
                     IntegrationFixture.DataSource,
-                    new PostgresStreamSubscriptionOptions(Stream) {
+                    new PostgresStreamSubscriptionOptions {
+                        Stream = Stream,
                         SubscriptionId = SubscriptionId,
                         Schema         = IntegrationFixture.SchemaName
                     },


### PR DESCRIPTION
Changing PostgresStreamSubscriptionOptions.Stream to be mutable, this now is more in-line with how the [documentation](https://eventuous.dev/docs/infra/postgres/#registering-subscriptions) outlines it's usage:

```
builder.Services.AddSubscription<PostgresStreamSubscription, PostgresStreamSubscriptionOptions>(
    "StreamSubscription",
    builder => builder
        .Configure(x => x.StreamName = "my-stream")
        .AddEventHandler<StreamSubscriptionHander>()
);
```

but the document should now be:
```
builder.Services.AddSubscription<PostgresStreamSubscription, PostgresStreamSubscriptionOptions>(
    "StreamSubscription",
    builder => builder
        .Configure(x => x.StreamName = new StreamName("my-stream"))
        .AddEventHandler<StreamSubscriptionHander>()
);
```
and is now closer to how `StreamPersistentSubscriptionOptions` is created.

(documentation site will need a PR if this is accepted)