### PR TITLE
Update _Schema.sql: fix typo in StreamMessage type name

### DIFF
--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/_Schema.sql
@@ -47,7 +47,7 @@ IF OBJECT_ID('__schema__.Checkpoints', 'U') IS NULL
         );
     END
 
-IF TYPE_ID('__schema__.stream_message') IS NULL
+IF TYPE_ID('__schema__.StreamMessage') IS NULL
     BEGIN
         CREATE type __schema__.StreamMessage AS TABLE
         (


### PR DESCRIPTION
The check to see if the `__schema__.StreamMessage` type already exists is using the wrong name (`__schema__.stream_message`) in the check, so multiple invocations of the script will raise an error, when the attempt is made to create the already existing type.