### PR TITLE
Creating SqlServerCheckpointStoreOptions

### DIFF
--- a/src/Postgres/test/Eventuous.Tests.Postgres/Fixtures/SubscriptionFixture.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Fixtures/SubscriptionFixture.cs
@@ -50,7 +50,7 @@ public abstract class SubscriptionFixture<T> : IAsyncLifetime
                 ? new PostgresStreamSubscription(
                     IntegrationFixture.DataSource,
                     new PostgresStreamSubscriptionOptions {
-                        Stream = Stream,
+                        Stream         = Stream,
                         SubscriptionId = SubscriptionId,
                         Schema         = IntegrationFixture.SchemaName
                     },

--- a/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerCheckpointStore.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerCheckpointStore.cs
@@ -18,12 +18,12 @@ public class SqlServerCheckpointStore : ICheckpointStore {
     readonly string                 _addCheckpointSql;
     readonly string                 _storeCheckpointSql;
 
-    public SqlServerCheckpointStore(GetSqlServerConnection getConnection, string schema) {
+    public SqlServerCheckpointStore(GetSqlServerConnection getConnection, SqlServerCheckpointStoreOptions? options) {
         _getConnection = getConnection;
-        var sch = new Schema(schema);
-        _getCheckpointSql   = sch.GetCheckpointSql;
-        _addCheckpointSql   = sch.AddCheckpointSql;
-        _storeCheckpointSql = sch.UpdateCheckpointSql;
+        var schema = options is { Schema: { } } ? new Schema(options.Schema) : new Schema();
+        _getCheckpointSql   = schema.GetCheckpointSql;
+        _addCheckpointSql   = schema.AddCheckpointSql;
+        _storeCheckpointSql = schema.UpdateCheckpointSql;
     }
 
     public async ValueTask<Checkpoint> GetLastCheckpoint(string checkpointId, CancellationToken cancellationToken) {
@@ -69,4 +69,15 @@ public class SqlServerCheckpointStore : ICheckpointStore {
 
     static SqlCommand GetCheckpointCommand(SqlConnection connection, string sql, string checkpointId)
         => connection.GetTextCommand(sql).Add("checkpointId", SqlDbType.NVarChar, checkpointId);
+}
+
+/// <summary>
+/// SQL Server checkpoint store options.
+/// </summary>
+[PublicAPI]
+public record SqlServerCheckpointStoreOptions {
+    /// <summary>
+    /// Name of schema to use
+    /// </summary>
+    public string? Schema { get; init; }
 }

--- a/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerStreamSubscription.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerStreamSubscription.cs
@@ -71,5 +71,3 @@ public class SqlServerStreamSubscription : SqlServerSubscriptionBase<SqlServerSt
     protected override EventPosition GetPositionFromContext(IMessageConsumeContext context)
         => EventPosition.FromContext(context);
 }
-
-public record SqlServerStreamSubscriptionOptions(StreamName Stream) : SqlServerSubscriptionBaseOptions;

--- a/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerStreamSubscriptionOptions.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerStreamSubscriptionOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (C) Ubiquitous AS.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+namespace Eventuous.SqlServer.Subscriptions;
+
+public record SqlServerStreamSubscriptionOptions : SqlServerSubscriptionBaseOptions {
+    /// <summary>
+    /// Stream name to subscribe for
+    /// </summary>
+    public StreamName Stream { get; set; }
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Fixtures/SubscriptionFixture.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Fixtures/SubscriptionFixture.cs
@@ -54,7 +54,8 @@ public abstract class SubscriptionFixture<T> : IAsyncLifetime
             !subscribeToAll
                 ? new SqlServerStreamSubscription(
                     Instance.GetConnection,
-                    new SqlServerStreamSubscriptionOptions(Stream) {
+                    new SqlServerStreamSubscriptionOptions {
+                        Stream = Stream,
                         SubscriptionId = SubscriptionId,
                         Schema         = SchemaName
                     },

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Fixtures/SubscriptionFixture.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Fixtures/SubscriptionFixture.cs
@@ -17,6 +17,7 @@ public abstract class SubscriptionFixture<T> : IAsyncLifetime
     protected StreamName              Stream          { get; }
     protected T                       Handler         { get; }
     protected ILogger                 Log             { get; }
+    protected SqlServerCheckpointStoreOptions CheckpointStoreOptions { get; }
     protected SqlServerCheckpointStore CheckpointStore { get; }
     IMessageSubscription              Subscription    { get; }
     protected string                  SchemaName      { get; }
@@ -39,9 +40,10 @@ public abstract class SubscriptionFixture<T> : IAsyncLifetime
         var loggerFactory = TestHelpers.Logging.GetLoggerFactory(outputHelper, logLevel);
         SubscriptionId = $"test-{Guid.NewGuid():N}";
 
-        Handler         = handler;
-        Log             = loggerFactory.CreateLogger(GetType());
-        CheckpointStore = new SqlServerCheckpointStore(Instance.GetConnection, SchemaName);
+        Handler                = handler;
+        Log                    = loggerFactory.CreateLogger(GetType());
+        CheckpointStoreOptions = new SqlServerCheckpointStoreOptions { Schema = SchemaName };
+        CheckpointStore        = new SqlServerCheckpointStore(Instance.GetConnection, CheckpointStoreOptions);
 
         _listener = new LoggingEventListener(loggerFactory);
         var pipe = new ConsumePipe();


### PR DESCRIPTION
Creating `SqlServerCheckpointStoreOptions` to use with `SqlServerCheckpointStore` so that we're not passing primative types into a constructor. Also allowing `SqlServerStreamSubscriptionOptions` to have mutable `StreamName`