### PR TITLE
Use the actual event number instead of the OriginalEventNumber

### DIFF
--- a/src/EventStore/src/Eventuous.EventStore/EsdbEventStore.cs
+++ b/src/EventStore/src/Eventuous.EventStore/EsdbEventStore.cs
@@ -255,7 +255,7 @@ public class EsdbEventStore : IEventStore {
                 payload,
                 DeserializeMetadata() ?? new Metadata(),
                 resolvedEvent.Event.ContentType,
-                resolvedEvent.OriginalEventNumber.ToInt64()
+                resolvedEvent.Event.EventNumber.ToInt64()
             );
     }
 

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/AllStreamSubscription.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/AllStreamSubscription.cs
@@ -112,13 +112,13 @@ public class AllStreamSubscription
             re.Event.EventId.ToString(),
             re.Event.EventType,
             re.Event.ContentType,
-            re.OriginalStreamId,
+            re.Event.EventStreamId,
             re.Event.EventNumber,
             re.Event.Position.CommitPosition,
             _sequence++,
             re.Event.Created,
             evt,
-            Options.MetadataSerializer.DeserializeMeta(Options, re.Event.Metadata, re.OriginalStreamId),
+            Options.MetadataSerializer.DeserializeMeta(Options, re.Event.Metadata, re.Event.EventStreamId),
             SubscriptionId,
             cancellationToken
         );

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/PersistentSubscriptionBase.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/PersistentSubscriptionBase.cs
@@ -181,7 +181,7 @@ public abstract class PersistentSubscriptionBase<T> : EventSubscription<T> where
             re.Event.ContentType,
             re.Event.EventType,
             re.Event.Data,
-            re.OriginalStreamId,
+            re.Event.EventStreamId,
             re.Event.Position.CommitPosition
         );
 
@@ -189,13 +189,13 @@ public abstract class PersistentSubscriptionBase<T> : EventSubscription<T> where
             re.Event.EventId.ToString(),
             re.Event.EventType,
             re.Event.ContentType,
-            re.OriginalStreamId,
+            re.Event.EventStreamId,
             GetContextStreamPosition(re),
             re.Event.Position.CommitPosition,
             re.OriginalEventNumber,
             re.Event.Created,
             evt,
-            Options.MetadataSerializer.DeserializeMeta(Options, re.Event.Metadata, re.OriginalStreamId, re.Event.EventNumber),
+            Options.MetadataSerializer.DeserializeMeta(Options, re.Event.Metadata, re.Event.EventStreamId, re.Event.EventNumber),
             SubscriptionId,
             cancellationToken
         );

--- a/src/EventStore/src/Eventuous.EventStore/Subscriptions/StreamSubscription.cs
+++ b/src/EventStore/src/Eventuous.EventStore/Subscriptions/StreamSubscription.cs
@@ -128,7 +128,7 @@ public class StreamSubscription : EventStoreCatchUpSubscriptionBase<StreamSubscr
             re.Event.EventType,
             re.Event.ContentType,
             re.Event.EventStreamId,
-            re.OriginalEventNumber,
+            re.Event.EventNumber,
             re.Event.Position.CommitPosition,
             _sequence++,
             re.Event.Created,
@@ -136,7 +136,7 @@ public class StreamSubscription : EventStoreCatchUpSubscriptionBase<StreamSubscr
             Options.MetadataSerializer.DeserializeMeta(
                 Options,
                 re.Event.Metadata,
-                re.OriginalStreamId,
+                re.Event.EventStreamId,
                 re.Event.EventNumber
             ),
             SubscriptionId,

--- a/src/Experimental/src/Eventuous.Spyglass/InsidePeek.cs
+++ b/src/Experimental/src/Eventuous.Spyglass/InsidePeek.cs
@@ -45,15 +45,10 @@ public class InsidePeek {
 
             var methods = (type as dynamic).DeclaredMethods as MethodInfo[];
 
-            AggregateInfos.Add(
-                new AggregateInfo(
-                    type,
-                    stateType,
-                    methods!,
-                    () => CreateInstance(reg, type)
-                )
-            );
+            AggregateInfos.Add(new AggregateInfo(type, stateType, methods!, () => CreateInstance(reg, type)));
         }
+
+        return;
 
         Type? GetStateType(Type type)
             => type.BaseType!.GenericTypeArguments.Length == 0
@@ -70,11 +65,9 @@ public class InsidePeek {
     }
 
     public async Task<object> Load(string streamName, int version) {
-        var typeName = streamName[..streamName.IndexOf('-')];
-        var agg      = AggregateInfos.First(x => x.AggregateType == typeName);
-
-        var events = await _eventStore.ReadStream(new StreamName(streamName), StreamReadPosition.Start, true, CancellationToken.None);
-
+        var typeName       = streamName[..streamName.IndexOf('-')];
+        var agg            = AggregateInfos.First(x => x.AggregateType == typeName);
+        var events         = await _eventStore.ReadStream(new StreamName(streamName), StreamReadPosition.Start, true, CancellationToken.None);
         var aggregate      = agg.GetAggregate();
         var selectedEvents = version == -1 ? events : events.Take(version + 1);
         aggregate.Load(selectedEvents.Select(x => x.Payload));
@@ -103,20 +96,16 @@ public class InsidePeek {
             _factory       = factory;
         }
 
-        public dynamic GetAggregate()
-            => _factory();
+        public dynamic GetAggregate() => _factory();
 
         public object GetInfo() {
-            var    instance = GetAggregate();
-            object state    = instance.State;
-            var    handlers = state.GetPrivateMember("_handlers");
-
-            var handlerType     = typeof(Func<,,>).MakeGenericType(_stateType, typeof(object), _stateType);
-            var handlersDicType = typeof(Dictionary<,>).MakeGenericType(typeof(Type), handlerType);
-
-            dynamic handlersDic = Convert.ChangeType(handlers, handlersDicType)!;
-
-            IEnumerable<Type> keys = handlersDic.Keys;
+            var               instance        = GetAggregate();
+            object            state           = instance.State;
+            var               handlers        = state.GetPrivateMember("_handlers");
+            var               handlerType     = typeof(Func<,,>).MakeGenericType(_stateType, typeof(object), _stateType);
+            var               handlersDicType = typeof(Dictionary<,>).MakeGenericType(typeof(Type), handlerType);
+            dynamic           handlersDic     = Convert.ChangeType(handlers, handlersDicType)!;
+            IEnumerable<Type> keys            = handlersDic.Keys;
 
             return new {
                 Type      = _aggregateType.Name,
@@ -126,8 +115,7 @@ public class InsidePeek {
             };
         }
 
-        public override string ToString()
-            => $"{_aggregateType.Name} ({_stateType.Name})";
+        public override string ToString() => $"{_aggregateType.Name} ({_stateType.Name})";
 
         readonly Type          _aggregateType;
         readonly Type          _stateType;

--- a/src/Experimental/src/Eventuous.Spyglass/SpyglassApi.cs
+++ b/src/Experimental/src/Eventuous.Spyglass/SpyglassApi.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -14,45 +13,50 @@ namespace Eventuous.Spyglass;
 
 public static class SpyglassApi {
     [PublicAPI]
-   public static IApplicationBuilder MapEventuousSpyglass(this IApplicationBuilder app, string? key = null) {
+    public static IApplicationBuilder MapEventuousSpyglass(this IApplicationBuilder app, string? key = null) {
         var logger = app.ApplicationServices.GetRequiredService<ILogger<IApplicationBuilder>>();
+
         if (!app.ApplicationServices.GetRequiredService<IWebHostEnvironment>().IsDevelopment() && key == null) {
             logger.LogWarning("Insecure Spyglass API is only available in development environment");
             key = Guid.NewGuid().ToString("N");
             logger.LogInformation("Using generated key: {Key}", key);
         }
+
         if (key == null) {
             logger.LogWarning("Spyglass API is not secured, ensure that it's not exposed to the Internet");
         }
 
         app.UseRouting();
-        app.UseEndpoints(builder =>
-        {
-            builder.MapGet("/spyglass/ping", (HttpRequest request) => CheckAndReturn(request, () => "Okay"))
-                .ExcludeFromDescription();
 
-            builder.MapGet(
-                    "/spyglass/aggregates",
-                    (HttpRequest request, [FromServices] InsidePeek peek) => CheckAndReturn(request, () => peek.Aggregates)
-                )
-                .ExcludeFromDescription();
+        app.UseEndpoints(
+            builder => {
+                builder.MapGet("/spyglass/ping", (HttpRequest request) => CheckAndReturn(request, () => "Okay"))
+                    .ExcludeFromDescription();
 
-            builder.MapGet(
-                    "/spyglass/events",
-                    (HttpRequest request, [FromServices] TypeMapper? typeMapper) => {
-                        var typeMap = typeMapper ?? TypeMap.Instance;
-                        return CheckAndReturn(request, () => typeMap.ReverseMap.Select(x => x.Key));
-                    }
-                )
-                .ExcludeFromDescription();
+                builder.MapGet(
+                        "/spyglass/aggregates",
+                        (HttpRequest request, [FromServices] InsidePeek peek) => CheckAndReturn(request, () => peek.Aggregates)
+                    )
+                    .ExcludeFromDescription();
 
-            builder.MapGet(
-                    "/spyglass/load/{streamName}",
-                    (HttpRequest request, [FromServices] InsidePeek peek, string streamName, [FromQuery] int version)
-                        => CheckAndReturnAsync(request, () => peek.Load(streamName, version))
-                )
-                .ExcludeFromDescription();
-        });
+                builder.MapGet(
+                        "/spyglass/events",
+                        (HttpRequest request, [FromServices] TypeMapper? typeMapper) => {
+                            var typeMap = typeMapper ?? TypeMap.Instance;
+
+                            return CheckAndReturn(request, () => typeMap.ReverseMap.Select(x => x.Key));
+                        }
+                    )
+                    .ExcludeFromDescription();
+
+                builder.MapGet(
+                        "/spyglass/load/{streamName}",
+                        (HttpRequest request, [FromServices] InsidePeek peek, string streamName, [FromQuery] int version)
+                            => CheckAndReturnAsync(request, () => peek.Load(streamName, version))
+                    )
+                    .ExcludeFromDescription();
+            }
+        );
 
         return app;
 


### PR DESCRIPTION
Use the actual event number instead of the OriginalEventNumber, which might point to a link event position (fixes #228)