### PR TITLE
Gaps handling for global subscriptions

### DIFF
--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionGapsDetectionBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionGapsDetectionBase.cs
@@ -1,0 +1,49 @@
+// Copyright (C) Eventuous HQ OÜ.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using DotNet.Testcontainers.Containers;
+using Eventuous.Subscriptions;
+using Eventuous.Subscriptions.Checkpoints;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+
+namespace Eventuous.Tests.Subscriptions.Base;
+
+public abstract class SubscriptionGapsDetectionBase<TContainer, TSubscription, TSubscriptionOptions, TCheckpointStore>(
+        SubscriptionFixtureBase<TContainer, TSubscription, TSubscriptionOptions, TCheckpointStore, TestEventHandler> fixture
+    ) : SubscriptionTestBase(fixture)
+    where TContainer : DockerContainer
+    where TSubscription : EventSubscription<TSubscriptionOptions>
+    where TSubscriptionOptions : SubscriptionOptions
+    where TCheckpointStore : class, ICheckpointStore {
+
+    protected async Task ShouldNotSkipEvents(CancellationToken cancellationToken) {
+        const int streamsCount    = 10;
+        const int eventsPerStream = 10;
+
+        await fixture.StartSubscription();
+        await AppendEventsConcurrently();
+
+        await fixture.Handler.AssertThat()
+            .Timebox(TimeSpan.FromSeconds(2))
+            .Exactly(streamsCount * eventsPerStream)
+            .Match(_ => true)
+            .Validate(cancellationToken);
+        await fixture.StopSubscription();
+
+        return;
+
+        Task AppendEventsConcurrently() {
+            var tasks = Enumerable.Range(0, streamsCount)
+                .Select(async streamIndex => {
+                        var streamName = new StreamName($"test-stream-{streamIndex}");
+                        var events     = fixture.CreateEvents(eventsPerStream).Cast<object>().ToArray();
+
+                        return await fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream);
+                    }
+                )
+                .ToArray();
+
+            return Task.WhenAll(tasks);
+        }
+    }
+}

--- a/src/Postgres/src/Eventuous.Postgresql/Eventuous.Postgresql.csproj
+++ b/src/Postgres/src/Eventuous.Postgresql/Eventuous.Postgresql.csproj
@@ -20,6 +20,7 @@
         <EmbeddedResource Include="Scripts\6_ReadStreamForwards.sql" />
         <EmbeddedResource Include="Scripts\7_ReadStreamSub.sql" />
         <EmbeddedResource Include="Scripts\8_TruncateStream.sql" />
+        <EmbeddedResource Include="Scripts\9_TryInsertTombstone.sql" />
     </ItemGroup>
     <ItemGroup>
         <Compile Include="$(CoreRoot)\Eventuous.Shared\Tools\TaskExtensions.cs">

--- a/src/Postgres/src/Eventuous.Postgresql/Schema.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Schema.cs
@@ -15,6 +15,8 @@ public class Schema(string schema = Schema.DefaultSchema) {
 
     public static string GetStreamMessageTypeName(string schema = DefaultSchema) => $"{schema}.stream_message";
 
+    public string Name => schema;
+
     public string StreamMessage       => GetStreamMessageTypeName(schema);
     public string AppendEvents        => $"select * from {schema}.append_events(@_stream_name, @_expected_version, @_created, @_messages)";
     public string ReadStreamForwards  => $"select * from {schema}.read_stream_forwards(@_stream_name, @_from_position, @_count)";

--- a/src/Postgres/src/Eventuous.Postgresql/Schema.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Schema.cs
@@ -29,6 +29,7 @@ public class Schema(string schema = Schema.DefaultSchema) {
     public string GetCheckpointSql    => $"select position from {schema}.checkpoints where id=(@checkpointId)";
     public string AddCheckpointSql    => $"insert into {schema}.checkpoints (id) values (@checkpointId)";
     public string UpdateCheckpointSql => $"update {schema}.checkpoints set position=(@position) where id=(@checkpointId)";
+    public string TryInsertTombstone  => $"select {schema}.try_insert_tombstone(@_gap_position, @_stream_name, @_type, @_id)";
 
     static readonly Assembly Assembly = typeof(Schema).Assembly;
 

--- a/src/Postgres/src/Eventuous.Postgresql/Scripts/2_AppendEvents.sql
+++ b/src/Postgres/src/Eventuous.Postgresql/Scripts/2_AppendEvents.sql
@@ -2,7 +2,8 @@ create or replace function __schema__.append_events(
     _stream_name varchar(1000),
     _expected_version integer,
     _created timestamp with time zone,
-    _messages __schema__.stream_message[]
+    _messages __schema__.stream_message[],
+    _enable_delay boolean default false
 )
 returns table (new_version integer, global_position bigint)
 as $$
@@ -31,7 +32,11 @@ begin
         where m.stream_id = _stream_id
         order by m.global_position desc limit 1;
     update __schema__.streams set version = _current_version where stream_id = _stream_id;
-    
+
+    if _enable_delay then
+        perform pg_sleep(random() * 0.1);
+    end if;
+
     return query select _current_version, _position;
 end;
 

--- a/src/Postgres/src/Eventuous.Postgresql/Scripts/9_TryInsertTombstone.sql
+++ b/src/Postgres/src/Eventuous.Postgresql/Scripts/9_TryInsertTombstone.sql
@@ -1,0 +1,33 @@
+create or replace function __schema__.try_insert_tombstone(
+    _gap_position bigint,
+    _stream_name text,
+    _message_type text,
+    _message_id uuid
+) returns void
+as $$
+declare sid int;
+        next_pos int;
+begin
+    -- Ensure stream exists
+    insert into __schema__.streams(stream_name, version)
+    values (_stream_name, -1)
+    on conflict (stream_name) do nothing;
+
+    select stream_id into sid from __schema__.streams where stream_name=_stream_name;
+
+    -- Allocate next stream position via atomic version bump
+    update __schema__.streams
+        set version = version + 1
+        where stream_id = sid
+        returning version into next_pos;
+
+    -- Attempt tombstone insert at the gap global position
+    insert into __schema__.messages(
+        message_id, message_type, stream_id, stream_position,
+        global_position, json_data, json_metadata, created
+    ) overriding system value
+    values (_message_id, _message_type, sid, next_pos, _gap_position, '{}'::jsonb, '{}'::jsonb, (now() at time zone 'utc'))
+    on conflict do nothing;
+end;
+
+$$ language 'plpgsql';

--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresSubscriptionBase.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresSubscriptionBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using Eventuous.Sql.Base.Subscriptions;
+using Eventuous.Sql.Base;
 using Eventuous.Subscriptions;
 using Eventuous.Subscriptions.Checkpoints;
 using Eventuous.Subscriptions.Filters;
@@ -46,6 +47,28 @@ public abstract class PostgresSubscriptionBase<T>(
 
     protected override string GetEndOfStream { get; } = $"select max(stream_position) from {options.Schema}.messages";
     protected override string GetEndOfAll    { get; } = $"select max(global_position) from {options.Schema}.messages";
+
+    protected override async ValueTask HandleGapTimeout(long gapPosition, long currentStart, CancellationToken cancellationToken) {
+        try {
+            await using var connection = await DataSource.OpenConnectionAsync(cancellationToken).NoContext();
+            await using var cmd        = new NpgsqlCommand(Schema.TryInsertTombstone, connection);
+            cmd.Parameters.AddWithValue("@_gap_position", gapPosition);
+            cmd.Parameters.AddWithValue("@_stream_name", PostgresSubscriptionConstants.TombstoneStream);
+            cmd.Parameters.AddWithValue("@_type", PostgresSubscriptionConstants.TombstoneMessageType);
+            cmd.Parameters.AddWithValue("@_id", Guid.NewGuid());
+            await cmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
+        } catch (PostgresException) {
+            // best-effort; ignore
+        }
+    }
+
+    protected override bool ShouldSkipEvent(PersistedEvent evt)
+        => evt.StreamName == PostgresSubscriptionConstants.TombstoneStream && evt.MessageType == PostgresSubscriptionConstants.TombstoneMessageType;
+}
+
+public static class PostgresSubscriptionConstants {
+    public const string TombstoneStream    = "__tombstones__";
+    public const string TombstoneMessageType = "$tombstone";
 }
 
 public abstract record PostgresSubscriptionBaseOptions : SqlSubscriptionOptionsBase {

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Projections/ProjectorTests.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Projections/ProjectorTests.cs
@@ -1,3 +1,4 @@
+using Eventuous.Postgresql;
 using Eventuous.Postgresql.Projections;
 using Eventuous.Postgresql.Subscriptions;
 using Eventuous.Sut.App;
@@ -10,7 +11,7 @@ using Assert = TUnit.Assertions.Assert;
 namespace Eventuous.Tests.Postgres.Projections;
 
 public class ProjectorTests() {
-    readonly SubscriptionFixture<PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestProjector> _fixture = new(_ => { });
+    readonly SubscriptionFixture<PostgresStore, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestProjector> _fixture = new(_ => { });
 
     const string Schema = """
                           create table if not exists __schema__.bookings (

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapIgnoreTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapIgnoreTest.cs
@@ -1,0 +1,48 @@
+// Copyright (C) Eventuous HQ OÜ.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class GapIgnoreTest() : SubscriptionTestBase(Fixture) {
+    static readonly TombstonesFixture Fixture = new(ConfigureOptions);
+
+    [Test]
+    public async Task ShouldIgnoreOldGaps(CancellationToken cancellationToken) {
+        var streamName = new StreamName("test-stream-gap-ignore");
+
+        await Fixture.AppendEvents(streamName, Fixture.CreateEvents(2).Cast<object>().ToArray(), ExpectedStreamVersion.NoStream);
+
+        // Create a gap that will become "old"
+        await Fixture.InsertGap(streamName, 1);
+
+        await Fixture.AppendEvents(streamName, Fixture.CreateEvents(3).Cast<object>().ToArray(), ExpectedStreamVersion.Any);
+
+        await Task.Delay(1000, cancellationToken);
+
+        // Start subscription - should ignore the old gap and process available events
+        await Fixture.StartSubscription();
+
+        // Should process all 5 events despite the gap at position 2
+        await Fixture.Handler.AssertThat()
+            .Timebox(TimeSpan.FromSeconds(10))
+            .Exactly(5)
+            .Match(_ => true)
+            .Validate(cancellationToken);
+
+        await Fixture.StopSubscription();
+
+        // Verify no tombstone were created since gap was ignored
+        var tombstonesCount = await Fixture.CountTombstones();
+        await Assert.That(tombstonesCount).IsEqualTo(0);
+    }
+
+    static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
+        options.GapHandlingTimeoutMs = 0; // try to create tombstone right away
+        options.GapAgeThresholdMs    = 500;
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscribeTests.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscribeTests.cs
@@ -1,3 +1,4 @@
+using Eventuous.Postgresql;
 using Eventuous.Postgresql.Subscriptions;
 using Eventuous.Tests.Subscriptions.Base;
 using Testcontainers.PostgreSql;
@@ -9,7 +10,7 @@ namespace Eventuous.Tests.Postgres.Subscriptions;
 [NotInParallel]
 public class SubscribeToAll()
     : SubscribeToAllBase<PostgreSqlContainer, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, PostgresCheckpointStore>(
-        new SubscriptionFixture<PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestEventHandler>(_ => { }, false)
+        new SubscriptionFixture<PostgresStore, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestEventHandler>(_ => { }, false)
     ) {
     [Test]
     public async Task Postgres_ShouldConsumeProducedEvents(CancellationToken cancellationToken) {
@@ -32,7 +33,7 @@ public class SubscribeToAll()
 public class SubscribeToStream(StreamNameFixture streamNameFixture)
     : SubscribeToStreamBase<PostgreSqlContainer, PostgresStreamSubscription, PostgresStreamSubscriptionOptions, PostgresCheckpointStore>(
         streamNameFixture.StreamName,
-        new SubscriptionFixture<PostgresStreamSubscription, PostgresStreamSubscriptionOptions, TestEventHandler>(
+        new SubscriptionFixture<PostgresStore, PostgresStreamSubscription, PostgresStreamSubscriptionOptions, TestEventHandler>(
             opt => ConfigureOptions(opt, streamNameFixture),
             false
         )

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionFixture.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionFixture.cs
@@ -9,13 +9,14 @@ using Testcontainers.PostgreSql;
 
 namespace Eventuous.Tests.Postgres.Subscriptions;
 
-public class SubscriptionFixture<TSubscription, TSubscriptionOptions, TEventHandler>(
+public class SubscriptionFixture<TEventStore, TSubscription, TSubscriptionOptions, TEventHandler>(
         Action<TSubscriptionOptions> configureOptions,
         bool                         autoStart         = true,
         Action<IServiceCollection>?  configureServices = null,
         LogLevel                     logLevel          = LogLevel.Information
     )
     : SubscriptionFixtureBase<PostgreSqlContainer, TSubscription, TSubscriptionOptions, PostgresCheckpointStore, TEventHandler>(autoStart, logLevel)
+    where TEventStore : PostgresStore
     where TSubscription : PostgresSubscriptionBase<TSubscriptionOptions>
     where TSubscriptionOptions : PostgresSubscriptionBaseOptions
     where TEventHandler : class, IEventHandler {
@@ -34,7 +35,7 @@ public class SubscriptionFixture<TSubscription, TSubscriptionOptions, TEventHand
         base.SetupServices(services);
         services.AddSingleton(new SchemaInfo(SchemaName));
         services.AddEventuousPostgres(Container.GetConnectionString(), SchemaName, true);
-        services.AddEventStore<PostgresStore>();
+        services.AddEventStore<TEventStore>();
         services.AddSingleton(new TestEventHandlerOptions());
         services.AddPostgresCheckpointStore();
         configureServices?.Invoke(services);

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionGapsDetection.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionGapsDetection.cs
@@ -1,0 +1,41 @@
+// Copyright (C) Eventuous HQ OÜ.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using System.Data.Common;
+using Eventuous.Postgresql;
+using Eventuous.Postgresql.Extensions;
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Sql.Base;
+using Eventuous.Tests.Subscriptions.Base;
+using Npgsql;
+using NpgsqlTypes;
+using Testcontainers.PostgreSql;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class SubscriptionGapsDetection()
+    : SubscriptionGapsDetectionBase<PostgreSqlContainer, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, PostgresCheckpointStore>(
+        new SubscriptionFixture<DelayedPostgresStore, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestEventHandler>(ConfigureOptions, false)
+    ) {
+    [Test]
+    public async Task Postgres_ShouldNotSkipEvents(CancellationToken cancellationToken) {
+        await ShouldNotSkipEvents(cancellationToken);
+    }
+
+    static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
+        options.Polling.MinIntervalMs = 0;
+        options.Polling.MaxIntervalMs = 0;
+    }
+
+    internal class DelayedPostgresStore(NpgsqlDataSource dataSource, PostgresStoreOptions? options, IEventSerializer? serializer = null, IMetadataSerializer? metaSerializer = null)
+        : PostgresStore(dataSource, options, serializer, metaSerializer) {
+        protected override DbCommand GetAppendCommand(NpgsqlConnection connection, NpgsqlTransaction transaction, StreamName stream, ExpectedStreamVersion expectedVersion, NewPersistedEvent[] events)
+            => connection.GetCommand($"select * from {Schema.Name}.append_events(@_stream_name, @_expected_version, @_created, @_messages, @_enable_delay)", transaction)
+                .Add("_stream_name", NpgsqlDbType.Varchar, stream.ToString())
+                .Add("_expected_version", NpgsqlDbType.Integer, expectedVersion.Value)
+                .Add("_created", DateTime.UtcNow)
+                .Add("_messages", events)
+                .Add("_enable_delay", true);
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/TombstonesCreationTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/TombstonesCreationTest.cs
@@ -1,0 +1,50 @@
+// Copyright (C) Eventuous HQ OÜ.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class TombstonesCreationTest() : SubscriptionTestBase(Fixture) {
+    static readonly TombstonesFixture Fixture = new(ConfigureOptions);
+
+    [Test]
+    public async Task ShouldCreateTombstones(CancellationToken cancellationToken) {
+        var streamName = new StreamName($"test-stream");
+
+        // create 2 events
+        await Fixture.AppendEvents(streamName, Fixture.CreateEvents(2).Cast<object>().ToArray(), ExpectedStreamVersion.NoStream);
+
+        // create gap
+        await Fixture.InsertGap(streamName, 1);
+
+        // create other 2 events
+        await Fixture.AppendEvents(streamName, Fixture.CreateEvents(2).Cast<object>().ToArray(), ExpectedStreamVersion.Any);
+
+        // create gaps
+        await Fixture.InsertGap(streamName, 3);
+        await Fixture.InsertGap(streamName, 3);
+
+        // create other 2 events
+        await Fixture.AppendEvents(streamName, Fixture.CreateEvents(2).Cast<object>().ToArray(), ExpectedStreamVersion.Any);
+
+        await Fixture.StartSubscription();
+
+        await Fixture.Handler.AssertThat()
+            .Timebox(TimeSpan.FromSeconds(5))
+            .Exactly(6)
+            .Match(_ => true)
+            .Validate(cancellationToken);
+        await Fixture.StopSubscription();
+
+        var tombstonesCount = await Fixture.CountTombstones();
+        await Assert.That(tombstonesCount).IsEqualTo(3);
+    }
+
+    static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
+        options.GapHandlingTimeoutMs = 500;
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/TombstonesFixture.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/TombstonesFixture.cs
@@ -1,0 +1,43 @@
+// Copyright (C) Eventuous HQ OÜ.All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Eventuous.Postgresql;
+using Eventuous.Postgresql.Extensions;
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Sql.Base;
+using Eventuous.Tests.Subscriptions.Base;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+public class TombstonesFixture(
+        Action<PostgresAllStreamSubscriptionOptions> configureOptions
+    )
+    : SubscriptionFixture<PostgresStore, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestEventHandler>(configureOptions, false) {
+    protected internal new TestEventHandler Handler => base.Handler;
+    protected internal new ValueTask StartSubscription() => base.StartSubscription();
+    protected internal new ValueTask StopSubscription() => base.StopSubscription();
+
+    public async Task InsertGap(StreamName streamName, int expectedVersion) {
+        await using var conn = await DataSource.OpenConnectionAsync();
+        await using var tx   = await conn.BeginTransactionAsync();
+
+        var appendCmd = conn.GetCommand($"select * from {SchemaName}.append_events(@_stream_name, @_expected_version, @_created, @_messages, @_enable_delay)", tx)
+            .Add("_stream_name", NpgsqlTypes.NpgsqlDbType.Varchar, streamName.ToString())
+            .Add("_expected_version", NpgsqlTypes.NpgsqlDbType.Integer, expectedVersion)
+            .Add("_created", DateTime.UtcNow)
+            .Add("_messages", new[] { new NewPersistedEvent(Guid.NewGuid(), "GapTemp", "{}", null) })
+            .Add("_enable_delay", false);
+        await appendCmd.ExecuteNonQueryAsync();
+        await tx.RollbackAsync(); // leaves a gap in global_position sequence
+    }
+
+    public async Task<long> CountTombstones() {
+        await using var conn = await DataSource.OpenConnectionAsync();
+
+        var cmd = conn.GetCommand($"select count(1) from {SchemaName}.messages where message_type = @_message_type")
+            .Add("_message_type", PostgresSubscriptionConstants.TombstoneMessageType);
+        var result = await cmd.ExecuteScalarAsync();
+
+        return result is DBNull ? 0 : (long)result!;
+    }
+}

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
@@ -74,8 +74,12 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
 
     // ReSharper disable once CognitiveComplexity
 
+    private record DetectedGap(long Position, DateTime FirstSeen);
+
     async Task PollingQuery(ulong? position, CancellationToken cancellationToken) {
         var start = position.HasValue ? (long)position : -1;
+
+        DetectedGap? gap = null;
 
         var retryCount   = 0;
         var currentDelay = Options.Polling.MinIntervalMs;
@@ -99,12 +103,34 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
                 var received = 0;
 
                 await foreach (var persistedEvent in result.NoContext(cancellationToken)) {
-                    await HandleInternal(ToConsumeContext(persistedEvent, cancellationToken)).NoContext();
+                    // For All subscriptions we need to ensure we don't skip not-yet-committed events from other concurrent transactions.
+                    // If we observe a gap in the global position sequence, we stop processing further events in this poll cycle
+                    // and will retry on the next poll. This prevents advancing the checkpoint beyond an uncommitted (invisible) row.
+                    if (Kind == SubscriptionKind.All) {
+                        gap = DetectGap(start, persistedEvent, gap);
+
+                        if (gap != null)
+                            break;
+                    }
+
+                    if (!ShouldSkipEvent(persistedEvent)) {
+                        await HandleInternal(ToConsumeContext(persistedEvent, cancellationToken)).NoContext();
+                    }
+
                     start = MoveStart(persistedEvent);
                     received++;
                 }
 
-                return new PollingResult(true, false, received);
+                // If a gap persists beyond timeout, attempt provider-specific remediation (e.g. tombstone insert).
+                if (Kind == SubscriptionKind.All && gap != null && Options.GapHandlingTimeoutMs != null) {
+                    var gapAge = DateTime.UtcNow - gap.FirstSeen;
+
+                    if (gapAge.TotalMilliseconds >= Options.GapHandlingTimeoutMs.Value) {
+                        await HandleGapTimeout(gap.Position, start, cancellationToken).NoContext();
+                    }
+                }
+
+                return new(true, gap != null, received);
             } catch (Exception e) {
                 if (IsStopping(e)) {
                     IsDropped = true;
@@ -149,6 +175,26 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
                 await Task.Delay(currentDelay, cancellationToken).NoContext();
             }
         }
+    }
+
+    DetectedGap? DetectGap(long start, PersistedEvent persistedEvent, DetectedGap? previousGap) {
+        var expectedNext = start < 0 ? 1 : start + 1; // global position identity starts at 1
+
+        if (persistedEvent.GlobalPosition > expectedNext) {
+            if (previousGap != null) {
+                if (Options.GapSkipTimeoutMs == null || (DateTime.UtcNow - previousGap.FirstSeen) < TimeSpan.FromMilliseconds(Options.GapSkipTimeoutMs.Value)) {
+                    return previousGap;
+                }
+            }
+
+            var newGapAge = DateTime.UtcNow - persistedEvent.Created;
+
+            if (Options.GapAgeThresholdMs == null || newGapAge.TotalMilliseconds < Options.GapAgeThresholdMs.Value) {
+                return new(expectedNext, DateTime.UtcNow);
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -233,6 +279,25 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
     TaskRunner? _runner;
 
     const string ContentType = "application/json";
+
+    /// <summary>
+    /// Provider-specific hook: attempt to resolve a persistent gap (e.g. insert tombstone rows).
+    /// Base implementation does nothing. Implementations should be idempotent; this method may be called repeatedly
+    /// until the gap is naturally filled by the original row becoming visible or by a remedial action (like tombstone insertion).
+    /// </summary>
+    /// <param name="gapPosition">The missing global position</param>
+    /// <param name="currentStart">Current start pointer</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected virtual ValueTask HandleGapTimeout(long gapPosition, long currentStart, CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+    /// <summary>
+    /// Determine if the event should be skipped instead of dispatched to user handlers.
+    /// Base implementation returns false; providers can override.
+    /// </summary>
+    /// <param name="evt"></param>
+    /// <returns></returns>
+    protected virtual bool ShouldSkipEvent(PersistedEvent evt) => false;
 
     [StructLayout(LayoutKind.Auto)]
     readonly record struct PollingResult(bool Continue, bool Retry, int ReceivedEvents);

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionOptionsBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionOptionsBase.cs
@@ -31,6 +31,26 @@ public abstract record SqlSubscriptionOptionsBase : SubscriptionWithCheckpointOp
     public RetryOptions Retry { get; set; } = new();
 
     /// <summary>
+    /// Gap age threshold in milliseconds. If != null, gaps older than this threshold will be ignored entirely,
+    /// allowing the subscription to skip past old missing positions. This is useful for scenarios where
+    /// old tombstones may have been deleted and should not be recreated during replay. Default is 1 hour.
+    /// </summary>
+    public int? GapAgeThresholdMs { get; set; } = 60 * 60 * 1000;
+
+    /// <summary>
+    /// Gap skip timeout in milliseconds. If != null, a detected gap will only hold the subscription from
+    /// advancing for this duration. Default value is 5 sec.
+    /// </summary>
+    public int? GapSkipTimeoutMs { get; set; } = 5000;
+
+    /// <summary>
+    /// Gap handling timeout in milliseconds. If != null, when a gap in the global position sequence is detected
+    /// and it persists for at least this duration, the subscription will attempt to handle it in a provider-specific
+    /// way (e.g. creating tombstones). Default is null (don't create tombstones).
+    /// </summary>
+    public int? GapHandlingTimeoutMs { get; set; }
+
+    /// <summary>
     /// Options for polling.
     /// </summary>
     public record PollingOptions {


### PR DESCRIPTION
This is intended to solve #222.

Added gap detection and tombstone creation for PostgreSQL subscriptions:

#### Gap Detection:

- Monitors sequential global positions during polling
- Detects when next event position > expected (start + 1)
- Configurable timeouts to avoid indefinite blocking

#### Optional tombstones creation:

- Creates placeholder events at gap positions using `try_insert_tombstone` SQL function
- Inserts into special `__tombstones__` stream with `$tombstone` message type
- Automatically filtered out from user handlers

#### Configuration Options:

- GapAgeThresholdMs: Ignore old gaps (default: 1 hour)
- GapSkipTimeoutMs: Max wait time for gaps (default: 5 seconds)
- GapHandlingTimeoutMs: When to create tombstones (default: disabled)

#### Benefits

- Prevents event skipping in high-concurrency scenarios
- Configurable and backward compatible (opt-in)
