### PR TITLE
Implement automatic reconnection for Google PubSub subscription

### DIFF
--- a/src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/GooglePubSubSubscription.cs
+++ b/src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/GooglePubSubSubscription.cs
@@ -79,6 +79,7 @@ public class GooglePubSubSubscription : EventSubscription<PubSubSubscriptionOpti
     }
 
     Task _subscriberTask = null!;
+    Task _monitorTask    = null!;
 
     protected override async ValueTask Subscribe(CancellationToken cancellationToken) {
         var builder = new SubscriberClientBuilder { Logger = Log.Logger };
@@ -92,6 +93,7 @@ public class GooglePubSubSubscription : EventSubscription<PubSubSubscriptionOpti
         _client = await builder.BuildAsync(cancellationToken).NoContext();
 
         _subscriberTask = _client.StartAsync(Handle);
+        _monitorTask    = MonitorSubscriberTask(_subscriberTask, cancellationToken);
 
         return;
 
@@ -129,9 +131,26 @@ public class GooglePubSubSubscription : EventSubscription<PubSubSubscriptionOpti
         Metadata AsMeta(MapField<string, string> attributes) => new(attributes.ToDictionary(x => x.Key, object (x) => x.Value)!);
     }
 
+    async Task MonitorSubscriberTask(Task subscriberTask, CancellationToken cancellationToken) {
+        try {
+            await subscriberTask.NoContext();
+
+            // If the task completes without cancellation, the subscription was dropped
+            if (!cancellationToken.IsCancellationRequested) {
+                Dropped(DropReason.Stopped, null);
+            }
+        } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            // Expected when shutting down
+        } catch (Exception ex) {
+            // Subscriber task failed with an unrecoverable error
+            Dropped(DropReason.ServerError, ex);
+        }
+    }
+
     protected override async ValueTask Unsubscribe(CancellationToken cancellationToken) {
         if (_client != null) await _client.StopAsync(cancellationToken).NoContext();
         await _subscriberTask.NoContext();
+        await _monitorTask.NoContext();
     }
 
     public async Task CreateSubscription(


### PR DESCRIPTION
### **User description**
In case Google PubSub subscription encounters an unrecoverable error, perform normal connection dropped handling: call the OnDropped callback and try to reconnect.


___

### **Auto-created Ticket**

[#478](https://github.com/Eventuous/eventuous/issues/478)

### **PR Type**
Enhancement


___

### **Description**
- Add automatic reconnection handling for Google PubSub subscription failures

- Monitor subscriber task for unrecoverable errors and dropped connections

- Call OnDropped callback with appropriate reason on subscription termination

- Ensure proper cleanup of monitor task during unsubscribe


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Subscribe starts<br/>_subscriberTask"] --> B["MonitorSubscriberTask<br/>monitors task"]
  B --> C{"Task completes<br/>or fails?"}
  C -->|Normal completion| D["Dropped callback<br/>DropReason.Stopped"]
  C -->|Unrecoverable error| E["Dropped callback<br/>DropReason.ServerError"]
  C -->|Cancellation| F["Expected shutdown"]
  D --> G["Reconnection triggered"]
  E --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GooglePubSubSubscription.cs</strong><dd><code>Add subscriber task monitoring and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GooglePubSub/src/Eventuous.GooglePubSub/Subscriptions/GooglePubSubSubscription.cs

<ul><li>Added <code>_monitorTask</code> field to track the monitoring task lifecycle<br> <li> Implemented <code>MonitorSubscriberTask</code> method to handle subscriber task <br>completion and failures<br> <li> Integrated monitoring task startup in <code>Subscribe</code> method after starting <br>subscriber<br> <li> Enhanced <code>Unsubscribe</code> method to properly await and clean up the monitor <br>task<br> <li> Handles three scenarios: normal completion, operation cancellation, <br>and unrecoverable errors</ul>


</details>


  </td>
  <td><a href="https://github.com/Eventuous/eventuous/pull/477/files#diff-14e0e57fdc7dfba80f354fa4e13fde3d3e833d5abf0682d9f63dfbd077e09f32">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

