### PR TITLE
Isolate type mapper from service result

### DIFF
--- a/src/Core/src/Eventuous.Application/Result.cs
+++ b/src/Core/src/Eventuous.Application/Result.cs
@@ -9,7 +9,13 @@ using System.Runtime.InteropServices;
 namespace Eventuous;
 
 [StructLayout(LayoutKind.Auto)]
-public record struct Change(object Event, string EventType);
+public record struct Change(object Event, string EventType) {
+    internal static Change FromEvent(object evt, ITypeMapper typeMapper) {
+        var typeName = typeMapper.GetTypeName(evt);
+
+        return new(evt, typeName != ITypeMapper.UnknownType ? typeName : evt.GetType().Name);
+    }
+}
 
 /// <summary>
 /// Represents the command handling result, could be either success or error

--- a/src/Core/src/Eventuous.Persistence/AppendEventsResult.cs
+++ b/src/Core/src/Eventuous.Persistence/AppendEventsResult.cs
@@ -3,7 +3,6 @@
 
 namespace Eventuous;
 
-[PublicAPI]
 public record AppendEventsResult(ulong GlobalPosition, long NextExpectedVersion) {
     public static readonly AppendEventsResult NoOp = new(0, -1);
 }

--- a/src/Core/src/Eventuous.Serialization/DefaultEventSerializer.cs
+++ b/src/Core/src/Eventuous.Serialization/DefaultEventSerializer.cs
@@ -7,10 +7,10 @@ using static Eventuous.DeserializationResult;
 namespace Eventuous;
 
 [PublicAPI]
-public class DefaultEventSerializer(JsonSerializerOptions options, TypeMapper? typeMapper = null) : IEventSerializer {
+public class DefaultEventSerializer(JsonSerializerOptions options, ITypeMapper? typeMapper = null) : IEventSerializer {
     public static IEventSerializer Instance { get; private set; } = new DefaultEventSerializer(new(JsonSerializerDefaults.Web));
 
-    readonly TypeMapper _typeMapper = typeMapper ?? TypeMap.Instance;
+    readonly ITypeMapper _typeMapper = typeMapper ?? TypeMap.Instance;
 
     public static void SetDefaultSerializer(IEventSerializer serializer) => Instance = serializer;
 

--- a/src/Core/src/Eventuous.Shared/TypeMap/ITypeMapper.cs
+++ b/src/Core/src/Eventuous.Shared/TypeMap/ITypeMapper.cs
@@ -1,0 +1,28 @@
+// Copyright (C) Ubiquitous AS.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+namespace Eventuous;
+
+public interface ITypeMapper {
+    public const string UnknownType = "unknown";
+
+    /// <summary>
+    /// Try getting a type name for a given type
+    /// </summary>
+    /// <param name="type">Type for which the name is requested</param>
+    /// <param name="typeName">Registered type name or null if the type isn't registered</param>
+    /// <returns>True if the type is registered, false otherwise</returns>
+    bool TryGetTypeName(Type type, [NotNullWhen(true)] out string? typeName);
+
+    /// <summary>
+    /// Try getting a registered type for a given name
+    /// </summary>
+    /// <param name="typeName">Known type name</param>
+    /// <param name="type">Registered type for a given name or null if the type name isn't registered</param>
+    /// <returns>True if the type is registered, false otherwise</returns>
+    bool TryGetType(string typeName, [NotNullWhen(true)] out Type? type);
+}
+
+public interface ITypeMapperExt : ITypeMapper {
+    IEnumerable<(string TypeName, Type Type)> GetRegisteredTypes();
+}

--- a/src/Core/src/Eventuous.Shared/TypeMap/TypeMapperExtensions.cs
+++ b/src/Core/src/Eventuous.Shared/TypeMap/TypeMapperExtensions.cs
@@ -1,0 +1,59 @@
+// Copyright (C) Ubiquitous AS.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+namespace Eventuous;
+
+using static TypeMapEventSource;
+
+public static class TypeMapperExtensions {
+    /// <summary>
+    /// Get the type name for a given type
+    /// </summary>
+    /// <param name="typeMapper">Type mapper instance</param>
+    /// <param name="type">Object type for which the name needs to be retrieved</param>
+    /// <param name="fail">Indicates if exception should be thrown if the type is now registered</param>
+    /// <returns>Type name from the map or "unknown" if the type isn't registered and <code>fail</code> is set to false</returns>
+    /// <exception cref="UnregisteredTypeException">Thrown if the type isn't registered and fail is set to true</exception>
+    public static string GetTypeNameByType(this ITypeMapper typeMapper, Type type, bool fail = true) {
+        var typeKnown = typeMapper.TryGetTypeName(type, out var name);
+
+        if (!typeKnown && fail) {
+            Log.TypeNotMappedToName(type);
+
+            throw new UnregisteredTypeException(type);
+        }
+
+        return name ?? ITypeMapper.UnknownType;
+    }
+
+    public static string GetTypeName(this ITypeMapper typeMapper, object o, bool fail = true) => typeMapper.GetTypeNameByType(o.GetType(), fail);
+
+    public static string GetTypeName<T>(this ITypeMapper typeMapper, bool fail = true) => typeMapper.GetTypeNameByType(typeof(T), fail);
+    
+    public static bool TryGetTypeName<T>(this ITypeMapper typeMapper, [NotNullWhen(true)] out string? typeName) => typeMapper.TryGetTypeName(typeof(T), out typeName);
+
+    /// <summary>
+    /// Get the registered type for a given name 
+    /// </summary>
+    /// <param name="typeMapper">Type mapper instance</param>
+    /// <param name="typeName">Type name for which the type needs to be returned</param>
+    /// <returns>Type that matches the given name</returns>
+    /// <exception cref="UnregisteredTypeException">Thrown if the type isn't registered and fail is set to true</exception>
+    public static Type GetType(this ITypeMapper typeMapper, string typeName) {
+        var typeKnown = typeMapper.TryGetType(typeName, out var type);
+
+        if (!typeKnown) {
+            Log.TypeNameNotMappedToType(typeName);
+
+            throw new UnregisteredTypeException(typeName);
+        }
+
+        return type!;
+    }
+
+    public static void EnsureTypesRegistered(this ITypeMapper typeMapper, IEnumerable<Type> types) {
+        foreach (var type in types) {
+            typeMapper.GetTypeNameByType(type);
+        }
+    }
+}

--- a/src/Core/src/Eventuous.Subscriptions/Handlers/EventHandler.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Handlers/EventHandler.cs
@@ -14,12 +14,12 @@ using Logging;
 /// Base class for event handlers, which allows registering typed handlers for different event types
 /// </summary>
 [PublicAPI]
-public abstract class EventHandler(TypeMapper? mapper = null) : BaseEventHandler {
+public abstract class EventHandler(ITypeMapper? mapper = null) : BaseEventHandler {
     readonly Dictionary<Type, HandleUntypedEvent> _handlersMap = new();
 
     static readonly ValueTask<EventHandlingStatus> Ignored = new(EventHandlingStatus.Ignored);
 
-    readonly TypeMapper _typeMapper = mapper ?? TypeMap.Instance;
+    readonly ITypeMapper _typeMapper = mapper ?? TypeMap.Instance;
 
     /// <summary>
     /// Register a handler for a particular event type
@@ -32,7 +32,7 @@ public abstract class EventHandler(TypeMapper? mapper = null) : BaseEventHandler
             throw new ArgumentException($"Type {typeof(T).Name} already has a handler");
         }
 
-        if (!_typeMapper.IsTypeRegistered<T>()) {
+        if (!_typeMapper.TryGetTypeName<T>(out _)) {
             SubscriptionsEventSource.Log.MessageTypeNotRegistered<T>();
         }
 

--- a/src/Core/test/Eventuous.Tests.Application/CommandServiceTests.cs
+++ b/src/Core/test/Eventuous.Tests.Application/CommandServiceTests.cs
@@ -14,7 +14,7 @@ public class CommandServiceTests(ITestOutputHelper output) : ServiceTestBase(out
     class ExtendedService : BookingService {
         public ExtendedService(
                 IEventStore                store,
-                TypeMapper                 typeMap,
+                ITypeMapper                typeMap,
                 AmendEvent<ImportBooking>? amendEvent = null,
                 AmendEvent?                amendAll   = null
             ) : base(store, typeMapper: typeMap, amendEvent: amendAll) {

--- a/src/Core/test/Eventuous.Tests.Application/Eventuous.Tests.Application.csproj
+++ b/src/Core/test/Eventuous.Tests.Application/Eventuous.Tests.Application.csproj
@@ -6,4 +6,9 @@
     <ItemGroup>
       <ProjectReference Include="$(SrcRoot)\Testing\src\Eventuous.Testing\Eventuous.Testing.csproj" />
     </ItemGroup>
+    <ItemGroup>
+      <Compile Update="ServiceTestBase.OnNew.cs">
+        <DependentUpon>ServiceTestBase.cs</DependentUpon>
+      </Compile>
+    </ItemGroup>
 </Project>

--- a/src/Core/test/Eventuous.Tests.Application/FunctionalServiceTests.cs
+++ b/src/Core/test/Eventuous.Tests.Application/FunctionalServiceTests.cs
@@ -15,7 +15,7 @@ public class FunctionalServiceTests(ITestOutputHelper output) : ServiceTestBase(
     class ExtendedService : BookingFuncService {
         public ExtendedService(
                 IEventStore                store,
-                TypeMapper?                typeMap,
+                ITypeMapper?               typeMap,
                 AmendEvent<ImportBooking>? amendEvent = null,
                 AmendEvent?                amendAll   = null
             ) : base(store, typeMap, amendAll) {

--- a/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.Amendments.cs
+++ b/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.Amendments.cs
@@ -1,0 +1,44 @@
+using Eventuous.Sut.Domain;
+using Eventuous.Testing;
+
+namespace Eventuous.Tests.Application;
+
+public abstract partial class ServiceTestBase {
+    [Fact]
+    public async Task Should_amend_event_from_command() {
+        var service = CreateService(amendEvent: AmendEvent);
+        var cmd     = CreateCommand();
+
+        await service.Handle(cmd, default);
+
+        var stream = await Store.ReadStream(StreamName.For<Booking>(cmd.BookingId), StreamReadPosition.Start);
+        stream[0].Metadata["userId"].Should().Be(cmd.ImportedBy);
+    }
+
+    [Fact]
+    public async Task Should_amend_event_with_static_meta() {
+        var cmd = Helpers.GetBookRoom();
+
+        await CommandServiceFixture
+            .ForService(() => CreateService(amendAll: AddMeta), Store)
+            .Given(cmd.BookingId)
+            .When(cmd)
+            .Then(x => x.StreamIs(e => e[0].Metadata["foo"].Should().Be("bar")));
+    }
+
+    [Fact]
+    public async Task Should_combine_amendments() {
+        var service = CreateService(amendEvent: AmendEvent, amendAll: AddMeta);
+        var cmd     = CreateCommand();
+
+        await service.Handle(cmd, default);
+
+        var stream = await Store.ReadStream(StreamName.For<Booking>(cmd.BookingId), StreamReadPosition.Start);
+        stream[0].Metadata["userId"].Should().Be(cmd.ImportedBy);
+        stream[0].Metadata["foo"].Should().Be("bar");
+    }
+
+    static NewStreamEvent AmendEvent(NewStreamEvent evt, ImportBooking cmd) => evt with { Metadata = evt.Metadata.With("userId", cmd.ImportedBy) };
+
+    static NewStreamEvent AddMeta(NewStreamEvent evt) => evt with { Metadata = evt.Metadata.With("foo", "bar") };
+}

--- a/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.OnAny.cs
+++ b/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.OnAny.cs
@@ -1,0 +1,26 @@
+using Eventuous.Sut.App;
+using Eventuous.Testing;
+using Shouldly;
+
+namespace Eventuous.Tests.Application;
+
+public abstract partial class ServiceTestBase {
+    [Fact]
+    public async Task Should_execute_on_any_no_stream() {
+        var bookRoom = Helpers.GetBookRoom();
+
+        var cmd = new Commands.ImportBooking {
+            BookingId = "dummy",
+            Price     = bookRoom.Price,
+            CheckIn   = bookRoom.CheckIn,
+            CheckOut  = bookRoom.CheckOut,
+            RoomId    = bookRoom.RoomId
+        };
+
+        await CommandServiceFixture
+            .ForService(() => CreateService(), Store)
+            .Given(cmd.BookingId)
+            .When(cmd)
+            .Then(result => result.ResultIsOk(x => x.Changes.Should().HaveCount(1)).StreamIs(x => x.Length.ShouldBe(1)));
+    }
+}

--- a/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.OnExisting.cs
+++ b/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.OnExisting.cs
@@ -1,0 +1,42 @@
+using Eventuous.Sut.App;
+using Eventuous.Sut.Domain;
+using Eventuous.Testing;
+using Shouldly;
+
+namespace Eventuous.Tests.Application;
+
+public abstract partial class ServiceTestBase {
+    [Fact]
+    public async Task Should_execute_on_existing_stream_exists() {
+        var seedCmd = Helpers.GetBookRoom();
+        var seed    = new BookingEvents.RoomBooked(seedCmd.RoomId, seedCmd.CheckIn, seedCmd.CheckOut, seedCmd.Price);
+
+        var paymentTime = DateTimeOffset.Now;
+        var cmd         = new Commands.RecordPayment(new(seedCmd.BookingId), "444", new(seedCmd.Price), paymentTime);
+
+        var expectedResult = new object[] {
+            new BookingEvents.BookingPaymentRegistered(cmd.PaymentId, cmd.Amount.Amount),
+            new BookingEvents.BookingOutstandingAmountChanged(0),
+            new BookingEvents.BookingFullyPaid(paymentTime)
+        };
+
+        await CommandServiceFixture
+            .ForService(() => CreateService(), Store)
+            .Given(seedCmd.BookingId, seed)
+            .When(cmd)
+            .Then(result => result.ResultIsOk().NewStreamEventsAre(expectedResult));
+    }
+
+    [Fact]
+    public async Task Should_fail_on_existing_no_stream() {
+        var seedCmd     = Helpers.GetBookRoom();
+        var paymentTime = DateTimeOffset.Now;
+        var cmd         = new Commands.RecordPayment(new(seedCmd.BookingId), "444", new(seedCmd.Price), paymentTime);
+
+        await CommandServiceFixture
+            .ForService(() => CreateService(), Store)
+            .Given(seedCmd.BookingId)
+            .When(cmd)
+            .Then(result => result.ResultIsError().StreamIs(x => x.Length.ShouldBe(0)));
+    }
+}

--- a/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.OnNew.cs
+++ b/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.OnNew.cs
@@ -1,0 +1,30 @@
+using Eventuous.Sut.Domain;
+using Eventuous.Testing;
+
+namespace Eventuous.Tests.Application;
+
+public abstract partial class ServiceTestBase {
+    [Fact]
+    public async Task Should_run_on_new_no_stream() {
+        var cmd      = Helpers.GetBookRoom();
+        var expected = new BookingEvents.RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price);
+
+        await CommandServiceFixture
+            .ForService(() => CreateService(), Store)
+            .Given(cmd.BookingId)
+            .When(cmd)
+            .Then(result => result.ResultIsOk(x => x.Changes.Should().HaveCount(1)).FullStreamEventsAre(expected));
+    }
+    
+    [Fact]
+    public async Task Should_fail_on_new_stream_exists() {
+        var cmd      = Helpers.GetBookRoom();
+        var seed = new BookingEvents.RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price);
+
+        await CommandServiceFixture
+            .ForService(() => CreateService(), Store)
+            .Given(cmd.BookingId, seed)
+            .When(cmd)
+            .Then(result => result.ResultIsError<WrongVersion>());
+    }
+}

--- a/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.cs
+++ b/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.cs
@@ -3,64 +3,11 @@ using Eventuous.Sut.Domain;
 using Eventuous.TestHelpers;
 using Eventuous.Testing;
 using NodaTime;
-using Shouldly;
 using static Eventuous.Sut.Domain.BookingEvents;
 
 namespace Eventuous.Tests.Application;
 
-public abstract class ServiceTestBase : IDisposable {
-    [Fact]
-    public async Task ExecuteOnNewStream() {
-        var cmd      = Helpers.GetBookRoom();
-        var expected = new RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price);
-
-        await CommandServiceFixture
-            .ForService(() => CreateService(), Store)
-            .Given(cmd.BookingId)
-            .When(cmd)
-            .Then(result => result.ResultIsOk(x => x.Changes.Should().HaveCount(1)).FullStreamEventsAre(expected));
-    }
-
-    [Fact]
-    public async Task ExecuteOnExistingStream() {
-        var seedCmd = Helpers.GetBookRoom();
-        var seed    = new RoomBooked(seedCmd.RoomId, seedCmd.CheckIn, seedCmd.CheckOut, seedCmd.Price);
-
-        var paymentTime = DateTimeOffset.Now;
-        var cmd         = new Commands.RecordPayment(new(seedCmd.BookingId), "444", new(seedCmd.Price), paymentTime);
-
-        var expectedResult = new object[] {
-            new BookingPaymentRegistered(cmd.PaymentId, cmd.Amount.Amount),
-            new BookingOutstandingAmountChanged(0),
-            new BookingFullyPaid(paymentTime)
-        };
-
-        await CommandServiceFixture
-            .ForService(() => CreateService(), Store)
-            .Given(seedCmd.BookingId, seed)
-            .When(cmd)
-            .Then(result => result.ResultIsOk().NewStreamEventsAre(expectedResult));
-    }
-
-    [Fact]
-    public async Task ExecuteOnAnyForNewStream() {
-        var bookRoom = Helpers.GetBookRoom();
-
-        var cmd = new Commands.ImportBooking {
-            BookingId = "dummy",
-            Price     = bookRoom.Price,
-            CheckIn   = bookRoom.CheckIn,
-            CheckOut  = bookRoom.CheckOut,
-            RoomId    = bookRoom.RoomId
-        };
-
-        await CommandServiceFixture
-            .ForService(() => CreateService(), Store)
-            .Given(cmd.BookingId)
-            .When(cmd)
-            .Then(result => result.ResultIsOk(x => x.Changes.Should().HaveCount(1)).StreamIs(x => x.Length.ShouldBe(1)));
-    }
-
+public abstract partial class ServiceTestBase : IDisposable {
     [Fact]
     public async Task Ensure_builder_is_thread_safe() {
         const int threadCount = 3;
@@ -81,44 +28,6 @@ public abstract class ServiceTestBase : IDisposable {
             ok!.Changes.Should().HaveCount(1);
         }
     }
-
-    [Fact]
-    public async Task Should_amend_event_from_command() {
-        var service = CreateService(amendEvent: AmendEvent);
-        var cmd     = CreateCommand();
-
-        await service.Handle(cmd, default);
-
-        var stream = await Store.ReadStream(StreamName.For<Booking>(cmd.BookingId), StreamReadPosition.Start);
-        stream[0].Metadata["userId"].Should().Be(cmd.ImportedBy);
-    }
-
-    [Fact]
-    public async Task Should_amend_event_with_static_meta() {
-        var cmd = Helpers.GetBookRoom();
-
-        await CommandServiceFixture
-            .ForService(() => CreateService(amendAll: AddMeta), Store)
-            .Given(cmd.BookingId)
-            .When(cmd)
-            .Then(x => x.StreamIs(e => e[0].Metadata["foo"].Should().Be("bar")));
-    }
-
-    [Fact]
-    public async Task Should_combine_amendments() {
-        var service = CreateService(amendEvent: AmendEvent, amendAll: AddMeta);
-        var cmd     = CreateCommand();
-
-        await service.Handle(cmd, default);
-
-        var stream = await Store.ReadStream(StreamName.For<Booking>(cmd.BookingId), StreamReadPosition.Start);
-        stream[0].Metadata["userId"].Should().Be(cmd.ImportedBy);
-        stream[0].Metadata["foo"].Should().Be("bar");
-    }
-
-    static NewStreamEvent AmendEvent(NewStreamEvent evt, ImportBooking cmd) => evt with { Metadata = evt.Metadata.With("userId", cmd.ImportedBy) };
-
-    static NewStreamEvent AddMeta(NewStreamEvent evt) => evt with { Metadata = evt.Metadata.With("foo", "bar") };
 
     static ImportBooking CreateCommand() {
         var today = LocalDate.FromDateTime(DateTime.Today);

--- a/src/Core/test/Eventuous.Tests/StoringEvents.cs
+++ b/src/Core/test/Eventuous.Tests/StoringEvents.cs
@@ -1,4 +1,5 @@
 global using NodaTime;
+using static Eventuous.Sut.Domain.BookingEvents;
 
 namespace Eventuous.Tests;
 
@@ -24,7 +25,7 @@ public class StoringEvents : NaiveFixture {
             Auto.Create<float>()
         );
 
-        Change[] expected = [new(new BookingEvents.RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price), "RoomBooked")];
+        Change[] expected = [new(new RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price), TypeNames.RoomBooked)];
 
         var result = await Service.Handle(cmd, default);
 

--- a/src/Core/test/Eventuous.Tests/StoringEventsWithCustomStream.cs
+++ b/src/Core/test/Eventuous.Tests/StoringEventsWithCustomStream.cs
@@ -20,7 +20,7 @@ public class StoringEventsWithCustomStream : NaiveFixture {
     public async Task TestOnNew() {
         var cmd = CreateBookRoomCommand();
 
-        Change[] expected = [new(new RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price), "RoomBooked")];
+        Change[] expected = [new(new RoomBooked(cmd.RoomId, cmd.CheckIn, cmd.CheckOut, cmd.Price), TypeNames.RoomBooked)];
 
         var result = await Service.Handle(cmd, default);
 
@@ -41,9 +41,9 @@ public class StoringEventsWithCustomStream : NaiveFixture {
         var secondCmd = new Commands.RecordPayment(new(cmd.BookingId), Auto.Create<string>(), new(cmd.Price), DateTimeOffset.Now);
 
         var expected = new Change[] {
-            new(new BookingPaymentRegistered(secondCmd.PaymentId, secondCmd.Amount.Amount), "PaymentRegistered"),
-            new(new BookingOutstandingAmountChanged(0), "OutstandingAmountChanged"),
-            new(new BookingFullyPaid(secondCmd.PaidAt), "BookingFullyPaid")
+            new(new BookingPaymentRegistered(secondCmd.PaymentId, secondCmd.Amount.Amount), TypeNames.PaymentRegistered),
+            new(new BookingOutstandingAmountChanged(0), TypeNames.OutstandingAmountChanged),
+            new(new BookingFullyPaid(secondCmd.PaidAt), TypeNames.BookingFullyPaid)
         };
 
         var result = await Service.Handle(secondCmd, default);

--- a/src/EventStore/src/Eventuous.EventStore/EsdbEventStore.cs
+++ b/src/EventStore/src/Eventuous.EventStore/EsdbEventStore.cs
@@ -253,8 +253,7 @@ public class EsdbEventStore : IEventStore {
     StreamEvent[] ToStreamEvents(ResolvedEvent[] resolvedEvents)
         => resolvedEvents
             .Where(x => !x.Event.EventType.StartsWith('$'))
-            // ReSharper disable once ConvertClosureToMethodGroup
-            .Select(e => ToStreamEvent(e))
+            .Select(ToStreamEvent)
             .ToArray();
 
     record ErrorInfo(string Message, params object[] Args);

--- a/src/EventStore/src/Eventuous.EventStore/EsdbEventStore.cs
+++ b/src/EventStore/src/Eventuous.EventStore/EsdbEventStore.cs
@@ -85,10 +85,7 @@ public class EsdbEventStore : IEventStore {
             async () => {
                 var result = await resultTask.NoContext();
 
-                return new AppendEventsResult(
-                    result.LogPosition.CommitPosition,
-                    result.NextExpectedStreamRevision.ToInt64()
-                );
+                return new AppendEventsResult(result.LogPosition.CommitPosition, result.NextExpectedStreamRevision.ToInt64());
             },
             stream,
             () => new("Unable to appends events to {Stream}", stream),

--- a/src/EventStore/test/Eventuous.Tests.EventStore/ProducerTracesTests.cs
+++ b/src/EventStore/test/Eventuous.Tests.EventStore/ProducerTracesTests.cs
@@ -10,6 +10,8 @@ namespace Eventuous.Tests.EventStore;
 public class TracesTests : LegacySubscriptionFixture<TracedHandler>, IDisposable {
     readonly ActivityListener _listener;
 
+    static TracesTests() => TypeMap.Instance.AddType<TestEvent>(TestEvent.TypeName);
+
     public TracesTests(ITestOutputHelper output) : base(output, new(), false) {
         _listener = new() {
             ShouldListenTo = _ => true,

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticSerializer.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticSerializer.cs
@@ -5,10 +5,10 @@ using System.Text.Json;
 
 namespace Eventuous.ElasticSearch.Store;
 
-public class ElasticSerializer(IElasticsearchSerializer builtIn, JsonSerializerOptions? options, TypeMapper? typeMapper = null)
+public class ElasticSerializer(IElasticsearchSerializer builtIn, JsonSerializerOptions? options, ITypeMapper? typeMapper = null)
     : IElasticsearchSerializer {
     readonly JsonSerializerOptions _options    = options    ?? new JsonSerializerOptions(JsonSerializerDefaults.Web);
-    readonly TypeMapper            _typeMapper = typeMapper ?? TypeMap.Instance;
+    readonly ITypeMapper           _typeMapper = typeMapper ?? TypeMap.Instance;
 
     public object Deserialize(Type type, Stream stream) {
         var reader = new BinaryReader(stream);

--- a/src/Experimental/src/Eventuous.Spyglass/SpyglassApi.cs
+++ b/src/Experimental/src/Eventuous.Spyglass/SpyglassApi.cs
@@ -34,10 +34,12 @@ public static class SpyglassApi {
 
         builder.MapGet(
                 "/spyglass/events",
-                (HttpRequest request, [FromServices] TypeMapper? typeMapper) => {
+                (HttpRequest request, [FromServices] ITypeMapper? typeMapper) => {
                     var typeMap = typeMapper ?? TypeMap.Instance;
 
-                    return CheckAndReturn(request, () => typeMap.ReverseMap.Select(x => x.Key));
+                    return typeMap is not ITypeMapperExt typeMapExt
+                        ? Results.Problem("Type mapper doesn't support listing registered types", statusCode: 500)
+                        : CheckAndReturn(request, () => typeMapExt.GetRegisteredTypes());
                 }
             )
             .ExcludeFromDescription();

--- a/src/Extensions/test/Eventuous.Tests.Extensions.AspNetCore/AggregateCommandsTests.MapEnrichedCommand.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.Extensions.AspNetCore/AggregateCommandsTests.MapEnrichedCommand.verified.txt
@@ -21,7 +21,7 @@
         price: 100,
         guestId: test guest
       },
-      eventType: RoomBooked
+      eventType: V1.RoomBooked
     }
   ],
   streamPosition: 0

--- a/src/Extensions/test/Eventuous.Tests.Extensions.AspNetCore/DiscoveredCommandsTests.CallDiscoveredCommandRoute.verified.txt
+++ b/src/Extensions/test/Eventuous.Tests.Extensions.AspNetCore/DiscoveredCommandsTests.CallDiscoveredCommandRoute.verified.txt
@@ -21,7 +21,7 @@
         price: 100,
         guestId: guest
       },
-      eventType: RoomBooked
+      eventType: V1.RoomBooked
     }
   ],
   streamPosition: 0

--- a/src/Mongo/src/Eventuous.Projections.MongoDB/MongoProjector.cs
+++ b/src/Mongo/src/Eventuous.Projections.MongoDB/MongoProjector.cs
@@ -11,7 +11,7 @@ namespace Eventuous.Projections.MongoDB;
 using Tools;
 
 [Obsolete("Use MongoProjector instead")]
-public abstract class MongoProjection<T>(IMongoDatabase database, TypeMapper? typeMap = null) : MongoProjector<T>(database, typeMap)
+public abstract class MongoProjection<T>(IMongoDatabase database, ITypeMapper? typeMap = null) : MongoProjector<T>(database, typeMap)
     where T : ProjectedDocument;
 
 /// <summary>
@@ -19,12 +19,12 @@ public abstract class MongoProjection<T>(IMongoDatabase database, TypeMapper? ty
 /// </summary>
 /// <typeparam name="T"></typeparam>
 [UsedImplicitly]
-public abstract class MongoProjector<T>(IMongoDatabase database, TypeMapper? typeMap = null) : BaseEventHandler where T : ProjectedDocument {
+public abstract class MongoProjector<T>(IMongoDatabase database, ITypeMapper? typeMap = null) : BaseEventHandler where T : ProjectedDocument {
     [PublicAPI]
     protected IMongoCollection<T> Collection { get; } = Ensure.NotNull<IMongoDatabase>(database).GetDocumentCollection<T>();
 
     readonly Dictionary<Type, ProjectUntypedEvent> _handlers = new();
-    readonly TypeMapper                            _map      = typeMap ?? TypeMap.Instance;
+    readonly ITypeMapper                           _map      = typeMap ?? TypeMap.Instance;
 
     /// <summary>
     /// Register a handler for a particular event type
@@ -38,7 +38,7 @@ public abstract class MongoProjector<T>(IMongoDatabase database, TypeMapper? typ
             throw new ArgumentException($"Type {typeof(TEvent).Name} already has a handler");
         }
 
-        if (!_map.IsTypeRegistered<TEvent>()) {
+        if (!_map.TryGetTypeName<TEvent>(out _)) {
             Log.MessageTypeNotRegistered<TEvent>();
         }
     }

--- a/src/Postgres/src/Eventuous.Postgresql/Projections/PostgresProjector.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Projections/PostgresProjector.cs
@@ -10,7 +10,7 @@ namespace Eventuous.Postgresql.Projections;
 /// <summary>
 /// Base class for projectors that store read models in PostgreSQL.
 /// </summary>
-public abstract class PostgresProjector(NpgsqlDataSource dataSource, TypeMapper? mapper = null) : EventHandler(mapper) {
+public abstract class PostgresProjector(NpgsqlDataSource dataSource, ITypeMapper? mapper = null) : EventHandler(mapper) {
     protected void On<T>(ProjectToPostgres<T> handler) where T : class {
         base.On<T>(async ctx => await Handle(ctx, GetCommand).NoContext());
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Projections/SqlServerProjector.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Projections/SqlServerProjector.cs
@@ -9,7 +9,7 @@ namespace Eventuous.SqlServer.Projections;
 /// <summary>
 /// Base class for projectors that store read models in SQL Server.
 /// </summary>
-public abstract class SqlServerProjector(SqlServerConnectionOptions options, TypeMapper? mapper = null) : EventHandler(mapper) {
+public abstract class SqlServerProjector(SqlServerConnectionOptions options, ITypeMapper? mapper = null) : EventHandler(mapper) {
     readonly string _connectionString = Ensure.NotEmptyString(options.ConnectionString);
 
     /// <summary>

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -104,4 +104,4 @@ class InMemoryStream(StreamName name) {
     }
 }
 
-class WrongVersion(ExpectedStreamVersion expected, int actual) : Exception($"Wrong stream version. Expected {expected.Value}, actual {actual}");
+public class WrongVersion(ExpectedStreamVersion expected, int actual) : Exception($"Wrong stream version. Expected {expected.Value}, actual {actual}");

--- a/test/Eventuous.Sut.App/BookingService.cs
+++ b/test/Eventuous.Sut.App/BookingService.cs
@@ -8,7 +8,7 @@ public class BookingService : CommandService<Booking, BookingState, BookingId> {
     public BookingService(
             IEventStore    eventStore,
             StreamNameMap? streamNameMap = null,
-            TypeMapper?    typeMapper    = null,
+            ITypeMapper?   typeMapper    = null,
             AmendEvent?    amendEvent    = null
         )
         : base(eventStore, streamNameMap: streamNameMap, typeMap: typeMapper, amendEvent: amendEvent) {
@@ -32,5 +32,10 @@ public class BookingService : CommandService<Booking, BookingState, BookingId> {
             .InState(ExpectedState.Existing)
             .GetId(cmd => cmd.BookingId)
             .Act((booking, cmd) => booking.RecordPayment(cmd.PaymentId, cmd.Amount, cmd.PaidAt));
+
+        On<CancelBooking>()
+            .InState(ExpectedState.Any)
+            .GetId(cmd => cmd.BookingId)
+            .Act((booking, _) => booking.Cancel());
     }
 }

--- a/test/Eventuous.Sut.App/Commands.cs
+++ b/test/Eventuous.Sut.App/Commands.cs
@@ -19,4 +19,6 @@ public static class Commands {
     public record RecordPayment(BookingId BookingId, string PaymentId, Money Amount, DateTimeOffset PaidAt) {
         public string? PaidBy { get; init; }
     };
+    
+    public record CancelBooking(BookingId BookingId);
 }

--- a/test/Eventuous.Sut.Domain/Booking.cs
+++ b/test/Eventuous.Sut.Domain/Booking.cs
@@ -15,6 +15,8 @@ public class Booking : Aggregate<BookingState> {
         Apply(new BookingImported(roomId, price.Amount, period.CheckIn, period.CheckOut));
     }
 
+    public void Cancel() => Apply(new BookingCancelled());
+
     public void RecordPayment(string paymentId, Money amount, DateTimeOffset paidAt) {
         EnsureExists();
 

--- a/test/Eventuous.Sut.Domain/BookingEvents.cs
+++ b/test/Eventuous.Sut.Domain/BookingEvents.cs
@@ -5,31 +5,35 @@ using NodaTime;
 namespace Eventuous.Sut.Domain;
 
 public static class BookingEvents {
-    [EventType("RoomBooked")]
+    [EventType(TypeNames.RoomBooked)]
     public record RoomBooked(string RoomId, LocalDate CheckIn, LocalDate CheckOut, float Price, string? GuestId = null);
 
-    [EventType("PaymentRegistered")]
+    [EventType(TypeNames.PaymentRegistered)]
     public record BookingPaymentRegistered(string PaymentId, float AmountPaid);
 
-    [EventType("OutstandingAmountChanged")]
+    [EventType(TypeNames.OutstandingAmountChanged)]
     public record BookingOutstandingAmountChanged(float OutstandingAmount);
 
-    [EventType("BookingFullyPaid")]
+    [EventType(TypeNames.BookingFullyPaid)]
     public record BookingFullyPaid(DateTimeOffset PaidAt);
 
-    [EventType("BookingOverpaid")]
+    [EventType(TypeNames.BookingOverpaid)]
     public record BookingOverpaid(float OverpaidAmount);
 
     [EventType(TypeNames.BookingCancelled)]
     public record BookingCancelled;
 
-    [EventType("V1.BookingImported")]
+    [EventType(TypeNames.BookingImported)]
     public record BookingImported(string RoomId, float Price, LocalDate CheckIn, LocalDate CheckOut);
 
     // These constants are for test purpose, use inline names in real apps
     public static class TypeNames {
-        public const string BookingCancelled = "V1.BookingCancelled";
+        public const string BookingCancelled         = "V1.BookingCancelled";
+        public const string BookingImported          = "V1.BookingImported";
+        public const string RoomBooked               = "V1.RoomBooked";
+        public const string PaymentRegistered        = "V1.PaymentRegistered";
+        public const string OutstandingAmountChanged = "V1.OutstandingAmountChanged";
+        public const string BookingFullyPaid         = "V1.BookingFullyPaid";
+        public const string BookingOverpaid          = "V1.BookingOverpaid";
     }
-
-    public static void MapBookingEvents() => TypeMap.RegisterKnownEventTypes();
 }


### PR DESCRIPTION
Service result should not depend on type mapper as it's for informational purposes only
Type mapper slimmed down to a simple interface