### PR TITLE
fix(postgres): fix nullability

### DIFF
--- a/src/Postgres/src/Eventuous.Postgresql/Scripts/1_Schema.sql
+++ b/src/Postgres/src/Eventuous.Postgresql/Scripts/1_Schema.sql
@@ -9,13 +9,13 @@ create table if not exists __schema__.streams (
 );
 
 create table if not exists __schema__.messages (
-    message_id      uuid,
+    message_id      uuid not null,
     message_type    varchar not null,
     stream_id       integer not null,
     stream_position integer not null,
     global_position bigint primary key generated always as identity, 
     json_data       jsonb not null,
-    json_metadata   jsonb,
+    json_metadata   jsonb null,
     created         timestamp not null,
     constraint fk_messages_stream foreign key (stream_id) references __schema__.streams (stream_id),
     constraint uq_messages_stream_id_and_stream_position unique (stream_id, stream_position),


### PR DESCRIPTION
- messages table has a message_id column that is not null
- messages table has a json_metadata column that is nullable but now specify that explicitly

This fixes #438  
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a critical nullability issue in the Postgres schema by making the message_id column non-null and explicitly allowing nulls for json_metadata. These changes enhance data integrity and provide clearer schema definitions, addressing the issue documented in #438.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>