### PR TITLE
Fix archive order

### DIFF
--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -17,7 +17,7 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
             ? await LoadStreamEvents(archiveReader, start, count - hotEvents.Length).NoContext()
             : Enumerable.Empty<StreamEvent>();
 
-        return hotEvents.Concat(archivedEvents.Select(x => x with { FromArchive = true })).Distinct(Comparer).ToArray();
+        return archivedEvents.Select(x => x with { FromArchive = true }).Concat(hotEvents).Distinct(Comparer).ToArray();
 
         async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount) {
             try {

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -14,7 +14,7 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
         var hotEvents = await LoadStreamEvents(hotReader, start, count).NoContext();
 
         var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Position > start.Value
-            ? await LoadStreamEvents(archiveReader, start, count - hotEvents.Length).NoContext()
+            ? await LoadStreamEvents(archiveReader, start, (int)hotEvents[0].Position).NoContext()
             : Enumerable.Empty<StreamEvent>();
 
         return archivedEvents.Select(x => x with { FromArchive = true }).Concat(hotEvents).Distinct(Comparer).ToArray();

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
@@ -23,8 +23,8 @@ public abstract class TieredStoreTestsBase<TContainer> where TContainer : Docker
         var actual = loaded.Select(x => (TestEventForTiers)x.Payload!).ToArray();
         actual.Should().BeEquivalentTo(testEvents);
 
-        loaded.Take(50).Select(x => x.FromArchive).Should().AllSatisfy(x => x.Should().BeFalse());
-        loaded.Skip(50).Select(x => x.FromArchive).Should().AllSatisfy(x => x.Should().BeTrue());
+        loaded.Take(50).Select(x => x.FromArchive).Should().AllSatisfy(x => x.Should().BeTrue());
+        loaded.Skip(50).Select(x => x.FromArchive).Should().AllSatisfy(x => x.Should().BeFalse());
     }
 
     readonly Fixture                      _fixture = new();


### PR DESCRIPTION
Tiered reader returns events in wrong order, fixing it for 0.15