### PR TITLE
Allow Aggregate to react to events

### DIFF
--- a/src/Core/src/Eventuous.Domain/Aggregate.cs
+++ b/src/Core/src/Eventuous.Domain/Aggregate.cs
@@ -84,15 +84,21 @@ public abstract class Aggregate<T> : Aggregate where T : State<T>, new() {
         AddChange(evt);
         var previous = State;
         State = State.When(evt);
-
+        When(evt);
         return (previous, State);
     }
 
+    protected virtual void When(object evt) {}
+    
     /// <inheritdoc />
     public override void Load(IEnumerable<object?> events) {
         Original = events.Where(x => x != null).ToArray()!;
         // ReSharper disable once ConvertClosureToMethodGroup
-        State = Original.Aggregate(new T(), (state, o) => Fold(state, o));
+        foreach (var o in Original) {
+            State = Fold(State, o);
+            When(o);
+        }
+       
     }
 
     static T Fold(T state, object evt)

--- a/src/Core/test/Eventuous.Tests/Aggregates/ChangeBehaviosSpec.cs
+++ b/src/Core/test/Eventuous.Tests/Aggregates/ChangeBehaviosSpec.cs
@@ -1,0 +1,87 @@
+
+namespace Eventuous.Tests.Aggregates;
+
+
+using Testing;
+
+public class StandardBehaviorSpec : AggregateSpec<BehaviorAggregate> {
+   
+    protected override object[] GivenEvents() => [
+      
+    ];
+
+    protected override void When(BehaviorAggregate aggregate) => aggregate.DoStuff(new TestCommand());
+
+    [Fact]
+    public void should_be_exceptional() {
+        Then().Changes.Should().Contain(new TestEvents.BecameExceptional());
+    }
+
+}
+
+public class ExceptionalBehaviorSpec : AggregateSpec<BehaviorAggregate> {
+   
+    protected override object[] GivenEvents() => [
+      new TestEvents.BecameExceptional()
+    ];
+
+    protected override void When(BehaviorAggregate aggregate) => aggregate.DoStuff(new TestCommand());
+
+    [Fact]
+    public void should_be_exceptional() {
+        Then().Changes.Should().Contain(new TestEvents.BecameStandard());
+    }
+
+}
+
+public class BehaviorAggregate
+    : Aggregate<TestState>{
+
+
+    private Action<TestCommand> _behavior;
+
+    public BehaviorAggregate() {
+        Become(Standard);
+    }
+
+    public void Become(Action<TestCommand> behavior) {
+        _behavior = behavior;
+    }
+
+    public void DoStuff(TestCommand command) {
+        _behavior(command);
+    }
+    
+    void Standard(TestCommand obj) {
+        Apply(new TestEvents.BecameExceptional());
+    }
+
+    void Exceptional(TestCommand obj) {
+        Apply(new TestEvents.BecameStandard());
+    }
+
+    protected override void When(object evt) {
+
+        switch (evt) {
+           case TestEvents.BecameExceptional: 
+            Become(Exceptional);
+                break; 
+           case TestEvents.BecameStandard: 
+            Become(Standard);
+                break;
+        }
+        
+    }
+}
+
+public record TestCommand;
+
+public record TestState : State<TestState,TestId>;
+
+public record TestId(string Value) : Id(Value);
+
+public  static class TestEvents {
+    public record BecameExceptional;
+    public record BecameStandard;
+    
+}


### PR DESCRIPTION
This allows to change an aggregate behavior in another way than checking state.
It was inspired by how Akka.net actor can change behavior.
There may be a better design for this or that it should be in another aggregate basetype.

I wanted to start a discussion about it :)

My test code is not where it should be I expect. But I put everything i one file for the overview.