### PR TITLE
Fixed the issue with Any expected state for func services

### DIFF
--- a/src/Core/src/Eventuous.Application/AggregateService/CommandHandlerBuilder.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandHandlerBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Ubiquitous AS.All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using static Eventuous.CommandServiceDelegates;
+
 namespace Eventuous;
 
 public abstract class CommandHandlerBuilder<TAggregate, TState, TId>

--- a/src/Core/src/Eventuous.Application/AggregateService/CommandHandlersMap.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandHandlersMap.cs
@@ -2,27 +2,11 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Reflection;
+using static Eventuous.CommandServiceDelegates;
 
 namespace Eventuous;
 
 using static Diagnostics.ApplicationEventSource;
-
-public delegate Task ActOnAggregateAsync<in TAggregate, in TCommand>(TAggregate aggregate, TCommand command, CancellationToken cancellationToken)
-    where TAggregate : Aggregate;
-
-public delegate void ActOnAggregate<in TAggregate, in TCommand>(TAggregate aggregate, TCommand command) where TAggregate : Aggregate;
-
-delegate ValueTask<T> HandleUntypedCommand<T>(T aggregate, object command, CancellationToken cancellationToken) where T : Aggregate;
-
-public delegate Task<TId> GetIdFromCommandAsync<TId, in TCommand>(TCommand command, CancellationToken cancellationToken) where TId : Id where TCommand : class;
-
-public delegate TId GetIdFromCommand<out TId, in TCommand>(TCommand command) where TId : Id where TCommand : class;
-
-delegate ValueTask<TId> GetIdFromUntypedCommand<TId>(object command, CancellationToken cancellationToken) where TId : Id;
-
-public delegate IAggregateStore ResolveStore<in TCommand>(TCommand command) where TCommand : class;
-
-delegate IAggregateStore ResolveStoreFromCommand(object command);
 
 record RegisteredHandler<T, TId>(
         ExpectedState                ExpectedState,

--- a/src/Core/src/Eventuous.Application/AggregateService/CommandHandlingDelegateExtensions.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandHandlingDelegateExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Ubiquitous AS.All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using static Eventuous.CommandServiceDelegates;
+
 namespace Eventuous;
 
 static class CommandHandlingDelegateExtensions {

--- a/src/Core/src/Eventuous.Application/AggregateService/CommandService.Async.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandService.Async.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Ubiquitous AS. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using static Eventuous.CommandServiceDelegates;
+
 namespace Eventuous;
 
 public abstract partial class CommandService<TAggregate, TState, TId> {

--- a/src/Core/src/Eventuous.Application/AggregateService/CommandService.Sync.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandService.Sync.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Ubiquitous AS. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using static Eventuous.CommandServiceDelegates;
+
 namespace Eventuous;
 
 public abstract partial class CommandService<TAggregate, TState, TId> {

--- a/src/Core/src/Eventuous.Application/AggregateService/CommandServiceDelegates.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandServiceDelegates.cs
@@ -1,0 +1,24 @@
+// Copyright (C) Ubiquitous AS.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+namespace Eventuous;
+
+public static class CommandServiceDelegates {
+    public delegate Task ActOnAggregateAsync<in TAggregate, in TCommand>(TAggregate aggregate, TCommand command, CancellationToken cancellationToken)
+        where TAggregate : Aggregate;
+
+    public delegate void ActOnAggregate<in TAggregate, in TCommand>(TAggregate aggregate, TCommand command) where TAggregate : Aggregate;
+
+    internal delegate ValueTask<T> HandleUntypedCommand<T>(T aggregate, object command, CancellationToken cancellationToken) where T : Aggregate;
+
+    public delegate Task<TId> GetIdFromCommandAsync<TId, in TCommand>(TCommand command, CancellationToken cancellationToken)
+        where TId : Id where TCommand : class;
+
+    public delegate TId GetIdFromCommand<out TId, in TCommand>(TCommand command) where TId : Id where TCommand : class;
+
+    internal delegate ValueTask<TId> GetIdFromUntypedCommand<TId>(object command, CancellationToken cancellationToken) where TId : Id;
+
+    public delegate IAggregateStore ResolveStore<in TCommand>(TCommand command) where TCommand : class;
+
+    internal delegate IAggregateStore ResolveStoreFromCommand(object command);
+}

--- a/src/Core/src/Eventuous.Application/FunctionalService/FuncHandlersMap.cs
+++ b/src/Core/src/Eventuous.Application/FunctionalService/FuncHandlersMap.cs
@@ -35,23 +35,5 @@ class FuncHandlersMap<TState> where TState : State<TState> {
         }
     }
 
-    public void AddHandler<TCommand>(
-            ExpectedState                      expectedState,
-            GetStreamNameFromCommand<TCommand> getStreamName,
-            ExecuteCommand<TState, TCommand>   action,
-            ResolveReaderFromCommand<TCommand> resolveReaderFromCommand,
-            ResolveWriterFromCommand<TCommand> resolveWriterFromCommand
-        )
-        where TCommand : class
-        => AddHandlerInternal<TCommand>(
-            new RegisteredFuncHandler<TState>(
-                expectedState,
-                getStreamName.AsGetStream(),
-                action.AsExecute(),
-                resolveReaderFromCommand.AsResolveReader(),
-                resolveWriterFromCommand.AsResolveWriter()
-            )
-        );
-
     public bool TryGet<TCommand>([NotNullWhen(true)] out RegisteredFuncHandler<TState>? handler) => _typeMap.TryGetValue<TCommand>(out handler);
 }

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -7,13 +7,13 @@ using static Diagnostics.PersistenceEventSource;
 
 public static class StoreFunctions {
     public static async Task<AppendEventsResult> Store(
-        this IEventWriter              eventWriter,
-        StreamName                     streamName,
-        int                            originalVersion,
-        IReadOnlyCollection<object>    changes,
-        Func<StreamEvent, StreamEvent> amendEvent,
-        CancellationToken              cancellationToken
-    ) {
+            this IEventWriter              eventWriter,
+            StreamName                     streamName,
+            int                            originalVersion,
+            IReadOnlyCollection<object>    changes,
+            Func<StreamEvent, StreamEvent> amendEvent,
+            CancellationToken              cancellationToken
+        ) {
         Ensure.NotNull(changes);
 
         if (changes.Count == 0) return AppendEventsResult.NoOp;
@@ -30,8 +30,7 @@ public static class StoreFunctions {
                 .NoContext();
 
             return result;
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
                 ? new OptimisticConcurrencyException(streamName, e)
                 : e;
@@ -39,35 +38,36 @@ public static class StoreFunctions {
 
         StreamEvent ToStreamEvent(object evt, int position) {
             var streamEvent = new StreamEvent(Guid.NewGuid(), evt, new Metadata(), "", position);
+
             return amendEvent(streamEvent);
         }
     }
 
     public static async Task<AppendEventsResult> Store<T>(
-        this IEventWriter              eventWriter,
-        StreamName                     streamName,
-        T                              aggregate,
-        Func<StreamEvent, StreamEvent> amendEvent,
-        CancellationToken              cancellationToken
-    ) where T : Aggregate {
+            this IEventWriter              eventWriter,
+            StreamName                     streamName,
+            T                              aggregate,
+            Func<StreamEvent, StreamEvent> amendEvent,
+            CancellationToken              cancellationToken
+        ) where T : Aggregate {
         Ensure.NotNull(aggregate);
 
         try {
             return await eventWriter.Store(streamName, aggregate.OriginalVersion, aggregate.Changes, amendEvent, cancellationToken).NoContext();
-        }
-        catch (OptimisticConcurrencyException e) {
+        } catch (OptimisticConcurrencyException e) {
             Log.UnableToStoreAggregate<T>(streamName, e);
+
             throw new OptimisticConcurrencyException<T>(streamName, e.InnerException!);
         }
     }
 
     public static async Task<StreamEvent[]> ReadStream(
-        this IEventReader  eventReader,
-        StreamName         streamName,
-        StreamReadPosition start,
-        bool               failIfNotFound,
-        CancellationToken  cancellationToken
-    ) {
+            this IEventReader  eventReader,
+            StreamName         streamName,
+            StreamReadPosition start,
+            bool               failIfNotFound,
+            CancellationToken  cancellationToken
+        ) {
         const int pageSize = 500;
 
         var streamEvents = new List<StreamEvent>();
@@ -83,8 +83,7 @@ public static class StoreFunctions {
 
                 position = new StreamReadPosition(position.Value + events.Length);
             }
-        }
-        catch (StreamNotFound) when (!failIfNotFound) {
+        } catch (StreamNotFound) when (!failIfNotFound) {
             return Array.Empty<StreamEvent>();
         }
 

--- a/src/Core/src/Eventuous.Persistence/StateStore/StateStoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/StateStore/StateStoreFunctions.cs
@@ -36,7 +36,10 @@ public static class StateStoreFunctions {
         try {
             var streamEvents = await reader.ReadStream(streamName, StreamReadPosition.Start, failIfNotFound, cancellationToken).NoContext();
             var events       = streamEvents.Select(x => x.Payload!).ToArray();
-            return (new FoldedEventStream<T>(streamName, new ExpectedStreamVersion(streamEvents.Last().Position), events));
+            var expectedVersion = events.Length == 0
+                ? ExpectedStreamVersion.NoStream
+                : new ExpectedStreamVersion(streamEvents.Last().Position);
+            return (new FoldedEventStream<T>(streamName, expectedVersion, events));
         }
         catch (StreamNotFound) when (!failIfNotFound) {
             return new FoldedEventStream<T>(streamName, ExpectedStreamVersion.NoStream, Array.Empty<object>());

--- a/src/Core/test/Eventuous.Tests.Application/BookingFuncService.cs
+++ b/src/Core/test/Eventuous.Tests.Application/BookingFuncService.cs
@@ -14,6 +14,7 @@ public class BookingFuncService : FunctionalCommandService<BookingState> {
         OnNew<BookRoom>(cmd => GetStream(cmd.BookingId), BookRoom);
 #pragma warning restore CS0618 // Type or member is obsolete
         On<RecordPayment>().InState(ExpectedState.Existing).GetStream(cmd => GetStream(cmd.BookingId)).Act(RecordPayment);
+        On<ImportBooking>().InState(ExpectedState.Any).GetStream(cmd => GetStream(cmd.BookingId)).Act(ImportBooking);
 
         return;
 
@@ -22,6 +23,10 @@ public class BookingFuncService : FunctionalCommandService<BookingState> {
 
         static IEnumerable<object> BookRoom(BookRoom cmd) {
             yield return new RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price);
+        }
+
+        static IEnumerable<object> ImportBooking(BookingState state, object[] events, ImportBooking cmd) {
+            yield return new BookingImported(cmd.RoomId, cmd.Price, cmd.CheckIn, cmd.CheckOut);
         }
 
         static IEnumerable<object> RecordPayment(BookingState state, object[] originalEvents, RecordPayment cmd) {

--- a/test/Eventuous.TestHelpers/Fakes/InMemoryEventStore.cs
+++ b/test/Eventuous.TestHelpers/Fakes/InMemoryEventStore.cs
@@ -82,12 +82,10 @@ public class InMemoryEventStore : IEventStore {
 
     // ReSharper disable once ReturnTypeCanBeEnumerable.Local
     InMemoryStream FindStream(StreamName stream) {
-        if (!_storage.TryGetValue(stream, out var existing)) throw new NotFound(stream);
+        if (!_storage.TryGetValue(stream, out var existing)) throw new StreamNotFound(stream);
 
         return existing;
     }
-
-    class NotFound(StreamName stream) : Exception($"Stream not found: {stream}");
 }
 
 record StoredEvent(StreamEvent Event, int Position);


### PR DESCRIPTION
When using `ExpectedState.Any` in a func service, it crashes with an exception if the stream didn't exist. 

It was caused by the code that tried to extract the new expected version from the stream, when the stream has no events, so calling `Last` on the sequence caused an exception,