### PR TITLE
Fix #291 for postgres

### DIFF
--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscribeToStream.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscribeToStream.cs
@@ -38,6 +38,9 @@ public class SubscribeToStream : SubscriptionFixture<TestEventHandler> {
         await InitializeAsync();
 
         await TestConsumptionOfProducedEvents();
+        
+        var checkpoint = await CheckpointStore.GetLastCheckpoint(SubscriptionId, default);
+        checkpoint.Position.Should().Be(19);
 
         return;
 
@@ -51,9 +54,6 @@ public class SubscribeToStream : SubscriptionFixture<TestEventHandler> {
             await Handler.Validate(2.Seconds());
             await Stop();
             Handler.Count.Should().Be(10);
-
-            var checkpoint = await CheckpointStore.GetLastCheckpoint(SubscriptionId, default);
-            checkpoint.Position.Should().Be(count - 1);
         }
     }
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Subscriptions/SubscribeToAll.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Subscriptions/SubscribeToAll.cs
@@ -24,6 +24,31 @@ public class SubscribeToAll(ITestOutputHelper outputHelper) : SubscriptionFixtur
     }
 
     [Fact]
+    public async Task ShouldConsumeProducedEventsWhenRestarting() {
+        await TestConsumptionOfProducedEvents();
+
+        Handler.Reset();
+        await InitializeAsync();
+
+        await TestConsumptionOfProducedEvents();
+
+        return;
+
+        async Task TestConsumptionOfProducedEvents() {
+            const int count = 10;
+
+            var (testEvents, _) = await GenerateAndProduceEvents(count);
+            Handler.AssertThat().Exactly(count, x => testEvents.Contains(x));
+
+            await Start();
+            await Handler.Validate(2.Seconds());
+            await Stop();
+
+            Handler.Count.Should().Be(10);
+        }
+    }
+
+    [Fact]
     public async Task ShouldUseExistingCheckpoint() {
         const int count = 10;
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Subscriptions/SubscribeToStream.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Subscriptions/SubscribeToStream.cs
@@ -24,6 +24,31 @@ public class SubscribeToStream(ITestOutputHelper outputHelper) : SubscriptionFix
     }
 
     [Fact]
+    public async Task ShouldConsumeProducedEventsWhenRestarting() {
+        await TestConsumptionOfProducedEvents();
+
+        Handler.Reset();
+        await InitializeAsync();
+
+        await TestConsumptionOfProducedEvents();
+
+        return;
+
+        async Task TestConsumptionOfProducedEvents() {
+            const int count = 10;
+
+            var testEvents = await GenerateAndProduceEvents(count);
+            Handler.AssertThat().Exactly(count, x => testEvents.Contains(x));
+
+            await Start();
+            await Handler.Validate(2.Seconds());
+            await Stop();
+
+            Handler.Count.Should().Be(10);
+        }
+    }
+
+    [Fact]
     public async Task ShouldUseExistingCheckpoint() {
         const int count = 10;
 


### PR DESCRIPTION
I've added the same tests for Postgres and Redis that I did for SQL Server in #292 , I figured that might be useful. It does look like the same problem might be present for Postgres but we don't use Postgres it so I'm just adding this PR for somebody else to pick up if needed.