### PR TITLE
Create CreateTestAggregateInstance method for Id as TId and mark other function as obsolete

### DIFF
--- a/src/Testing/src/Eventuous.Testing/AggregateFactoryExtensions.cs
+++ b/src/Testing/src/Eventuous.Testing/AggregateFactoryExtensions.cs
@@ -13,7 +13,21 @@ public static class AggregateFactoryExtensions {
     /// <typeparam name="TState">Aggregate state type</typeparam>
     /// <typeparam name="TId">Aggregate identity type</typeparam>
     /// <returns></returns>
-    public static TAggregate CreateTestAggregateInstance<TAggregate, TState, TId>(this AggregateFactoryRegistry registry, TId id) 
+    [Obsolete("This overload is for backwards compability. Use CreateTestAggregateInstance that uses Id in stead of AggregateId as TId parameter.")]
+    public static TAggregate CreateTestAggregateInstanceForAggregateId<TAggregate, TState, TId>(this AggregateFactoryRegistry registry, TId id) 
         where TAggregate : Aggregate<TState> where TState : State<TState>, new() where TId : AggregateId
+        => registry.CreateInstance<TAggregate>().WithId<TAggregate, TState, TId>(id);
+
+    /// <summary>
+    /// Creates an instance of the aggregate and assigns the ID of the aggregate
+    /// </summary>
+    /// <param name="registry">Aggregate factory registry</param>
+    /// <param name="id">Aggregate identity</param>
+    /// <typeparam name="TAggregate">Aggregate type</typeparam>
+    /// <typeparam name="TState">Aggregate state type</typeparam>
+    /// <typeparam name="TId">Aggregate identity type</typeparam>
+    /// <returns></returns>
+    public static TAggregate CreateTestAggregateInstance<TAggregate, TState, TId>(this AggregateFactoryRegistry registry, TId id)
+        where TAggregate : Aggregate<TState> where TState : State<TState>, new() where TId : Id
         => registry.CreateInstance<TAggregate>().WithId<TAggregate, TState, TId>(id);
 }


### PR DESCRIPTION
Change name for backwards compability. 

To migrate instandly, change in existing tests the method CreateTestAggregateInstance to CreateTestAggregateInstanceForAggregateId.