### PR TITLE
Fixed bug in CommandService of wrong exception message

### DIFF
--- a/src/Core/src/Eventuous.Application/AggregateService/CommandService.cs
+++ b/src/Core/src/Eventuous.Application/AggregateService/CommandService.cs
@@ -56,7 +56,7 @@ public abstract partial class CommandService<TAggregate, TState, TId>(
 
         if (!_handlers.TryGet<TCommand>(out var registeredHandler)) {
             Log.CommandHandlerNotFound<TCommand>();
-            var exception = new Exceptions.CommandHandlerNotFound<TCommand>();
+            var exception = new Exceptions.CommandHandlerNotFound(command.GetType());
 
             return new ErrorResult<TState>(exception);
         }


### PR DESCRIPTION
Regarding #264
When a command handler is not registered, the exception message contains now the correct type. So instead of 'No handler found for command Object' it is now "No handler found for command StartEngine".