### PR TITLE
Fix #406 Postgres sample won't run correctly until second time around

### DIFF
--- a/samples/postgres/Bookings.Payments/Program.cs
+++ b/samples/postgres/Bookings.Payments/Program.cs
@@ -48,4 +48,5 @@ async Task InitialiseSchema(IHost webApplication) {
     var schema = store.Schema;
     var ds     = webApplication.Services.GetRequiredService<NpgsqlDataSource>();
     await schema.CreateSchema(ds, webApplication.Services.GetRequiredService<ILogger<Schema>>());
+    await ds.ReloadTypesAsync();
 }

--- a/samples/postgres/Bookings/Program.cs
+++ b/samples/postgres/Bookings/Program.cs
@@ -52,4 +52,5 @@ async Task InitialiseSchema(IHost webApplication) {
     var schema = store.Schema;
     var ds     = webApplication.Services.GetRequiredService<NpgsqlDataSource>();
     await schema.CreateSchema(ds, webApplication.Services.GetRequiredService<ILogger<Schema>>());
+    await ds.ReloadTypesAsync();
 }


### PR DESCRIPTION
`System.ArgumentException: A PostgreSQL type with the name 'bookings.stream_message' was not found in the current database info at Npgsql.Internal.NpgsqlDatabaseInfo.GetPostgresType(DataTypeName dataTypeName) `

This is caused by the Npgsql internal info cache not getting updated after initial database creation.  Previously, restarting the app a second time would work successfully because the info cache could see the user defined type for the booking.stream_message on the second run.  Simple fix is to force the info cache to reload after database initialization