### PR TITLE
Consolidate SubscriptionHealthCheck DI registrations

### DIFF
--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionRegistrationExtensions.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionRegistrationExtensions.cs
@@ -25,7 +25,7 @@ public static class SubscriptionRegistrationExtensions {
         Ensure.NotNull(configureSubscription);
         var builder = new SubscriptionBuilder<T, TOptions>(Ensure.NotNull(services), Ensure.NotEmptyString(subscriptionId));
         configureSubscription(builder);
-        services.TryAddSingleton<ISubscriptionHealth, SubscriptionHealthCheck>();
+        TryAddSubscriptionHealthCheck(services);
 
         if (typeof(IMeasuredSubscription).IsAssignableFrom(typeof(T))) services.AddSingleton(GetEndOfStream);
 
@@ -64,8 +64,7 @@ public static class SubscriptionRegistrationExtensions {
             HealthStatus?             failureStatus,
             string[]                  tags
         ) {
-        builder.Services.TryAddSingleton<SubscriptionHealthCheck>();
-        builder.Services.TryAddSingleton<ISubscriptionHealth>(sp => sp.GetRequiredService<SubscriptionHealthCheck>());
+        TryAddSubscriptionHealthCheck(builder.Services);
 
         return builder.AddCheck<SubscriptionHealthCheck>(checkName, failureStatus, tags);
     }
@@ -86,5 +85,10 @@ public static class SubscriptionRegistrationExtensions {
         return EventuousDiagnostics.Enabled
             ? services.AddSingleton<ICheckpointStore>(sp => new MeasuredCheckpointStore(sp.GetRequiredService<T>()))
             : services.AddSingleton<ICheckpointStore>(sp => sp.GetRequiredService<T>());
+    }
+
+    static void TryAddSubscriptionHealthCheck(IServiceCollection services) {
+        services.TryAddSingleton<SubscriptionHealthCheck>();
+        services.TryAddSingleton<ISubscriptionHealth>(sp => sp.GetRequiredService<SubscriptionHealthCheck>());
     }
 }

--- a/src/Core/test/Eventuous.Tests.Subscriptions/RegistrationTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/RegistrationTests.cs
@@ -75,7 +75,11 @@ public class RegistrationTests(ITestOutputHelper outputHelper) {
     [Fact]
     public void ShouldRegisterBothAsHealthReporters() {
         var services = _server.Services.GetServices<ISubscriptionHealth>().ToArray();
+        var health   = _server.Services.GetServices<SubscriptionHealthCheck>().ToArray();
+        
         services.Length.Should().Be(1);
+        health.Length.Should().Be(1);
+        services.Single().Should().BeSameAs(health.Single());
     }
 
     [Fact]
@@ -120,6 +124,8 @@ public class RegistrationTests(ITestOutputHelper outputHelper) {
             );
 
             services.AddOpenTelemetry().WithMetrics(builder => builder.AddEventuousSubscriptions());
+            
+            services.AddHealthChecks().AddSubscriptionsHealthCheck("subscriptions", HealthStatus.Unhealthy, new[] { "tag" });
         }
 
         public void Configure(IApplicationBuilder app) { }


### PR DESCRIPTION
Consolidate SubscriptionHealthCheck DI registrations because the differing way of registering was causing 2 instances to be created, with SubscriptionHostedService being injected with a different instance than the one used by the ASP health check runner.

This lead to the health check always reporting Healthy because the `_healthReports` array was always empty. `ReportUnhealthy` was being called properly, but it was updating the `_healthReports` of another instance.