### PR TITLE
Checkpointing crash fix

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
         dotnet: [ 'net6.0', 'net7.0' ]
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-#      TC_CLOUD_TOKEN: ${{ secrets.TC_TOKEN }}
+      TC_CLOUD_TOKEN: ${{ secrets.TC_TOKEN }}
     steps:
       -  
         name: Checkout

--- a/src/Core/src/Eventuous.Subscriptions/EventSubscriptionWithCheckpoint.cs
+++ b/src/Core/src/Eventuous.Subscriptions/EventSubscriptionWithCheckpoint.cs
@@ -30,8 +30,8 @@ public abstract class EventSubscriptionWithCheckpoint<T>(
     CheckpointCommitHandler CheckpointCommitHandler { get; } = new(
         options.SubscriptionId,
         checkpointStore,
-        TimeSpan.FromMilliseconds(options.CommitDelayMs),
-        options.BatchSize,
+        TimeSpan.FromMilliseconds(options.CheckpointCommitDelayMs),
+        options.CheckpointCommitBatchSize,
         loggerFactory
     );
     ICheckpointStore CheckpointStore { get; } = Ensure.NotNull(checkpointStore);

--- a/src/Core/src/Eventuous.Subscriptions/Logging/SubscriptionLogging.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Logging/SubscriptionLogging.cs
@@ -18,7 +18,7 @@ public static class LoggingExtensions {
         );
 
     public static void MessageHandled(this LogContext log, string handlerType, IBaseConsumeContext context)
-        => log.DebugLog?.Log(
+        => log.TraceLog?.Log(
             "{Handler} handled {MessageType} {Stream}:{Position} seq {Sequence}",
             handlerType,
             context.MessageType,
@@ -28,7 +28,7 @@ public static class LoggingExtensions {
         );
 
     public static void MessageIgnored(this LogContext log, string handlerType, IBaseConsumeContext context)
-        => log.DebugLog?.Log(
+        => log.TraceLog?.Log(
             "{Handler} ignored {MessageType} {Stream}:{Position} seq {Sequence}",
             handlerType,
             context.MessageType,

--- a/src/Core/src/Eventuous.Subscriptions/SubscriptionOptions.cs
+++ b/src/Core/src/Eventuous.Subscriptions/SubscriptionOptions.cs
@@ -22,6 +22,6 @@ public abstract record SubscriptionOptions {
 }
 
 public abstract record SubscriptionWithCheckpointOptions : SubscriptionOptions {
-    public int BatchSize     { get; set; } = 100;
-    public int CommitDelayMs { get; set; } = 5000;
+    public int CheckpointCommitBatchSize { get; set; } = 100;
+    public int CheckpointCommitDelayMs   { get; set; } = 5000;
 }

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapAggregateContractToCommandExplicitly.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapAggregateContractToCommandExplicitly.verified.txt
@@ -18,8 +18,8 @@
       event: {
         roomId: Guid_2,
         price: 100,
-        checkIn: 2023-10-02,
-        checkOut: 2023-10-03
+        checkIn: 2023-10-01,
+        checkOut: 2023-10-02
       },
       eventType: V1.BookingImported
     }

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapAggregateContractToCommandExplicitlyWithoutRoute.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapAggregateContractToCommandExplicitlyWithoutRoute.verified.txt
@@ -18,8 +18,8 @@
       event: {
         roomId: Guid_2,
         price: 100,
-        checkIn: 2023-10-02,
-        checkOut: 2023-10-03
+        checkIn: 2023-10-01,
+        checkOut: 2023-10-02
       },
       eventType: V1.BookingImported
     }

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapAggregateContractToCommandExplicitlyWithoutRouteWithGenericAttr.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapAggregateContractToCommandExplicitlyWithoutRouteWithGenericAttr.verified.txt
@@ -18,8 +18,8 @@
       event: {
         roomId: Guid_2,
         price: 100,
-        checkIn: 2023-10-02,
-        checkOut: 2023-10-03
+        checkIn: 2023-10-01,
+        checkOut: 2023-10-02
       },
       eventType: V1.BookingImported
     }

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapContractToCommandExplicitly.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapContractToCommandExplicitly.verified.txt
@@ -18,8 +18,8 @@
       event: {
         roomId: Guid_2,
         price: 100,
-        checkIn: 2023-10-02,
-        checkOut: 2023-10-03
+        checkIn: 2023-10-01,
+        checkOut: 2023-10-02
       },
       eventType: V1.BookingImported
     }

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapEnrichedCommand.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/AggregateCommandsTests.MapEnrichedCommand.verified.txt
@@ -17,8 +17,8 @@
     {
       event: {
         roomId: Guid_2,
-        checkIn: 2023-10-02,
-        checkOut: 2023-10-03,
+        checkIn: 2023-10-01,
+        checkOut: 2023-10-02,
         price: 100,
         guestId: test guest
       },

--- a/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/Fixture/ServerFixture.cs
+++ b/src/Extensions/test/Eventuous.Tests.AspNetCore.Web/Fixture/ServerFixture.cs
@@ -59,7 +59,8 @@ public class ServerFixture {
         => Resolve<IEventStore>().ReadEvents(StreamName.For<T>(id), StreamReadPosition.Start, 100, default);
 
     internal BookRoom GetBookRoom() {
-        var date = LocalDate.FromDateTime(DateTime.Now);
+        var now  = new DateTime(2023, 10, 1);
+        var date = LocalDate.FromDateTime(now);
 
         return new(_fixture.Create<string>(), _fixture.Create<string>(), date, date.PlusDays(1), 100, "guest");
     }

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/CheckpointTest.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/CheckpointTest.cs
@@ -1,3 +1,4 @@
+using Eventuous.Diagnostics.Logging;
 using Eventuous.SqlServer.Subscriptions;
 using Eventuous.Subscriptions.Filters;
 using Eventuous.Sut.Subs;
@@ -5,17 +6,27 @@ using Eventuous.Tests.SqlServer.Fixtures;
 
 namespace Eventuous.Tests.SqlServer.Checkpointing;
 
-public class CheckpointTest(IntegrationFixture fixture, ITestOutputHelper output) : IClassFixture<IntegrationFixture> {
+public class CheckpointTest : IClassFixture<IntegrationFixture>, IDisposable {
+    readonly IDisposable        _listener;
+    readonly IntegrationFixture _fixture;
+    readonly ILoggerFactory     _loggerFactory;
+
+    public CheckpointTest(IntegrationFixture fixture, ITestOutputHelper output) {
+        _fixture       = fixture;
+        _loggerFactory = new LoggerFactory().AddXunit(output, LogLevel.Debug);
+        _listener      = new LoggingEventListener(_loggerFactory);
+    }
+
     [Fact]
-    public async Task Execute() {
+    public async Task EmitMassiveNumberOfEventsAndEnsureCheckpointingWorks() {
         TypeMap.RegisterKnownEventTypes();
 
-        var aggregateStore = new AggregateStore(fixture.EventStore);
+        var aggregateStore = new AggregateStore(_fixture.EventStore);
 
         var checkpointStore = new SqlServerCheckpointStore(
-            fixture.GetConnection,
+            _fixture.GetConnection,
             new SqlServerCheckpointStoreOptions {
-                Schema = fixture.SchemaName
+                Schema = _fixture.SchemaName
             }
         );
         var service = new TestCommandService(aggregateStore);
@@ -24,24 +35,29 @@ public class CheckpointTest(IntegrationFixture fixture, ITestOutputHelper output
         pipe.AddDefaultConsumer(handler);
 
         var sub = new SqlServerAllStreamSubscription(
-            fixture.GetConnection,
+            _fixture.GetConnection,
             new SqlServerAllStreamSubscriptionOptions {
-                Schema         = fixture.SchemaName,
-                SubscriptionId = "TestSubscription"
+                Schema                    = _fixture.SchemaName,
+                SubscriptionId            = "TestSubscription",
+                CheckpointCommitBatchSize = 1000,
             },
             checkpointStore,
-            pipe
+            pipe,
+            _loggerFactory
         );
-        var loggerFactory = new LoggerFactory().AddXunit(output, LogLevel.Debug);
-
-        await sub.SubscribeWithLog(loggerFactory.CreateLogger(sub.SubscriptionId));
+        await sub.SubscribeWithLog(_loggerFactory.CreateLogger(sub.SubscriptionId));
         var accounts = Enumerable.Range(0, 100000).Select(n => new TestAccount($"user{n:D4}")).ToList();
         await service.Handle(new InjectTestAccounts(accounts), default);
-        
+
         while (handler.HandledCount < 100000) {
             await Task.Delay(100);
         }
 
         await sub.Unsubscribe(id => { }, default);
+
+        var checkpoint = await checkpointStore.GetLastCheckpoint(sub.SubscriptionId, default);
+        checkpoint.Position.Should().Be(99999);
     }
+
+    public void Dispose() => _listener.Dispose();
 }

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/CheckpointTest.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/CheckpointTest.cs
@@ -1,0 +1,47 @@
+using Eventuous.SqlServer.Subscriptions;
+using Eventuous.Subscriptions.Filters;
+using Eventuous.Sut.Subs;
+using Eventuous.Tests.SqlServer.Fixtures;
+
+namespace Eventuous.Tests.SqlServer.Checkpointing;
+
+public class CheckpointTest(IntegrationFixture fixture, ITestOutputHelper output) : IClassFixture<IntegrationFixture> {
+    [Fact]
+    public async Task Execute() {
+        TypeMap.RegisterKnownEventTypes();
+
+        var aggregateStore = new AggregateStore(fixture.EventStore);
+
+        var checkpointStore = new SqlServerCheckpointStore(
+            fixture.GetConnection,
+            new SqlServerCheckpointStoreOptions {
+                Schema = fixture.SchemaName
+            }
+        );
+        var service = new TestCommandService(aggregateStore);
+        var pipe    = new ConsumePipe();
+        var handler = new TestHandler();
+        pipe.AddDefaultConsumer(handler);
+
+        var sub = new SqlServerAllStreamSubscription(
+            fixture.GetConnection,
+            new SqlServerAllStreamSubscriptionOptions {
+                Schema         = fixture.SchemaName,
+                SubscriptionId = "TestSubscription"
+            },
+            checkpointStore,
+            pipe
+        );
+        var loggerFactory = new LoggerFactory().AddXunit(output, LogLevel.Debug);
+
+        await sub.SubscribeWithLog(loggerFactory.CreateLogger(sub.SubscriptionId));
+        var accounts = Enumerable.Range(0, 100000).Select(n => new TestAccount($"user{n:D4}")).ToList();
+        await service.Handle(new InjectTestAccounts(accounts), default);
+        
+        while (handler.HandledCount < 100000) {
+            await Task.Delay(100);
+        }
+
+        await sub.Unsubscribe(id => { }, default);
+    }
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/SutElements.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/SutElements.cs
@@ -1,0 +1,22 @@
+namespace Eventuous.Tests.SqlServer.Checkpointing;
+
+public record TestAccount(string UserName);
+
+public record InjectTestAccounts(IList<TestAccount> Accounts);
+
+[EventType("V1.TestAccountInserted")]
+public record TestAccountInserted(TestAccount Account);
+
+public class TestAccounts : Aggregate<TestAccountsState> {
+    public void InjectAccounts(IList<TestAccount> accounts) {
+        foreach (var insertion in accounts) {
+            Apply(new TestAccountInserted(insertion));
+        }
+    }
+}
+
+public record TestAccountsState : State<TestAccountsState>;
+
+public record TestAccountsId() : Id("$$Singleton$$") {
+    public static readonly TestAccountsId Instance = new();
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/TestCommandService.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/TestCommandService.cs
@@ -1,0 +1,11 @@
+namespace Eventuous.Tests.SqlServer.Checkpointing;
+
+class TestCommandService : CommandService<TestAccounts, TestAccountsState, TestAccountsId> {
+    public TestCommandService(IAggregateStore store)
+        : base(store) {
+        On<InjectTestAccounts>()
+            .InState(ExpectedState.Any)
+            .GetId(_ => TestAccountsId.Instance)
+            .Act((accounts, cmd) => accounts.InjectAccounts(cmd.Accounts));
+    }
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/TestHandler.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Checkpointing/TestHandler.cs
@@ -1,0 +1,22 @@
+using Eventuous.Subscriptions;
+using Eventuous.Subscriptions.Context;
+
+namespace Eventuous.Tests.SqlServer.Checkpointing;
+
+public class TestHandler : IEventHandler {
+    public string DiagnosticName => nameof(TestHandler);
+
+    public ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) {
+        _count++;
+
+        if (_count % 1000 == 0) {
+            context.LogContext.DebugLog?.Log("Handled {Count} events", _count);
+        }
+
+        return ValueTask.FromResult(EventHandlingStatus.Success);
+    }
+
+    int _count;
+    
+    public int HandledCount => _count;
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Fixtures/IntegrationFixture.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Fixtures/IntegrationFixture.cs
@@ -44,7 +44,6 @@ public sealed class IntegrationFixture : IAsyncLifetime {
         await schema.CreateSchema(GetConnection);
         DefaultEventSerializer.SetDefaultSerializer(Serializer);
         EventStore     = new SqlServerStore(GetConnection, new SqlServerStoreOptions(SchemaName), Serializer);
-        new AggregateStore(EventStore);
         ActivitySource.AddActivityListener(_listener);
 
         return;

--- a/test/Eventuous.TestHelpers/EventStoreDbContainerBuilder.cs
+++ b/test/Eventuous.TestHelpers/EventStoreDbContainerBuilder.cs
@@ -1,6 +1,3 @@
-// Copyright (C) Ubiquitous AS.All rights reserved
-// Licensed under the Apache License, Version 2.0.
-
 using System.Runtime.InteropServices;
 using Docker.DotNet.Models;
 using DotNet.Testcontainers.Builders;
@@ -11,7 +8,7 @@ namespace Eventuous.TestHelpers;
 
 public sealed class EventStoreDbContainerBuilder : ContainerBuilder<EventStoreDbContainerBuilder, EventStoreDbContainer, EventStoreDbConfiguration> {
     public static readonly string ContainerTag = RuntimeInformation.ProcessArchitecture switch {
-        Architecture.Arm64 => "22.10.2-alpha-arm64v8",
+        // Architecture.Arm64 => "22.10.2-alpha-arm64v8",
         _                  => "22.10.2-buster-slim"
     };
 


### PR DESCRIPTION
The PR adds a test from #165 repro into SQL Server test suite. It, indeed, crashed when checkpointing from time to time as the observable produced an error. A different question would be if something should happen with the subscription if the observable crashes for any reason, but it's out of scope.

So, what I found out is that pushing checkpoint batches through the observable caused the sequence to be updated in parallel with adding new stuff to it, as well as collection manipulation wasn't exactly sequential.

To fix the issue, I added a semaphore to control access to the sequence. It solved the issue, and it doesn't have much performance hit as the operation is done per checkpoint batch. One thing that helps in such a scenario is to increase the commit batch size so it doesn't try to checkpoint very often. The test has 1000 as the batch size.

So, basically, it works now :)