### PR TITLE
SessionId support for Eventuous.Azure.ServiceBus

### DIFF
--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusMessageBuilder.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusMessageBuilder.cs
@@ -35,8 +35,16 @@ class ServiceBusMessageBuilder(
             TimeToLive = options?.TimeToLive ?? TimeSpan.MaxValue,
             CorrelationId = message.Metadata?.GetCorrelationId(),
             To = metadata?.GetValueOrDefault(attributes.To, options?.To)?.ToString(),
-            ReplyTo = metadata?.GetValueOrDefault(attributes.ReplyTo, options?.ReplyTo)?.ToString()
+            ReplyTo = metadata?.GetValueOrDefault(attributes.ReplyTo, options?.ReplyTo)?.ToString(),
+            ReplyToSessionId = options?.ReplyToSessionId,
         };
+
+        // We set the SessionId only when a value is present because
+        // it overrides the PartitionKey, even if the SessionId is null.
+
+        if (options?.SessionId is not null) {
+            serviceBusMessage.SessionId = options.SessionId;
+        }
 
         var reservedAttributes = attributes.ReservedNames();
 

--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusProduceOptions.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusProduceOptions.cs
@@ -23,6 +23,16 @@ public class ServiceBusProduceOptions {
     public string? ReplyTo { get; set; }
 
     /// <summary>
+    /// Session ID to guarantee ordering on session-enabled entities.
+    /// </summary>
+    public string? SessionId { get; init; }
+
+    /// <summary>
+    /// The reply-to session ID attribute name for request-reply over sessions.
+    /// </summary>
+    public string? ReplyToSessionId { get; init; }
+
+    /// <summary>
     /// Gets or sets the time interval after which the message expires.
     /// </summary>
     public TimeSpan TimeToLive { get; set; } = TimeSpan.MaxValue;

--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscription.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscription.cs
@@ -15,6 +15,7 @@ public class ServiceBusSubscription : EventSubscription<ServiceBusSubscriptionOp
     readonly ServiceBusClient                  _client;
     readonly Func<ProcessErrorEventArgs, Task> _defaultErrorHandler;
     ServiceBusProcessor?                       _processor;
+    ServiceBusSessionProcessor?                _sessionProcessor;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServiceBusSubscription"/> class.
@@ -37,12 +38,21 @@ public class ServiceBusSubscription : EventSubscription<ServiceBusSubscriptionOp
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
     protected override ValueTask Subscribe(CancellationToken cancellationToken) {
-        _processor = Options.QueueOrTopic.MakeProcessor(_client, Options);
+        if (Options.SessionProcessorOptions is not null) {
+            _sessionProcessor = Options.QueueOrTopic.MakeSessionProcessor(_client, Options);
 
-        _processor.ProcessMessageAsync += HandleMessage;
-        _processor.ProcessErrorAsync   += _defaultErrorHandler;
+            _sessionProcessor.ProcessMessageAsync += HandleSessionMessage;
+            _sessionProcessor.ProcessErrorAsync   += _defaultErrorHandler;
 
-        return new(_processor.StartProcessingAsync(cancellationToken));
+            return new ValueTask(_sessionProcessor.StartProcessingAsync(cancellationToken));
+        } else {
+            _processor = Options.QueueOrTopic.MakeProcessor(_client, Options);
+
+            _processor.ProcessMessageAsync += HandleMessage;
+            _processor.ProcessErrorAsync   += _defaultErrorHandler;
+
+            return new(_processor.StartProcessingAsync(cancellationToken));
+        }
 
         async Task HandleMessage(ProcessMessageEventArgs arg) {
             var ct = arg.CancellationToken;
@@ -87,6 +97,54 @@ public class ServiceBusSubscription : EventSubscription<ServiceBusSubscriptionOp
             } catch (Exception ex) {
                 // Abandoning the message will make it available for reprocessing, or dead letter it?
                 await arg.AbandonMessageAsync(msg, null, ct).NoContext(); 
+                await _defaultErrorHandler(new(ex, ServiceBusErrorSource.Abandon, arg.FullyQualifiedNamespace, arg.EntityPath, arg.Identifier, arg.CancellationToken)).NoContext();
+                Log.ErrorLog?.Log(ex, "Error processing message: {MessageId}", msg.MessageId);
+            }
+        }
+
+        async Task HandleSessionMessage(ProcessSessionMessageEventArgs arg) {
+            var ct = arg.CancellationToken;
+
+            if (ct.IsCancellationRequested) return;
+
+            var msg = arg.Message;
+
+            var eventType = msg.ApplicationProperties[Options.AttributeNames.MessageType].ToString()
+             ?? throw new InvalidOperationException("Event type is missing in message properties");
+            var contentType = msg.ContentType;
+
+            // Should this be a stream name? or topic or something
+            var streamName = msg.ApplicationProperties[Options.AttributeNames.StreamName].ToString()
+             ?? throw new InvalidOperationException("Stream name is missing in message properties");
+
+            Logger.Current = Log;
+
+            var evt = DeserializeData(contentType, eventType, msg.Body, streamName);
+
+            var applicationProperties = msg.ApplicationProperties.Concat(MessageProperties(msg));
+
+            var ctx = new MessageConsumeContext(
+                msg.MessageId,
+                eventType,
+                contentType,
+                streamName,
+                0,
+                0,
+                0,
+                Sequence++,
+                msg.EnqueuedTime.UtcDateTime,
+                evt,
+                AsMeta(applicationProperties),
+                SubscriptionId,
+                ct
+            );
+
+            try {
+                await Handler(ctx).NoContext();
+                await arg.CompleteMessageAsync(msg, ct).NoContext();
+            } catch (Exception ex) {
+                // Abandoning the message will make it available for reprocessing, or dead letter it?
+                await arg.AbandonMessageAsync(msg, null, ct).NoContext();
                 await _defaultErrorHandler(new(ex, ServiceBusErrorSource.Abandon, arg.FullyQualifiedNamespace, arg.EntityPath, arg.Identifier, arg.CancellationToken)).NoContext();
                 Log.ErrorLog?.Log(ex, "Error processing message: {MessageId}", msg.MessageId);
             }

--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscription.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscription.cs
@@ -187,7 +187,11 @@ public class ServiceBusSubscription : EventSubscription<ServiceBusSubscriptionOp
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     protected override async ValueTask Unsubscribe(CancellationToken cancellationToken) {
-        if (_processor == null) return;
-        await _processor.StopProcessingAsync(cancellationToken).NoContext();
+        if (_sessionProcessor is not null) {
+            await _sessionProcessor.StopProcessingAsync(cancellationToken).NoContext();
+        }
+        else if (_processor is not null) {
+            await _processor.StopProcessingAsync(cancellationToken).NoContext();
+        }
     }
 }

--- a/src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscriptionOptions.cs
+++ b/src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscriptionOptions.cs
@@ -21,6 +21,12 @@ public record ServiceBusSubscriptionOptions : SubscriptionOptions {
     public ServiceBusProcessorOptions ProcessorOptions { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the options for the session Service Bus processor.
+    /// If these options are specified, they take priority over <see cref="ProcessorOptions"/>
+    /// </summary>
+    public ServiceBusSessionProcessorOptions? SessionProcessorOptions { get; set; }
+
+    /// <summary>
     /// Gets the message attributes for Service Bus messages.
     /// </summary>
     public ServiceBusMessageAttributeNames AttributeNames { get; init; } = new();
@@ -42,6 +48,14 @@ public interface IQueueOrTopic {
     /// <param name="options">The subscription options.</param>
     /// <returns>A configured <see cref="ServiceBusProcessor"/> instance.</returns>
     ServiceBusProcessor MakeProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options);
+
+    /// <summary>
+    /// Creates a <see cref="ServiceBusSessionProcessor"/> for the specfiied client and options.
+    /// </summary>
+    /// <param name="client">The Service Bus client.</param>
+    /// <param name="options">The subscription options.</param>
+    /// <returns>A configured <see cref="ServiceBusSessionProcessor"/> instance.</returns>
+    ServiceBusSessionProcessor MakeSessionProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options);
 }
 
 /// <summary>
@@ -56,6 +70,15 @@ public record Queue(string Name) : IQueueOrTopic {
     /// <returns>A configured <see cref="ServiceBusProcessor"/> for the queue.</returns>
     public ServiceBusProcessor MakeProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options) 
         => client.CreateProcessor(Name, options.ProcessorOptions);
+
+    /// <summary>
+    /// Creates a <see cref="ServiceBusSessionProcessor"/> for the queue.
+    /// </summary>
+    /// <param name="client">The Service Bus client.</param>
+    /// <param name="options">The subscription options.</param>
+    /// <returns>A configured <see cref="ServiceBusSessionProcessor"/> for the queue.</returns>
+    public ServiceBusSessionProcessor MakeSessionProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options)
+        => client.CreateSessionProcessor(Name, options.SessionProcessorOptions);
 }
 
 /// <summary>
@@ -70,6 +93,15 @@ public record Topic(string Name) : IQueueOrTopic {
     /// <returns>A configured <see cref="ServiceBusProcessor"/> for the topic.</returns>
     public ServiceBusProcessor MakeProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options) 
         => client.CreateProcessor(Name, options.SubscriptionId, options.ProcessorOptions);
+
+    /// <summary>
+    /// Creates a <see cref="ServiceBusSessionProcessor"/> for the topic and subscription ID from options.
+    /// </summary>
+    /// <param name="client">The Service Bus client.</param>
+    /// <param name="options">The subscription options.</param>
+    /// <returns>A configured <see cref="ServiceBusSessionProcessor"/> for the topic.</returns>
+    public ServiceBusSessionProcessor MakeSessionProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options)
+        => client.CreateSessionProcessor(Name, options.SubscriptionId, options.SessionProcessorOptions);
 }
 
 /// <summary>
@@ -84,4 +116,13 @@ public record TopicAndSubscription(string Name, string Subscription) : IQueueOrT
     /// <returns>A configured <see cref="ServiceBusProcessor"/> for the topic and subscription.</returns>
     public ServiceBusProcessor MakeProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options)
         => client.CreateProcessor(Name, Subscription, options.ProcessorOptions);
+
+    /// <summary>
+    /// Creates a <see cref="ServiceBusSessionProcessor"/> for the topic and specified subscription.
+    /// </summary>
+    /// <param name="client">The Service Bus client.</param>
+    /// <param name="options">The subscription options.</param>
+    /// <returns>A configured <see cref="ServiceBusSessionProcessor"/> for the topic and subscription.</returns>
+    public ServiceBusSessionProcessor MakeSessionProcessor(ServiceBusClient client, ServiceBusSubscriptionOptions options)
+        => client.CreateSessionProcessor(Name, Subscription, options.SessionProcessorOptions);
 }


### PR DESCRIPTION
### **User description**
Added the ability to specify a SessionId when publishing events for parallel processing with guaranteed order within the SessionId on the consumer side


___

### **Auto-created Ticket**

[#471](https://github.com/Eventuous/eventuous/issues/471)

### **PR Type**
Enhancement


___

### **Description**
- Add SessionId and ReplyToSessionId support for message producers

- Implement ServiceBusSessionProcessor for ordered message consumption

- Enable session-based message processing with guaranteed ordering

- Support both standard and session-based subscription modes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Producer["Producer with SessionId"] -->|"SessionId + ReplyToSessionId"| Message["ServiceBusMessage"]
  Message -->|"Session-enabled"| Broker["Service Bus Broker"]
  Broker -->|"SessionProcessorOptions"| Consumer["SessionProcessor Consumer"]
  Consumer -->|"Ordered by SessionId"| Handler["Message Handler"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServiceBusMessageBuilder.cs</strong><dd><code>Add SessionId and ReplyToSessionId to messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusMessageBuilder.cs

<ul><li>Added <code>ReplyToSessionId</code> property assignment to ServiceBusMessage<br> <li> Implemented conditional <code>SessionId</code> assignment with null-check to avoid <br>overriding PartitionKey<br> <li> Added explanatory comment about SessionId behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/470/files#diff-5e835fc9370892ac5081dc7de0c1a5548a1c6818d885c14ab2f873a828fbaec5">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ServiceBusProduceOptions.cs</strong><dd><code>Add session properties to produce options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/src/Eventuous.Azure.ServiceBus/Producers/ServiceBusProduceOptions.cs

<ul><li>Added <code>SessionId</code> property for specifying session identifier on messages<br> <li> Added <code>ReplyToSessionId</code> property for request-reply session patterns<br> <li> Both properties use init-only accessors for immutability</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/470/files#diff-2e195df3d67659119b6278da3ae855c5e0fb7aac57f3ae356350232d49ecfeae">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ServiceBusSubscription.cs</strong><dd><code>Implement session processor support in subscriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscription.cs

<ul><li>Added <code>_sessionProcessor</code> field to support session-based message <br>processing<br> <li> Implemented conditional logic to use SessionProcessor when <br><code>SessionProcessorOptions</code> is configured<br> <li> Added new <code>HandleSessionMessage</code> method to process session-based <br>messages with identical logic to standard handler<br> <li> Both processor types register their respective message and error <br>handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/470/files#diff-8caab44965025a630ce19d145967e4a3f5a112bd75e16d20fee393cd44ee2577">+62/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ServiceBusSubscriptionOptions.cs</strong><dd><code>Add session processor configuration options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Azure/src/Eventuous.Azure.ServiceBus/Subscriptions/ServiceBusSubscriptionOptions.cs

<ul><li>Added <code>SessionProcessorOptions</code> property to enable session-based <br>processing<br> <li> Added <code>MakeSessionProcessor</code> method to <code>IQueueOrTopic</code> interface<br> <li> Implemented <code>MakeSessionProcessor</code> in Queue, Topic, and <br>TopicAndSubscription classes<br> <li> Session processor options take priority over standard ProcessorOptions <br>when specified</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/470/files#diff-77fe02db238b7a33db498a1b7bd22ee1cd66dfc1d2a057a5efd5913d62327ae2">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

