### PR TITLE
filter non serialisable custom attributes from service bus messages

### DIFF
--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusMessageBuilder.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusMessageBuilder.cs
@@ -2,29 +2,30 @@
 // Licensed under the Apache License, Version 2.0.
 
 using Eventuous.Producers;
+using static Eventuous.Azure.ServiceBus.Shared.ServiceBusHelper;
 
 namespace Eventuous.Azure.ServiceBus.Producers;
 
 using Shared;
 
 class ServiceBusMessageBuilder {
-    readonly IEventSerializer                _serializer;
-    readonly string                          _streamName;
-    readonly ServiceBusProduceOptions?       _options;
+    readonly IEventSerializer _serializer;
+    readonly string _streamName;
+    readonly ServiceBusProduceOptions? _options;
     readonly ServiceBusMessageAttributeNames _attributes;
-    readonly Action<string>?                 _setActivityMessageType;
+    readonly Action<string>? _setActivityMessageType;
 
     public ServiceBusMessageBuilder(
-            IEventSerializer                serializer,
-            string                          streamName,
+            IEventSerializer serializer,
+            string streamName,
             ServiceBusMessageAttributeNames attributes,
-            ServiceBusProduceOptions?       options                = null,
-            Action<string>?                 setActivityMessageType = null
+            ServiceBusProduceOptions? options = null,
+            Action<string>? setActivityMessageType = null
         ) {
-        _serializer             = serializer;
-        _streamName             = streamName;
-        _options                = options;
-        _attributes             = attributes;
+        _serializer = serializer;
+        _streamName = streamName;
+        _options = options;
+        _attributes = attributes;
         _setActivityMessageType = setActivityMessageType;
     }
 
@@ -42,13 +43,13 @@ class ServiceBusMessageBuilder {
         var metadata = message.Metadata;
 
         var serviceBusMessage = new ServiceBusMessage(payload) {
-            ContentType   = contentType,
-            MessageId     = metadata?.GetValueOrDefault(_attributes.MessageId, message.MessageId)?.ToString(),
-            Subject       = metadata?.GetValueOrDefault(_attributes.Subject, _options?.Subject)?.ToString(),
-            TimeToLive    = _options?.TimeToLive ?? TimeSpan.MaxValue,
+            ContentType = contentType,
+            MessageId = metadata?.GetValueOrDefault(_attributes.MessageId, message.MessageId)?.ToString(),
+            Subject = metadata?.GetValueOrDefault(_attributes.Subject, _options?.Subject)?.ToString(),
+            TimeToLive = _options?.TimeToLive ?? TimeSpan.MaxValue,
             CorrelationId = message.Metadata?.GetCorrelationId(),
-            To            = metadata?.GetValueOrDefault(_attributes.To, _options?.To)?.ToString(),
-            ReplyTo       = metadata?.GetValueOrDefault(_attributes.ReplyTo, _options?.ReplyTo)?.ToString()
+            To = metadata?.GetValueOrDefault(_attributes.To, _options?.To)?.ToString(),
+            ReplyTo = metadata?.GetValueOrDefault(_attributes.ReplyTo, _options?.ReplyTo)?.ToString()
         };
 
         var reservedAttributes = _attributes.ReservedNames();
@@ -65,6 +66,6 @@ class ServiceBusMessageBuilder {
             .Concat(message.AdditionalHeaders ?? [])
             .Concat([new(_attributes.MessageType, messageType), new(_attributes.StreamName, _streamName)])
             .Where(pair => !reservedAttributes.Contains(pair.Key))
-            .Where(pair => pair.Value is not null)
-            .Select(pair => new KeyValuePair<string, object>(pair.Key, pair.Value!));
+            .Where(pair => IsSerialisableByServiceBus(pair.Value))
+            .Select(pair => new KeyValuePair<string, object>(pair.Key, pair.Value!)); 
 }

--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Shared/ServiceBusHelper.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Shared/ServiceBusHelper.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+
+namespace Eventuous.Azure.ServiceBus.Shared;
+
+public static class ServiceBusHelper
+{
+ public static bool IsSerialisableByServiceBus(object? value) => 
+    value is not null && (
+        value is string ||
+        value is bool ||
+        value is byte ||
+        value is sbyte ||
+        value is short ||
+        value is ushort ||
+        value is int ||
+        value is uint ||
+        value is long ||
+        value is ulong ||
+        value is float ||
+        value is double ||
+        value is decimal ||
+        value is char ||
+        value is Guid ||
+        value is DateTime ||
+        value is DateTimeOffset ||
+        value is Stream ||
+        value is Uri ||
+        value is TimeSpan
+    );
+}

--- a/src/Azure/test/Eventuous.Tests.Azure.ServiceBus/IsSerialisableByServiceBus.cs
+++ b/src/Azure/test/Eventuous.Tests.Azure.ServiceBus/IsSerialisableByServiceBus.cs
@@ -1,0 +1,45 @@
+using static Eventuous.Azure.ServiceBus.Shared.ServiceBusHelper;
+using System.Threading.Tasks;
+
+namespace Eventuous.Tests.Azure.ServiceBus;
+
+public class IsSerialisableByServiceBus {
+    public static IEnumerable<Func<object?>> PassingTestData() {
+        yield return () => "string";
+        yield return () => 123; // int
+        yield return () => 123L; // long
+        yield return () => (short)1;
+        yield return () => (byte)1;
+        yield return () => 123u; // uint
+        yield return () => 123UL; // ulong
+        yield return () => 1.23f; // float
+        yield return () => 1.23d; // double
+        yield return () => 12.34m; // decimal
+        yield return () => true; // bool
+        yield return () => 'c'; // char
+        yield return () => Guid.NewGuid();
+        yield return () => DateTime.UtcNow;
+        yield return () => DateTimeOffset.UtcNow;
+        yield return () => TimeSpan.FromMinutes(5);
+        yield return () => new Uri("https://example.com");
+    }
+
+    public static IEnumerable<Func<object?>> FailingTestData() {
+        yield return () => null;
+        yield return () => new object(); // plain object
+        yield return () => new Dictionary<object, string> { [new object()] = "v" }; // dictionary with non-string key
+        yield return () => new Dictionary<string, object> { ["k"] = new object() }; // dictionary with non-serializable value
+        yield return () => new List<object> { new() }; // list with non-serializable item
+        yield return () => Task.CompletedTask; // Task
+        yield return () => new Action(() => { }); // delegate
+        yield return () => new WeakReference(new object()); // complex type
+    }
+
+    [Test]
+    [MethodDataSource(nameof(PassingTestData))]
+    public async Task Passes(object value) => await Assert.That(IsSerialisableByServiceBus(value)).IsTrue();
+
+    [Test]
+    [MethodDataSource(nameof(FailingTestData))]
+    public async Task Fails(object value) => await Assert.That(IsSerialisableByServiceBus(value)).IsFalse();
+}

--- a/src/Azure/test/Eventuous.Tests.Azure.ServiceBus/IsSerialisableByServiceBus.cs
+++ b/src/Azure/test/Eventuous.Tests.Azure.ServiceBus/IsSerialisableByServiceBus.cs
@@ -22,6 +22,7 @@ public class IsSerialisableByServiceBus {
         yield return () => DateTimeOffset.UtcNow;
         yield return () => TimeSpan.FromMinutes(5);
         yield return () => new Uri("https://example.com");
+        yield return () => new MemoryStream(); // Stream
     }
 
     public static IEnumerable<Func<object?>> FailingTestData() {


### PR DESCRIPTION
### **User description**
the azure service bus provider currently has an issue where meta data that is copied to service bus message attributes includes object types that are not serialisable by the azure sdk.

this pr filters out the meta data objects which are not serialisable.

this resolves #447


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Filters non-serializable custom attributes from Service Bus messages

- Adds `IsSerialisableByServiceBus` helper method to validate attribute types

- Replaces null check with serialization validation in message builder

- Includes comprehensive unit tests for serializable and non-serializable types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Service Bus Message Builder"] -->|validates attributes| B["IsSerialisableByServiceBus Helper"]
  B -->|checks type| C["Allowed Types<br/>string, int, bool, Guid, etc."]
  B -->|rejects| D["Non-serializable Types<br/>objects, collections, delegates"]
  E["Unit Tests"] -->|verifies| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceBusMessageBuilder.cs</strong><dd><code>Replace null check with serialization validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusMessageBuilder.cs

<ul><li>Reformatted code alignment for consistency<br> <li> Replaced null check filter with <code>IsSerialisableByServiceBus</code> validation<br> <li> Added static import of <code>ServiceBusHelper</code> for serialization checking<br> <li> Ensures only serializable attributes are added to Service Bus messages</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/460/files#diff-5e835fc9370892ac5081dc7de0c1a5548a1c6818d885c14ab2f873a828fbaec5">+22/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceBusHelper.cs</strong><dd><code>Add Service Bus serialization validation helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/src/Eventuous.Azure.ServiceBus/Shared/ServiceBusHelper.cs

<ul><li>New helper class with <code>IsSerialisableByServiceBus</code> static method<br> <li> Validates if object types are serializable by Azure Service Bus SDK<br> <li> Supports 18 serializable types including primitives, Guid, DateTime, <br>Uri, Stream<br> <li> Returns false for null and non-serializable complex types</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/460/files#diff-733385e1e2d89b188e44487f2471b9e122c1d3f872e6954f7d5c6f111f12d4b7">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IsSerialisableByServiceBus.cs</strong><dd><code>Add serialization validation unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/test/Eventuous.Tests.Azure.ServiceBus/IsSerialisableByServiceBus.cs

<ul><li>New test class with comprehensive test coverage for serialization <br>validation<br> <li> <code>PassingTestData</code> tests 17 serializable types including primitives and <br>common types<br> <li> <code>FailingTestData</code> tests 7 non-serializable types including null, <br>objects, collections<br> <li> Uses <code>MethodDataSource</code> for parameterized testing of both passing and <br>failing cases</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/460/files#diff-889360ee6af2fa26e0b43b5a20ac479b7d818a147684615b368a136b1ba34495">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

