### PR TITLE
Fix the aggregate version calculation

### DIFF
--- a/src/Core/gen/Eventuous.Shared.Generators/TypeMappingsGenerator.cs
+++ b/src/Core/gen/Eventuous.Shared.Generators/TypeMappingsGenerator.cs
@@ -163,12 +163,12 @@ public sealed class TypeMappingsGenerator : IIncrementalGenerator {
         sb.AppendLine();
         sb.AppendLine($"internal static class {className} {{");
         sb.AppendLine("    [ModuleInitializer]");
-        sb.AppendLine("    internal static void Initialize() => Register(TypeMap.Instance);");
+        sb.AppendLine("    internal static void Initialize() => RegisterDiscoveredTypes(TypeMap.Instance);");
         sb.AppendLine();
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Registers all [EventType] types discovered at compile time into the provided mapper.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    public static void Register(TypeMapper mapper) {");
+        sb.AppendLine("    public static void RegisterDiscoveredTypes(this TypeMapper mapper) {");
 
         foreach (var m in distinct) {
             // Prefer passing the explicit name when we have it, so runtime reflection is avoided

--- a/src/Core/src/Eventuous.Domain/Aggregate.cs
+++ b/src/Core/src/Eventuous.Domain/Aggregate.cs
@@ -30,13 +30,13 @@ public abstract class Aggregate<T> where T : State<T>, new() {
     /// It is used for optimistic concurrency to check if there were no changes made to the
     /// aggregate state between load and save for the current operation.
     /// </summary>
-    public int OriginalVersion => Original.Length - 1;
+    public long OriginalVersion { get; private set; } = -1;
 
     /// <summary>
     /// The current version is set to the original version when the aggregate is loaded from the store.
     /// It should increase for each state transition performed within the scope of the current operation.
     /// </summary>
-    public int CurrentVersion => OriginalVersion + Changes.Count;
+    public long CurrentVersion => OriginalVersion + Changes.Count;
 
     readonly List<object> _changes = [];
 
@@ -78,9 +78,10 @@ public abstract class Aggregate<T> where T : State<T>, new() {
         return (previous, State);
     }
 
-    public void Load(IEnumerable<object?> events) {
-        Original = events.Where(x => x != null).ToArray()!;
-        State    = Original.Aggregate(State, Fold);
+    public void Load(long version, IEnumerable<object?> events) {
+        Original        = events.Where(x => x != null).ToArray()!;
+        OriginalVersion = version;
+        State           = Original.Aggregate(State, Fold);
 
         return;
 

--- a/src/Core/src/Eventuous.Persistence/AggregateStore/AggregatePersistenceExtensions.cs
+++ b/src/Core/src/Eventuous.Persistence/AggregateStore/AggregatePersistenceExtensions.cs
@@ -128,6 +128,7 @@ public static class AggregatePersistenceExtensions {
 
             try {
                 var events = await eventReader.ReadStream(streamName, StreamReadPosition.Start, failIfNotFound, cancellationToken).NoContext();
+                if (events.Length == 0) return aggregate;
                 aggregate.Load(events[^1].Revision, events.Select(x => x.Payload));
             } catch (StreamNotFound) when (!failIfNotFound) {
                 return aggregate;

--- a/src/Core/src/Eventuous.Persistence/AggregateStore/AggregatePersistenceExtensions.cs
+++ b/src/Core/src/Eventuous.Persistence/AggregateStore/AggregatePersistenceExtensions.cs
@@ -128,7 +128,7 @@ public static class AggregatePersistenceExtensions {
 
             try {
                 var events = await eventReader.ReadStream(streamName, StreamReadPosition.Start, failIfNotFound, cancellationToken).NoContext();
-                aggregate.Load(events.Select(x => x.Payload));
+                aggregate.Load(events[^1].Revision, events.Select(x => x.Payload));
             } catch (StreamNotFound) when (!failIfNotFound) {
                 return aggregate;
             } catch (Exception e) {

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -15,8 +15,8 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
     public async Task<StreamEvent[]> ReadEvents(StreamName streamName, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
         var hotEvents = await LoadStreamEvents(hotReader, start, count, true).NoContext();
 
-        var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Position > start.Value
-            ? await LoadStreamEvents(archiveReader, start, (int)hotEvents[0].Position, !failIfNotFound).NoContext()
+        var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Revision > start.Value
+            ? await LoadStreamEvents(archiveReader, start, (int)hotEvents[0].Revision, !failIfNotFound).NoContext()
             : Enumerable.Empty<StreamEvent>();
 
         return archivedEvents.Select(x => x with { FromArchive = true }).Concat(hotEvents).Distinct(Comparer).ToArray();
@@ -35,8 +35,8 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
     public async Task<StreamEvent[]> ReadEventsBackwards(StreamName streamName, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
         var hotEvents = await LoadStreamEvents(hotReader, start, count, true).NoContext();
 
-        var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Position > start.Value - count
-            ? await LoadStreamEvents(archiveReader, new(hotEvents[0].Position - 1), count - hotEvents.Length, failIfNotFound).NoContext()
+        var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Revision > start.Value - count
+            ? await LoadStreamEvents(archiveReader, new(hotEvents[0].Revision - 1), count - hotEvents.Length, failIfNotFound).NoContext()
             : Enumerable.Empty<StreamEvent>();
 
         return hotEvents.Concat(archivedEvents.Select(x => x with { FromArchive = true })).Distinct(Comparer).ToArray();
@@ -53,8 +53,8 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
     static readonly StreamEventPositionComparer Comparer = new();
 
     class StreamEventPositionComparer : IEqualityComparer<StreamEvent> {
-        public bool Equals(StreamEvent x, StreamEvent y) => x.Position == y.Position;
+        public bool Equals(StreamEvent x, StreamEvent y) => x.Revision == y.Revision;
 
-        public int GetHashCode(StreamEvent obj) => obj.Position.GetHashCode();
+        public int GetHashCode(StreamEvent obj) => obj.Revision.GetHashCode();
     }
 }

--- a/src/Core/src/Eventuous.Persistence/StateStore/StateStoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/StateStore/StateStoreFunctions.cs
@@ -27,7 +27,7 @@ public static class StateStoreFunctions {
             try {
                 var streamEvents    = await reader.ReadStream(streamName, StreamReadPosition.Start, failIfNotFound, cancellationToken).NoContext();
                 var events          = streamEvents.Select(x => x.Payload!).ToArray();
-                var expectedVersion = events.Length == 0 ? ExpectedStreamVersion.NoStream : new(streamEvents.Last().Position);
+                var expectedVersion = events.Length == 0 ? ExpectedStreamVersion.NoStream : new(streamEvents.Last().Revision);
 
                 return (new(streamName, expectedVersion, events));
             } catch (StreamNotFound) when (!failIfNotFound) {

--- a/src/Core/src/Eventuous.Persistence/StreamEvent.cs
+++ b/src/Core/src/Eventuous.Persistence/StreamEvent.cs
@@ -3,10 +3,10 @@
 
 using System.Runtime.InteropServices;
 
-namespace Eventuous; 
+namespace Eventuous;
 
 [StructLayout(LayoutKind.Auto)]
 public record struct NewStreamEvent(Guid Id, object? Payload, Metadata Metadata);
 
 [StructLayout(LayoutKind.Auto)]
-public record struct StreamEvent(Guid Id, object? Payload, Metadata Metadata, string ContentType, long Position, bool FromArchive = false);
+public record struct StreamEvent(Guid Id, object? Payload, Metadata Metadata, string ContentType, long Revision, bool FromArchive = false);

--- a/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.Amendments.cs
+++ b/src/Core/test/Eventuous.Tests.Application/ServiceTestBase.Amendments.cs
@@ -9,7 +9,7 @@ public abstract partial class ServiceTestBase {
         var service = CreateService(amendEvent: AmendEvent);
         var cmd     = CreateCommand();
 
-        await service.Handle(cmd, cancellationToken);
+        var result = await service.Handle(cmd, cancellationToken);
 
         var stream = await Store.ReadStream(StreamName.For<Booking>(cmd.BookingId), StreamReadPosition.Start, cancellationToken: cancellationToken);
         await Assert.That(stream[0].Metadata["userId"]).IsEqualTo(cmd.ImportedBy);

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
@@ -62,7 +62,7 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
             cancellationToken
         );
 
-        return response.Length == 0 && failIfNotFound ? throw new StreamNotFound(stream) : response.OrderByDescending(x => x.Position).ToArray();
+        return response.Length == 0 && failIfNotFound ? throw new StreamNotFound(stream) : response.OrderByDescending(x => x.Revision).ToArray();
     }
 
     public async Task<bool> StreamExists(StreamName stream, CancellationToken cancellationToken) {

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/AppServiceTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/AppServiceTests.cs
@@ -12,7 +12,7 @@ public class AppServiceTests {
 
     public AppServiceTests(StoreFixture fixture) {
         _fixture = fixture;
-        _fixture.TypeMapper.AddType<BookingEvents.BookingImported>();
+        _fixture.TypeMapper.RegisterDiscoveredTypes();
     }
 
     BookingService Service { get; set; } = null!;
@@ -37,6 +37,23 @@ public class AppServiceTests {
         var result = events.Select(x => x.Payload).ToArray();
 
         result.ShouldBeEquivalentTo(expected);
+    }
+
+    [Test]
+    public async Task ProcessNewThenDeleteAndDoItAgain(CancellationToken cancellationToken) {
+        // This will create a new stream
+        var cmd = DomainFixture.CreateImportBooking();
+        await Service.Handle(cmd, cancellationToken);
+
+        var streamName = StreamName.For<Booking>(cmd.BookingId);
+        await _fixture.EventStore.DeleteStream(streamName, ExpectedStreamVersion.Any, cancellationToken);
+
+        var handlingResult = await Service.Handle(cmd, cancellationToken);
+        handlingResult.Success.ShouldBeTrue();
+
+        var cancelCmd    = new Commands.CancelBooking(new(cmd.BookingId));
+        var secondResult = await Service.Handle(cancelCmd, cancellationToken);
+        secondResult.Success.ShouldBeTrue();
     }
 
     [After(Test)]

--- a/src/Redis/test/Eventuous.Tests.Redis/Subscriptions/SubscribeToStream.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Subscriptions/SubscribeToStream.cs
@@ -98,6 +98,6 @@ public class SubscribeToStream {
     async Task<long> GetStreamPosition(int count) {
         var readEvents = await _fixture.IntegrationFixture.EventReader.ReadEvents(_fixture.Stream, StreamReadPosition.Start, count, true, default);
 
-        return readEvents.Last().Position;
+        return readEvents.Last().Revision;
     }
 }

--- a/src/Testing/src/Eventuous.Testing/AggregateSpec.cs
+++ b/src/Testing/src/Eventuous.Testing/AggregateSpec.cs
@@ -42,7 +42,8 @@ public abstract class AggregateSpec<TAggregate, TState>(AggregateFactoryRegistry
     [MemberNotNull(nameof(Instance))]
     protected TAggregate Then() {
         Instance = CreateInstance();
-        Instance.Load(GivenEvents());
+        var events = GivenEvents();
+        Instance.Load(events.Length - 1, events);
         When(Instance);
 
         return Instance;

--- a/src/Testing/src/Eventuous.Testing/CommandServiceFixture.cs
+++ b/src/Testing/src/Eventuous.Testing/CommandServiceFixture.cs
@@ -256,7 +256,7 @@ public class CommandServiceFixture<TState> : IServiceFixtureGiven<TState>, IServ
         /// <returns></returns>
         [StackTraceHidden]
         public FixtureResult NewStreamEventsAre(params object[] events) {
-            var stream = _streamEvents.Where(x => x.Position >= _version).Select(x => x.Payload);
+            var stream = _streamEvents.Where(x => x.Revision >= _version).Select(x => x.Payload);
             stream.ShouldBe(events);
 
             return this;

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -92,7 +92,7 @@ class InMemoryStream(StreamName name) {
 
         if (count > 0) selected = selected.Take(count);
 
-        return selected.Select(x => x.Event with { Position = x.Position });
+        return selected.Select(x => x.Event with { Revision = x.Position });
     }
 
     public IEnumerable<StreamEvent> GetEventsBackwards(StreamReadPosition from, int count) {


### PR DESCRIPTION
### **User description**
* Fix the aggregate version calculation 
* Rename Position to Revision in StreamEvent for clarify
* Fixes #412


___

### **PR Type**
Bug fix


___

### **Description**
- Fix aggregate version calculation for deleted streams
  - Changed `OriginalVersion` from computed property to stored field
  - Pass stream revision when loading aggregate events

- Rename `Position` to `Revision` in `StreamEvent` for clarity
  - Updated all references across persistence and event store implementations

- Add test for stream deletion and recreation scenario

- Refactor type registration method to extension method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Aggregate.Load<br/>receives version"] -->|"stores version"| B["OriginalVersion<br/>field"]
  B -->|"used for"| C["CurrentVersion<br/>calculation"]
  C -->|"ensures correct"| D["Optimistic<br/>concurrency"]
  E["StreamEvent.Position"] -->|"renamed to"| F["StreamEvent.Revision"]
  F -->|"passed to"| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Aggregate.cs</strong><dd><code>Fix version tracking for deleted streams</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-b448514193df08a9fe50aab6402c95982651d8c3228ef95c15c1210a2a1ca2c1">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AggregatePersistenceExtensions.cs</strong><dd><code>Pass stream revision when loading aggregate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-2673f1e690bd6522ba1a3e8ab9e3397a26a45cefa0e3375422f3acab857472f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>StreamEvent.cs</strong><dd><code>Rename Position property to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-f366ac9cc1a3921b8a3e359a9256acf4bdbb979122e5e774a116d5b319f8dff7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TieredEventReader.cs</strong><dd><code>Update Position references to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-6903b30ef8307ed1fec6ae04c83504773a21e589220678cc8a7512668b09fcb0">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>StateStoreFunctions.cs</strong><dd><code>Update Position references to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-1772bb0703ce5eaa13ac92db3b5387f523d62b07bb111949c35d8c49300548a3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TypeMappingsGenerator.cs</strong><dd><code>Refactor Register to extension method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-fbd2403a2bf54e19cb8ee6c7afb9a3e2119e945f885517b23f751da8628566a3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ElasticEventStore.cs</strong><dd><code>Update Position references to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-7d33ff40aba66dd5c9c91432670db440727ea3637ccc403b155cfc0ee63d4bac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CommandServiceFixture.cs</strong><dd><code>Update Position references to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-45dd6bcde4dfacc35b9922aba0789266c52039d2996ad5375cbfd4ada145cec4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>InMemoryEventStore.cs</strong><dd><code>Update Position references to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-039e09b033c322d2eae311f74916ef25a237596e57cbb1adf9ebe09d5364e116">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SubscribeToStream.cs</strong><dd><code>Update Position references to Revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-3b771a8047512f3fe5836c734401cadd861c37eccf5d087894e6069521f53533">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>AggregateSpec.cs</strong><dd><code>Pass version when loading test aggregate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-863008b3c42f001084fe9b7841ae5f928a0b518e0b309cc48b999023daa3583b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AppServiceTests.cs</strong><dd><code>Add test for stream deletion scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/475/files#diff-e1988725b099dbdb845107c921dfe0d07c4157c0519fcb900efdcbf3751ea3d6">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

