### PR TITLE
mssql improvements, code clean up and fix issue 428

### DIFF
--- a/src/Postgres/src/Eventuous.Postgresql/Scripts/6_ReadStreamForwards.sql
+++ b/src/Postgres/src/Eventuous.Postgresql/Scripts/6_ReadStreamForwards.sql
@@ -33,7 +33,7 @@ begin
                         m.json_data, m.json_metadata, m.created
         from __schema__.messages m 
         where m.stream_id = _stream_id and m.stream_position >= _from_position
-        order by m.global_position
+        order by m.stream_position
         limit _count;
 end;
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -27,7 +27,7 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             GlobalPosition BIGINT IDENTITY (0,1) NOT NULL,
             JsonData       NVARCHAR(MAX)         NOT NULL,
             JsonMetadata   NVARCHAR(MAX)             NULL,
-            Created        DATETIME2                 NULL,
+            Created        DATETIME2             NOT NULL,
             CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition),
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -10,7 +10,7 @@ IF OBJECT_ID('__schema__.Streams', 'U') IS NULL
             StreamId   INT IDENTITY (1,1) NOT NULL,
             StreamName NVARCHAR(850)      NOT NULL,
             [Version]  INT DEFAULT (-1)   NOT NULL,
-            CONSTRAINT PK_Streams PRIMARY KEY CLUSTERED (StreamId),
+            CONSTRAINT PK_Streams PRIMARY KEY CLUSTERED (StreamId) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON),
             CONSTRAINT UQ_StreamName UNIQUE NONCLUSTERED (StreamName),
             CONSTRAINT CK_VersionGteNegativeOne CHECK ([Version] >= -1)
         );
@@ -28,7 +28,7 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             JsonData       NVARCHAR(MAX)         NOT NULL,
             JsonMetadata   NVARCHAR(MAX)         NOT NULL,
             Created        DATETIME2(7)          NOT NULL,
-            CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition),
+            CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition) WITH (OPTIMIZE_FOR_SEQUENTIAL_KEY = ON),
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),
             CONSTRAINT UQ_StreamIdAndMessageId UNIQUE NONCLUSTERED (StreamId, MessageId),

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -26,13 +26,15 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             StreamPosition INT                   NOT NULL,
             GlobalPosition BIGINT IDENTITY (0,1) NOT NULL,
             JsonData       NVARCHAR(MAX)         NOT NULL,
-            JsonMetadata   NVARCHAR(MAX)             NULL,
+            JsonMetadata   NVARCHAR(MAX)         NOT NULL,
             Created        DATETIME2             NOT NULL,
             CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition),
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),
             CONSTRAINT UQ_StreamIdAndMessageId UNIQUE NONCLUSTERED (StreamId, MessageId),
             CONSTRAINT CK_StreamPositionGteZero CHECK (Messages.StreamPosition >= 0),
+            CONSTRAINT CK_JsonDataIsJson CHECK (ISJSON(JsonData) = 1),
+            CONSTRAINT CK_JsonMetadataIsJson CHECK (ISJSON(JsonMetadata) = 1),
             INDEX IDX_EventsStream (StreamId)
         );
     END
@@ -54,7 +56,6 @@ IF TYPE_ID('__schema__.StreamMessage') IS NULL
             message_id    UNIQUEIDENTIFIER NOT NULL,
             message_type  NVARCHAR(128)    NOT NULL,
             json_data     NVARCHAR(MAX)    NOT NULL,
-            json_metadata NVARCHAR(MAX)        NULL
+            json_metadata NVARCHAR(MAX)    NOT NULL
         )
     END
-

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -27,7 +27,7 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             GlobalPosition BIGINT IDENTITY (0,1) NOT NULL,
             JsonData       NVARCHAR(MAX)         NOT NULL,
             JsonMetadata   NVARCHAR(MAX)         NOT NULL,
-            Created        DATETIME2             NOT NULL,
+            Created        DATETIME2(7)          NOT NULL,
             CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition),
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -12,7 +12,7 @@ IF OBJECT_ID('__schema__.Streams', 'U') IS NULL
             [Version]  INT DEFAULT (-1)   NOT NULL,
             CONSTRAINT PK_Streams PRIMARY KEY CLUSTERED (StreamId),
             CONSTRAINT UQ_StreamName UNIQUE NONCLUSTERED (StreamName),
-            CONSTRAINT CK_VersionGteNegativeOne CHECK ([version] >= -1)
+            CONSTRAINT CK_VersionGteNegativeOne CHECK ([Version] >= -1)
         );
     END
 
@@ -25,9 +25,9 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             StreamId       INT                   NOT NULL,
             StreamPosition INT                   NOT NULL,
             GlobalPosition BIGINT IDENTITY (0,1) NOT NULL,
-            JsonData       NVARCHAR(max)         NOT NULL,
-            JsonMetadata   NVARCHAR(max),
-            Created        DATETIME2,
+            JsonData       NVARCHAR(MAX)         NOT NULL,
+            JsonMetadata   NVARCHAR(MAX)             NULL,
+            Created        DATETIME2                 NULL,
             CONSTRAINT PK_Events PRIMARY KEY CLUSTERED (GlobalPosition),
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),
@@ -42,7 +42,7 @@ IF OBJECT_ID('__schema__.Checkpoints', 'U') IS NULL
         CREATE TABLE __schema__.Checkpoints
         (
             Id       NVARCHAR(128) NOT NULL,
-            Position BIGINT        NULL,
+            Position BIGINT            NULL,
             CONSTRAINT PK_Checkpoints PRIMARY KEY CLUSTERED (Id),
         );
     END
@@ -53,8 +53,8 @@ IF TYPE_ID('__schema__.StreamMessage') IS NULL
         (
             message_id    UNIQUEIDENTIFIER NOT NULL,
             message_type  NVARCHAR(128)    NOT NULL,
-            json_data     NVARCHAR(max)    NOT NULL,
-            json_metadata NVARCHAR(max)
+            json_data     NVARCHAR(MAX)    NOT NULL,
+            json_metadata NVARCHAR(MAX)        NULL
         )
     END
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/1_Schema.sql
@@ -32,7 +32,7 @@ IF OBJECT_ID('__schema__.Messages', 'U') IS NULL
             CONSTRAINT FK_MessageStreamId FOREIGN KEY (StreamId) REFERENCES __schema__.Streams (StreamId),
             CONSTRAINT UQ_StreamIdAndStreamPosition UNIQUE NONCLUSTERED (StreamId, StreamPosition),
             CONSTRAINT UQ_StreamIdAndMessageId UNIQUE NONCLUSTERED (StreamId, MessageId),
-            CONSTRAINT CK_StreamPositionGteZero CHECK (Messages.StreamPosition >= 0),
+            CONSTRAINT CK_StreamPositionGteZero CHECK (StreamPosition >= 0),
             CONSTRAINT CK_JsonDataIsJson CHECK (ISJSON(JsonData) = 1),
             CONSTRAINT CK_JsonMetadataIsJson CHECK (ISJSON(JsonMetadata) = 1),
             INDEX IDX_EventsStream (StreamId)

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -1,5 +1,5 @@
 CREATE OR ALTER PROCEDURE __schema__.append_events
-    @stream_name VARCHAR(850),
+    @stream_name NVARCHAR(850),
     @expected_version INT,
     @created DATETIME2(7) NULL,
     @messages __schema__.StreamMessage READONLY
@@ -7,24 +7,36 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
+    -- Note: This procedure is wrapped in a transaction by the caller. This explains why there is no explicit transaction here within the procedure.
+
     DECLARE
         @current_version INT,
         @stream_id INT,
         @position BIGINT,
-        @customErrorMessage NVARCHAR(200);
+        @count_messages INT,
+        @new_version INT;
 
-    IF @created IS NULL
-        BEGIN
-            SET @created = SYSUTCDATETIME();
-        END
+    -- capture inserted rows to compute final position
+    DECLARE @inserted TABLE (
+        GlobalPosition BIGINT
+    );
 
-    EXEC [__schema__].check_stream
+    SELECT @count_messages = COUNT(1) FROM @messages;
+
+    EXEC __schema__.check_stream
         @stream_name      = @stream_name,
         @expected_version = @expected_version,
         @current_version  = @current_version OUTPUT,
         @stream_id        = @stream_id OUTPUT;
 
+    SET @new_version = @current_version + @count_messages;
+
     BEGIN TRY
+
+        /*
+            If another writer raced us, the unique constraint (StreamId,StreamPosition) will throw here.
+            Translate to WrongExpectedVersion in the CATCH below.
+        */
         INSERT INTO __schema__.Messages (
             MessageId,
             MessageType,
@@ -34,25 +46,35 @@ BEGIN
             JsonMetadata,
             Created
         )
+        OUTPUT inserted.GlobalPosition
+        INTO @inserted (GlobalPosition)
         SELECT
             message_id,
             message_type,
             @stream_id,
-            @current_version + (ROW_NUMBER() OVER(ORDER BY (SELECT NULL))),
+            @current_version + CAST(ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS INT),
             json_data,
             json_metadata,
-            @created
-        FROM @messages
+            ISNULL(@created, SYSUTCDATETIME())
+        FROM @messages;
     END TRY
     BEGIN CATCH
-        IF (ERROR_NUMBER() = 2627 OR ERROR_NUMBER() = 2601) AND (SELECT CHARINDEX(N'UQ_StreamIdAndStreamPosition', ERROR_MESSAGE())) > 0
-            BEGIN
-                DECLARE @streamIdFromError NVARCHAR(20) = SUBSTRING(ERROR_MESSAGE(), PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()), PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) - PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()))
-                DECLARE @streamPositionFromError NVARCHAR(20) = SUBSTRING(ERROR_MESSAGE(), (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE())) + 2, PATINDEX(N'%).', ERROR_MESSAGE()) - (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) + 2))
+        DECLARE @errmsg NVARCHAR(2048) = ERROR_MESSAGE();
 
-                -- TODO: There are multiple causes of OptimisticConcurrencyExceptions, but current client code is hard-coded to check for 'WrongExpectedVersion' in message and 50000 as error number.
-                SELECT @customErrorMessage = FORMATMESSAGE(N'WrongExpectedVersion, another message has already been written at stream position %s on stream %s.', @streamIdFromError, @streamPositionFromError);
-                THROW 50000, @customErrorMessage, 1;
+        IF ERROR_NUMBER() IN (
+            2627, -- Violation of PRIMARY KEY or UNIQUE constraint
+            2601  -- Cannot insert duplicate key row in object with unique index
+        )
+        AND (@errmsg LIKE N'%UQ_StreamIdAndStreamPosition%')
+            BEGIN
+                -- Must BEGIN with "WrongExpectedVersion" for the client detection of OptimisticConcurrencyException
+                DECLARE @clientMsg NVARCHAR(4000) =
+                    N'WrongExpectedVersion: duplicate append for stream '
+                    + CAST(@stream_id AS NVARCHAR(20))
+                    + N' with expected_version=' + CAST(@expected_version AS NVARCHAR(20))
+                    + N'. SQL: ' + @errmsg;
+
+                THROW 50000, @clientMsg, 1;
             END;
         ELSE
         BEGIN
@@ -60,19 +82,19 @@ BEGIN
         END;
     END CATCH;
 
-    SELECT TOP (1)
-        @current_version = StreamPosition,
-        @position = GlobalPosition
-    FROM __schema__.Messages
-    WHERE StreamId = @stream_id
-    ORDER BY GlobalPosition DESC;
-
     UPDATE s
-    SET [Version] = @current_version
+    SET [Version] = @new_version
     FROM __schema__.Streams s
-    WHERE s.StreamId = @stream_id;
+    WHERE s.StreamId = @stream_id
+    AND s.[Version] = @current_version;
+
+    -- final GlobalPosition value to return
+    SELECT @position = (
+        SELECT MAX(GlobalPosition)
+        FROM @inserted
+    );
 
     SELECT
-        @current_version current_version,
+        @new_version current_version,
         @position position;
 END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -6,6 +6,7 @@ CREATE OR ALTER PROCEDURE __schema__.append_events
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     -- Note: This procedure is wrapped in a transaction by the caller. This explains why there is no explicit transaction here within the procedure.
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -58,6 +58,22 @@ BEGIN
             json_metadata,
             ISNULL(@created, SYSUTCDATETIME())
         FROM @messages;
+
+        UPDATE s
+        SET [Version] = @new_version
+        FROM __schema__.Streams s
+        WHERE s.StreamId = @stream_id
+        AND s.[Version] = @current_version;
+
+        IF @@ROWCOUNT = 0
+        BEGIN
+            DECLARE @streamUpdateErrorMessage NVARCHAR(4000) = CONCAT(
+                N'WrongExpectedVersion: concurrent update detected for stream ',
+                CAST(@stream_id AS NVARCHAR(20))
+            );
+            ;THROW 50000, @streamUpdateErrorMessage, 1;
+        END
+
     END TRY
     BEGIN CATCH
         DECLARE @errmsg NVARCHAR(2048) = ERROR_MESSAGE();
@@ -82,12 +98,6 @@ BEGIN
             ;THROW;
         END;
     END CATCH;
-
-    UPDATE s
-    SET [Version] = @new_version
-    FROM __schema__.Streams s
-    WHERE s.StreamId = @stream_id
-    AND s.[Version] = @current_version;
 
     -- final GlobalPosition value to return
     SELECT @position = (

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -1,7 +1,7 @@
 CREATE OR ALTER PROCEDURE __schema__.append_events
     @stream_name VARCHAR(850),
     @expected_version INT,
-    @created DATETIME2 NULL,
+    @created DATETIME2(7) NULL,
     @messages __schema__.StreamMessage READONLY
 AS
 BEGIN

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -5,46 +5,74 @@ CREATE OR ALTER PROCEDURE __schema__.append_events
     @messages __schema__.StreamMessage READONLY
 AS
 BEGIN
-    DECLARE @current_version INT,
+    SET NOCOUNT ON;
+
+    DECLARE
+        @current_version INT,
         @stream_id INT,
         @position BIGINT,
-        @customErrorMessage NVARCHAR(200),
-        @newMessagesCount INT,
-        @expected_StreamVersionAfterUpdate INT,
-        @actual_StreamVersionAfterUpdate INT
+        @customErrorMessage NVARCHAR(200);
 
-    if @created is null
+    IF @created IS NULL
         BEGIN
-            SET @created = SYSUTCDATETIME()
+            SET @created = SYSUTCDATETIME();
         END
 
-    EXEC [__schema__].[check_stream] @stream_name, @expected_version, @current_version = @current_version OUTPUT, @stream_id = @stream_id OUTPUT
+    EXEC [__schema__].check_stream
+        @stream_name      = @stream_name,
+        @expected_version = @expected_version,
+        @current_version  = @current_version OUTPUT,
+        @stream_id        = @stream_id OUTPUT;
 
     BEGIN TRY
-        INSERT INTO __schema__.Messages (MessageId, MessageType, StreamId, StreamPosition, JsonData, JsonMetadata, Created)
-        SELECT message_id, message_type, @stream_id, @current_version + (ROW_NUMBER() OVER(ORDER BY (SELECT NULL))), json_data, json_metadata, @created
+        INSERT INTO __schema__.Messages (
+            MessageId,
+            MessageType,
+            StreamId,
+            StreamPosition,
+            JsonData,
+            JsonMetadata,
+            Created
+        )
+        SELECT
+            message_id,
+            message_type,
+            @stream_id,
+            @current_version + (ROW_NUMBER() OVER(ORDER BY (SELECT NULL))),
+            json_data,
+            json_metadata,
+            @created
         FROM @messages
     END TRY
     BEGIN CATCH
         IF (ERROR_NUMBER() = 2627 OR ERROR_NUMBER() = 2601) AND (SELECT CHARINDEX(N'UQ_StreamIdAndStreamPosition', ERROR_MESSAGE())) > 0
             BEGIN
-                DECLARE @streamIdFromError nvarchar(20) = SUBSTRING(ERROR_MESSAGE(), PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()), PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) - PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()))
-                DECLARE @streamPositionFromError nvarchar(20) = SUBSTRING(ERROR_MESSAGE(), (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE())) + 2, PATINDEX(N'%).', ERROR_MESSAGE()) - (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) + 2))
+                DECLARE @streamIdFromError NVARCHAR(20) = SUBSTRING(ERROR_MESSAGE(), PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()), PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) - PATINDEX(N'%[0-9]%,%', ERROR_MESSAGE()))
+                DECLARE @streamPositionFromError NVARCHAR(20) = SUBSTRING(ERROR_MESSAGE(), (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE())) + 2, PATINDEX(N'%).', ERROR_MESSAGE()) - (PATINDEX(N'%, [0-9]%).', ERROR_MESSAGE()) + 2))
 
                 -- TODO: There are multiple causes of OptimisticConcurrencyExceptions, but current client code is hard-coded to check for 'WrongExpectedVersion' in message and 50000 as error number.
                 SELECT @customErrorMessage = FORMATMESSAGE(N'WrongExpectedVersion, another message has already been written at stream position %s on stream %s.', @streamIdFromError, @streamPositionFromError);
                 THROW 50000, @customErrorMessage, 1;
-            END
+            END;
         ELSE
-            THROW
-    END CATCH
-    
-    SELECT TOP 1 @current_version =  StreamPosition, @position = GlobalPosition
-    FROM __schema__.Messages
+        BEGIN
+            ;THROW;
+        END;
+    END CATCH;
+
+    SELECT TOP (1)
+        @current_version = StreamPosition,
+        @position = GlobalPosition
+    FROM __schema__.[Messages]
     WHERE StreamId = @stream_id
-    ORDER BY GlobalPosition DESC
+    ORDER BY GlobalPosition DESC;
 
-    UPDATE __schema__.Streams SET Version = @current_version WHERE StreamId = @stream_id
+    UPDATE s
+    SET [Version] = @current_version
+    FROM __schema__.Streams s
+    WHERE s.StreamId = @stream_id;
 
-    SELECT @current_version AS current_version, @position AS position
-END
+    SELECT
+        @current_version current_version,
+        @position position;
+END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/2_AppendEvents.sql
@@ -63,7 +63,7 @@ BEGIN
     SELECT TOP (1)
         @current_version = StreamPosition,
         @position = GlobalPosition
-    FROM __schema__.[Messages]
+    FROM __schema__.Messages
     WHERE StreamId = @stream_id
     ORDER BY GlobalPosition DESC;
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/3_CheckStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/3_CheckStream.sql
@@ -6,6 +6,7 @@ CREATE OR ALTER PROCEDURE __schema__.check_stream
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     DECLARE @customErrorMessage NVARCHAR(200);
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/3_CheckStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/3_CheckStream.sql
@@ -22,19 +22,16 @@ BEGIN
                 OR @expected_version = -1 -- NoStream
                 BEGIN
                     BEGIN TRY
+                        SET @current_version = -1
                         INSERT INTO [__schema__].Streams (
                             StreamName,
                             [Version]
                         ) VALUES (
                             @stream_name,
-                            -1
+                            @current_version
                         );
 
-                        SELECT
-                            @current_version = [Version],
-                            @stream_id = StreamId
-                        FROM [__schema__].Streams
-                        WHERE StreamName = @stream_name;
+                        SET @stream_id = SCOPE_IDENTITY();
                     END TRY
                     BEGIN CATCH
                         IF (ERROR_NUMBER() = 2627 OR ERROR_NUMBER() = 2601) AND (SELECT CHARINDEX(N'UQ_StreamName', ERROR_MESSAGE())) > 0

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/3_CheckStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/3_CheckStream.sql
@@ -1,43 +1,63 @@
-CREATE OR ALTER PROCEDURE __schema__.check_stream @stream_name NVARCHAR(850),
-                                                  @expected_version int,
-                                                  @current_version INT OUTPUT,
-                                                  @stream_id INT OUTPUT
+CREATE OR ALTER PROCEDURE __schema__.check_stream
+    @stream_name NVARCHAR(850),
+    @expected_version INT,
+    @current_version INT OUTPUT,
+    @stream_id INT OUTPUT
 AS
 BEGIN
-    DECLARE @customErrorMessage NVARCHAR(200)
+    SET NOCOUNT ON;
 
-    SELECT @current_version = [Version], @stream_id = StreamId
+    DECLARE @customErrorMessage NVARCHAR(200);
+
+    SELECT
+        @current_version = [Version],
+        @stream_id = StreamId
     FROM [__schema__].Streams
-    WHERE StreamName = @stream_name
+    WHERE StreamName = @stream_name;
 
-    IF @stream_id is null
+    IF @stream_id IS NULL
         BEGIN
             IF @expected_version = -2 -- Any
                 OR @expected_version = -1 -- NoStream
                 BEGIN
                     BEGIN TRY
-                        INSERT INTO [__schema__].Streams (StreamName, Version) VALUES (@stream_name, -1);
-                        SELECT @current_version = Version, @stream_id = StreamId
+                        INSERT INTO [__schema__].Streams (
+                            StreamName,
+                            [Version]
+                        ) VALUES (
+                            @stream_name,
+                            -1
+                        );
+
+                        SELECT
+                            @current_version = [Version],
+                            @stream_id = StreamId
                         FROM [__schema__].Streams
-                        WHERE StreamName = @stream_name
+                        WHERE StreamName = @stream_name;
                     END TRY
                     BEGIN CATCH
                         IF (ERROR_NUMBER() = 2627 OR ERROR_NUMBER() = 2601) AND (SELECT CHARINDEX(N'UQ_StreamName', ERROR_MESSAGE())) > 0
                             BEGIN
                                 SELECT @customErrorMessage = FORMATMESSAGE(N'WrongExpectedVersion %i, stream already exists', @expected_version);
                                 THROW 50000, @customErrorMessage, 1;
-                            END
+                            END;
                         ELSE
-                            THROW
-                    END CATCH
-                END
+                        BEGIN
+                            ;THROW;
+                        END;
+                    END CATCH;
+                END;
             ELSE
-                THROW 50001, N'StreamNotFound', 1;
+            BEGIN
+                ;THROW 50001, N'StreamNotFound', 1;
+            END;
         END
     ELSE
-        IF @expected_version != -2 and @expected_version != @current_version
+    BEGIN
+        IF @expected_version != -2 AND @expected_version != @current_version
             BEGIN
                 SELECT @customErrorMessage = FORMATMESSAGE(N'WrongExpectedVersion %i, current version %i', @expected_version, @current_version);
                 THROW 50000, @customErrorMessage, 1;
-            END
-END
+            END;
+    END;
+END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/4_ReadAllForwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/4_ReadAllForwards.sql
@@ -4,6 +4,7 @@ CREATE OR ALTER PROCEDURE __schema__.read_all_forwards
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     SELECT TOP (@count)
         m.MessageId,

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/4_ReadAllForwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/4_ReadAllForwards.sql
@@ -1,15 +1,21 @@
 CREATE OR ALTER PROCEDURE __schema__.read_all_forwards
-    @from_position bigint,
-    @count int
-    AS
+    @from_position BIGINT,
+    @count INT
+AS
 BEGIN
-    
-SELECT TOP (@count) 
-    MessageId, MessageType, StreamPosition, GlobalPosition,
-    JsonData, JsonMetadata, Created, StreamName
-FROM __schema__.Messages
-INNER JOIN __schema__.Streams ON Messages.StreamId = Streams.StreamId
-WHERE Messages.GlobalPosition >= @from_position
-ORDER BY Messages.GlobalPosition
+    SET NOCOUNT ON;
 
-END
+    SELECT TOP (@count)
+        m.MessageId,
+        m.MessageType,
+        m.StreamPosition,
+        m.GlobalPosition,
+        m.JsonData,
+        m.JsonMetadata,
+        m.Created,
+        s.StreamName
+    FROM __schema__.Messages m
+    JOIN __schema__.Streams s ON m.StreamId = s.StreamId
+    WHERE m.GlobalPosition >= @from_position
+    ORDER BY m.GlobalPosition;
+END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
@@ -34,7 +34,7 @@ BEGIN
         JsonData,
         JsonMetadata,
         Created
-    FROM __schema__.[Messages]
+    FROM __schema__.Messages
     WHERE StreamId = @stream_id
     AND StreamPosition <= @from_position
     ORDER BY StreamPosition DESC;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
@@ -4,24 +4,38 @@ CREATE OR ALTER PROCEDURE __schema__.read_stream_backwards
     @count INT
 AS
 BEGIN
+    SET NOCOUNT ON;
 
-DECLARE @current_version int, @stream_id int
+    DECLARE
+        @current_version INT,
+        @stream_id INT;
 
-SELECT @current_version = Version, @stream_id = StreamId
-FROM __schema__.Streams
-WHERE StreamName = @stream_name
+    SELECT
+        @current_version = [Version],
+        @stream_id = StreamId
+    FROM __schema__.Streams
+    WHERE StreamName = @stream_name;
 
-IF @stream_id IS NULL
-    THROW 50001, 'StreamNotFound', 1;
+    IF @stream_id IS NULL
+    BEGIN
+        ;THROW 50001, 'StreamNotFound', 1;
+    END;
 
-IF @current_version < @from_position + @count
-    RETURN
+    IF @current_version < @from_position + @count
+    BEGIN
+        RETURN;
+    END;
 
-SELECT TOP (@count) 
-    MessageId, MessageType, StreamPosition, GlobalPosition,
-    JsonData, JsonMetadata, Created
-FROM __schema__.Messages
-WHERE StreamId = @stream_id AND StreamPosition <= @from_position
-ORDER BY Messages.StreamPosition DESC
-
-END
+    SELECT TOP (@count)
+        MessageId,
+        MessageType,
+        StreamPosition,
+        GlobalPosition,
+        JsonData,
+        JsonMetadata,
+        Created
+    FROM __schema__.[Messages]
+    WHERE StreamId = @stream_id
+    AND StreamPosition <= @from_position
+    ORDER BY StreamPosition DESC;
+END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
@@ -5,6 +5,7 @@ CREATE OR ALTER PROCEDURE __schema__.read_stream_backwards
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     DECLARE
         @current_version INT,

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/5_ReadStreamBackwards.sql
@@ -22,7 +22,15 @@ BEGIN
         ;THROW 50001, 'StreamNotFound', 1;
     END;
 
-    IF @current_version < @from_position + @count
+    -- nothing to read / invalid request
+    IF @count <= 0
+    BEGIN
+        RETURN;
+    END;
+
+    -- Validate the starting position for backwards read.
+    IF @from_position < 0                -- A negative starting position is invalid
+    OR @from_position > @current_version -- A starting position greater than the current version means we're trying to read from beyond the head of the stream
     BEGIN
         RETURN;
     END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
@@ -37,6 +37,6 @@ BEGIN
     FROM __schema__.[Messages]
     WHERE StreamId = @stream_id
     AND StreamPosition >= @from_position
-    ORDER BY GlobalPosition;
+    ORDER BY StreamPosition;
 
 END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
@@ -4,24 +4,39 @@ CREATE OR ALTER PROCEDURE __schema__.read_stream_forwards
     @count INT
 AS
 BEGIN
+    SET NOCOUNT ON;
 
-DECLARE @current_version int, @stream_id int
+    DECLARE
+        @current_version INT,
+        @stream_id INT;
 
-SELECT @current_version = Version, @stream_id = StreamId
-FROM __schema__.Streams
-WHERE StreamName = @stream_name
+    SELECT
+        @current_version = [Version],
+        @stream_id = StreamId
+    FROM __schema__.Streams
+    WHERE StreamName = @stream_name;
 
-IF @stream_id IS NULL
-    THROW 50001, 'StreamNotFound', 1;
+    IF @stream_id IS NULL
+    BEGIN
+        ;THROW 50001, 'StreamNotFound', 1;
+    END;
 
-IF @current_version < @from_position
-	RETURN
+    IF @current_version < @from_position
+    BEGIN
+        RETURN;
+    END;
 
-SELECT TOP (@count) 
-    MessageId, MessageType, StreamPosition, GlobalPosition,
-    JsonData, JsonMetadata, Created
-FROM __schema__.Messages
-WHERE StreamId = @stream_id AND StreamPosition >= @from_position
-ORDER BY Messages.GlobalPosition
+    SELECT TOP (@count)
+        MessageId,
+        MessageType,
+        StreamPosition,
+        GlobalPosition,
+        JsonData,
+        JsonMetadata,
+        Created
+    FROM __schema__.[Messages]
+    WHERE StreamId = @stream_id
+    AND StreamPosition >= @from_position
+    ORDER BY GlobalPosition;
 
-END
+END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
@@ -5,6 +5,7 @@ CREATE OR ALTER PROCEDURE __schema__.read_stream_forwards
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     DECLARE
         @current_version INT,

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/6_ReadStreamForwards.sql
@@ -34,7 +34,7 @@ BEGIN
         JsonData,
         JsonMetadata,
         Created
-    FROM __schema__.[Messages]
+    FROM __schema__.Messages
     WHERE StreamId = @stream_id
     AND StreamPosition >= @from_position
     ORDER BY StreamPosition;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/7_ReadStreamSub.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/7_ReadStreamSub.sql
@@ -1,16 +1,23 @@
 CREATE OR ALTER PROCEDURE __schema__.read_stream_sub
-    @stream_id int,
+    @stream_id INT,
     @stream_name NVARCHAR(850),
     @from_position INT,
-    @count int
+    @count INT
     AS
 BEGIN
-    
-SELECT TOP (@count) 
-    MessageId, MessageType, StreamPosition, GlobalPosition,
-    JsonData, JsonMetadata, Created, @stream_name AS StreamName
-FROM __schema__.Messages
-WHERE StreamId = @stream_id AND Messages.StreamPosition >= @from_position
-ORDER BY Messages.GlobalPosition
-    
-END
+    SET NOCOUNT ON;
+
+    SELECT TOP (@count)
+        MessageId,
+        MessageType,
+        StreamPosition,
+        GlobalPosition,
+        JsonData,
+        JsonMetadata,
+        Created,
+        @stream_name StreamName
+    FROM __schema__.[Messages]
+    WHERE StreamId = @stream_id
+    AND StreamPosition >= @from_position
+    ORDER BY GlobalPosition;
+END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/7_ReadStreamSub.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/7_ReadStreamSub.sql
@@ -16,7 +16,7 @@ BEGIN
         JsonMetadata,
         Created,
         @stream_name StreamName
-    FROM __schema__.[Messages]
+    FROM __schema__.Messages
     WHERE StreamId = @stream_id
     AND StreamPosition >= @from_position
     ORDER BY GlobalPosition;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/7_ReadStreamSub.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/7_ReadStreamSub.sql
@@ -6,6 +6,7 @@ CREATE OR ALTER PROCEDURE __schema__.read_stream_sub
     AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     SELECT TOP (@count)
         MessageId,

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
@@ -29,7 +29,9 @@ BEGIN
 
     IF @expected_version != -2 AND @expected_version != @current_version
     BEGIN
-        ;THROW 50000, 'WrongExpectedVersion %, current version %', 1;
+        DECLARE @customMessage NVARCHAR(4000);
+        SELECT @customMessage = FORMATMESSAGE(N'WrongExpectedVersion %i, current version %i', @expected_version, @current_version);
+        ;THROW 50000, @customMessage, 1;
     END;
 
     DELETE m

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
@@ -32,7 +32,7 @@ BEGIN
     END;
 
     DELETE m
-    FROM __schema__.[Messages] m
+    FROM __schema__.Messages m
     WHERE m.StreamId = @stream_id
     AND m.StreamPosition < @position;
 END;

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
@@ -5,6 +5,7 @@ CREATE OR ALTER PROCEDURE __schema__.truncate_stream
 AS
 BEGIN
     SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
     DECLARE
         @current_version INT,

--- a/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
+++ b/src/SqlServer/src/Eventuous.SqlServer/Scripts/8_TruncateStream.sql
@@ -4,23 +4,35 @@ CREATE OR ALTER PROCEDURE __schema__.truncate_stream
     @position INT
 AS
 BEGIN
+    SET NOCOUNT ON;
 
-DECLARE @current_version int, @stream_id int
+    DECLARE
+        @current_version INT,
+        @stream_id INT;
 
-SELECT @current_version = Version, @stream_id = StreamId
-FROM __schema__.Streams
-WHERE StreamName = @stream_name
+    SELECT
+        @current_version = [Version],
+        @stream_id = StreamId
+    FROM __schema__.Streams
+    WHERE StreamName = @stream_name;
 
-IF @stream_id IS NULL
-    THROW 50001, 'StreamNotFound', 1;
+    IF @stream_id IS NULL
+    BEGIN
+        ;THROW 50001, 'StreamNotFound', 1;
+    END;
 
-IF @current_version < @position
-	RETURN
+    IF @current_version < @position
+    BEGIN
+        RETURN;
+    END;
 
-IF @expected_version != -2 and @expected_version != @current_version
-    THROW 50000, 'WrongExpectedVersion %, current version %', 1;
+    IF @expected_version != -2 AND @expected_version != @current_version
+    BEGIN
+        ;THROW 50000, 'WrongExpectedVersion %, current version %', 1;
+    END;
 
-DELETE FROM __schema__.Messages
-WHERE StreamId = @stream_id AND StreamPosition < @position
-
-END
+    DELETE m
+    FROM __schema__.[Messages] m
+    WHERE m.StreamId = @stream_id
+    AND m.StreamPosition < @position;
+END;


### PR DESCRIPTION
Each commit has isolated changes to a SQL table or procedure with detailed changes
No functional changes; these changes were a result of me doing a deep review of the procedure/tables that Eventuous creates.

This fixes #428

Other changes do include preferences, but I feel will aid to this SQL being easier to maintain for the long term. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses issue #428 by implementing improvements across PostgreSQL and SQL Server components. The PostgreSQL update corrects stream data ordering, while SQL Server changes refactor schema definitions and stored procedures. Updates standardize data types, constraints, and error handling to enhance transaction safety, maintainability, and performance. These modifications improve the overall reliability and consistency of the event store implementation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
-->
</div>