### PR TITLE
Return bad request as ValidationProblemDetails

### DIFF
--- a/src/Extensions/src/Eventuous.AspNetCore.Web/Http/CommandHttpApiBase'TResult.cs
+++ b/src/Extensions/src/Eventuous.AspNetCore.Web/Http/CommandHttpApiBase'TResult.cs
@@ -1,6 +1,9 @@
 // Copyright (C) Ubiquitous AS.All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Http;
+
 namespace Eventuous.AspNetCore.Web; 
 
 /// <summary>
@@ -46,12 +49,40 @@ public abstract class CommandHttpApiBase<TAggregate, TResult>(ICommandService<TA
         return AsActionResult<TAggregate>(result);
     }
 
-    static ActionResult<TResult> AsActionResult<T>(Result result) where T : Aggregate
-        => result is ErrorResult error
+    protected virtual ActionResult<TResult> AsActionResult<T>(Result result) where T : Aggregate {
+        return result is ErrorResult error
             ? error.Exception switch {
-                OptimisticConcurrencyException<T> => new ConflictObjectResult(error),
-                AggregateNotFoundException<T>     => new NotFoundObjectResult(error),
-                _                                 => new BadRequestObjectResult(error)
+                OptimisticConcurrencyException<T> => AsProblemResult(StatusCodes.Status409Conflict),
+                AggregateNotFoundException<T>     => AsProblemResult(StatusCodes.Status404NotFound),
+                DomainException                   => AsValidationProblemResult(StatusCodes.Status400BadRequest),
+                _                                 => AsProblemResult(StatusCodes.Status500InternalServerError)
             }
             : new OkObjectResult(result);
+
+        ActionResult AsProblemResult(int statusCode)
+            => new ObjectResult(
+                new ProblemDetails {
+                    Status = statusCode,
+                    Title = error.ErrorMessage,
+                    Detail = error.Exception?.ToString(),
+                    Type = error.Exception?.GetType().Name
+                }
+            ) {
+                StatusCode = StatusCodes.Status400BadRequest,
+                ContentTypes = new MediaTypeCollection { ContentTypes.ProblemDetails },
+            };
+
+        ActionResult AsValidationProblemResult(int statusCode)
+            => new ObjectResult(
+                new ValidationProblemDetails(new Dictionary<string, string[]> { ["Domain"] = [error.ErrorMessage] }) {
+                    Status = statusCode,
+                    Title = error.ErrorMessage,
+                    Detail = error.Exception?.ToString(),
+                    Type = error.Exception?.GetType().Name
+                }
+            ) {
+                StatusCode = StatusCodes.Status400BadRequest,
+                ContentTypes = new MediaTypeCollection { ContentTypes.ProblemDetails },
+            };
+    }
 }

--- a/src/Extensions/src/Eventuous.AspNetCore.Web/Http/HttpCommandMapping.cs
+++ b/src/Extensions/src/Eventuous.AspNetCore.Web/Http/HttpCommandMapping.cs
@@ -175,7 +175,7 @@ public static partial class RouteBuilderExtensions {
             .ProducesProblemDetails(Status404NotFound)
             .ProducesProblemDetails(Status409Conflict)
             .ProducesProblemDetails(Status500InternalServerError)
-            .ProducesProblemDetails(Status400BadRequest);
+            .ProducesValidationProblemDetails(Status400BadRequest);
 
         routeBuilder.AddPolicy(policyName);
         routeBuilder.AddAuthorization(typeof(TContract));
@@ -247,7 +247,7 @@ public static partial class RouteBuilderExtensions {
                 .ProducesOk(resultType)
                 .ProducesProblemDetails(Status404NotFound)
                 .ProducesProblemDetails(Status409Conflict)
-                .ProducesProblemDetails(Status400BadRequest)
+                .ProducesValidationProblemDetails(Status400BadRequest)
                 .ProducesProblemDetails(Status500InternalServerError);
 
             routeBuilder.AddPolicy(policyName);

--- a/src/Extensions/src/Eventuous.AspNetCore.Web/Http/RouteHandlerBuilderExt.cs
+++ b/src/Extensions/src/Eventuous.AspNetCore.Web/Http/RouteHandlerBuilderExt.cs
@@ -7,18 +7,21 @@ using Microsoft.AspNetCore.Http;
 namespace Eventuous.AspNetCore.Web;
 
 static class RouteHandlerBuilderExt {
+    public static RouteHandlerBuilder ProducesValidationProblemDetails(this RouteHandlerBuilder builder, int statusCode)
+        => builder.Produces<ValidationProblemDetails>(statusCode, ContentTypes.ProblemDetails);
+
     public static RouteHandlerBuilder ProducesProblemDetails(this RouteHandlerBuilder builder, int statusCode)
         => builder.Produces<ProblemDetails>(statusCode, ContentTypes.ProblemDetails);
 
     public static RouteHandlerBuilder ProducesOk(this RouteHandlerBuilder builder, Type resultType)
         => builder.Produces(StatusCodes.Status200OK, resultType, ContentTypes.Json);
-    
+
     public static RouteHandlerBuilder ProducesOk<T>(this RouteHandlerBuilder builder) where T : Result
         => builder.ProducesOk(typeof(T));
 
     public static RouteHandlerBuilder Accepts(this RouteHandlerBuilder builder, Type commandType)
         => builder.Accepts(commandType, false, ContentTypes.Json);
-    
+
     public static RouteHandlerBuilder Accepts<T>(this RouteHandlerBuilder builder)
         => builder.Accepts(typeof(T));
 }


### PR DESCRIPTION
- Return ValidationProblemDetails as result for 400 errors
- Implement AsActionResult the same way as in ResultExtensions
- Make AsActionResult protected virtual so you can override the implementation.