### PR TITLE
feat: add multi-stream atomic append to IEventWriter

### DIFF
--- a/docs/src/content/docs/persistence/event-store.md
+++ b/docs/src/content/docs/persistence/event-store.md
@@ -32,7 +32,34 @@ Right now, we only have four operations for an event store:
 | Function              | What's it for                                                                                                 |
 |-----------------------|---------------------------------------------------------------------------------------------------------------|
 | `AppendEvents`        | Append one or more events to a given stream.                                                                  |
+| `AppendEvents` (multi-stream) | Append events to multiple streams in a single operation.                                               |
 | `ReadEvents`          | Read events from a stream forwards, from a given start position.                                              |
+
+### Multi-stream append
+
+You can append events to multiple streams in a single operation using the multi-stream overload of `AppendEvents`:
+
+```csharp
+var appends = new NewStreamAppend[]
+{
+    new(orderStream, ExpectedStreamVersion.NoStream, orderEvents),
+    new(inventoryStream, new ExpectedStreamVersion(currentVersion), inventoryEvents)
+};
+
+AppendEventsResult[] results = await eventStore.AppendEvents(appends, cancellationToken);
+```
+
+Each element specifies a target stream, its expected version, and the events to append. The return array contains one `AppendEventsResult` per stream in the same order as the input.
+
+**Atomicity guarantees vary by store:**
+
+| Store | Atomicity |
+|---|---|
+| KurrentDB (25.1+) | Atomic — all streams updated or entire operation fails |
+| PostgreSQL | Atomic — uses a single database transaction |
+| SQL Server | Atomic — uses a single database transaction |
+| SQLite | Atomic — uses a single database transaction |
+| Default (other stores) | Not atomic — streams are written sequentially, fails on first error |
 
 Eventuous has several implementations of the event store: 
  * [KurrentDB](../../infra/esdb)

--- a/docs/src/content/docs/persistence/event-store.md
+++ b/docs/src/content/docs/persistence/event-store.md
@@ -29,22 +29,21 @@ All of those are immutable records.
 
 Right now, we only have four operations for an event store:
 
-| Function              | What's it for                                                                                                 |
-|-----------------------|---------------------------------------------------------------------------------------------------------------|
-| `AppendEvents`        | Append one or more events to a given stream.                                                                  |
-| `AppendEvents` (multi-stream) | Append events to multiple streams in a single operation.                                               |
-| `ReadEvents`          | Read events from a stream forwards, from a given start position.                                              |
+| Function                      | What's it for                                                    |
+|-------------------------------|------------------------------------------------------------------|
+| `AppendEvents`                | Append one or more events to a given stream.                     |
+| `AppendEvents` (multi-stream) | Append events to multiple streams in a single operation.         |
+| `ReadEvents`                  | Read events from a stream forwards, from a given start position. |
 
 ### Multi-stream append
 
 You can append events to multiple streams in a single operation using the multi-stream overload of `AppendEvents`:
 
 ```csharp
-var appends = new NewStreamAppend[]
-{
+NewStreamAppend[] appends = [
     new(orderStream, ExpectedStreamVersion.NoStream, orderEvents),
     new(inventoryStream, new ExpectedStreamVersion(currentVersion), inventoryEvents)
-};
+];
 
 AppendEventsResult[] results = await eventStore.AppendEvents(appends, cancellationToken);
 ```
@@ -53,22 +52,22 @@ Each element specifies a target stream, its expected version, and the events to 
 
 **Atomicity guarantees vary by store:**
 
-| Store | Atomicity |
-|---|---|
-| KurrentDB (25.1+) | Atomic — all streams updated or entire operation fails |
-| PostgreSQL | Atomic — uses a single database transaction |
-| SQL Server | Atomic — uses a single database transaction |
-| SQLite | Atomic — uses a single database transaction |
+| Store                  | Atomicity                                                           |
+|------------------------|---------------------------------------------------------------------|
+| KurrentDB (25.1+)      | Atomic — all streams updated or entire operation fails              |
+| PostgreSQL             | Atomic — uses a single database transaction                         |
+| SQL Server             | Atomic — uses a single database transaction                         |
+| SQLite                 | Atomic — uses a single database transaction                         |
 | Default (other stores) | Not atomic — streams are written sequentially, fails on first error |
 
-Eventuous has several implementations of the event store: 
+Eventuous has several implementations of the event store:
  * [KurrentDB](../../infra/esdb)
  * [PostgreSQL](../../infra/postgres)
  * [Microsoft SQL Server](../../infra/mssql)
  * [SQLite](../../infra/sqlite)
  * [Elasticsearch](../../infra/elastic)
 
-If you use one of the implementations provided, you won't need to know about the event store abstraction. It is required though if you want to implement it for your preferred database. 
+If you use one of the implementations provided, you won't need to know about the event store abstraction. It is required though if you want to implement it for your preferred database.
 
 :::tip
 Preferring KurrentDB will save you lots of time!

--- a/src/Core/src/Eventuous.Application/Persistence/WriterExtensions.cs
+++ b/src/Core/src/Eventuous.Application/Persistence/WriterExtensions.cs
@@ -4,62 +4,65 @@
 namespace Eventuous.Persistence;
 
 static class WriterExtensions {
-    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
-    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public static async Task<AppendEventsResult> Store(this IEventWriter writer, ProposedAppend append, AmendEvent? amendEvent, CancellationToken cancellationToken) {
-        Ensure.NotNull(append.Events);
+    extension(IEventWriter writer) {
+        [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+        [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+        public async Task<AppendEventsResult> Store(ProposedAppend append, AmendEvent? amendEvent, CancellationToken cancellationToken) {
+            Ensure.NotNull(append.Events);
 
-        if (append.Events.Length == 0) return AppendEventsResult.NoOp;
+            if (append.Events.Length == 0) return AppendEventsResult.NoOp;
 
-        try {
-            return await writer.AppendEvents(
-                    append.StreamName,
-                    append.ExpectedVersion,
-                    append.Events.Select(ToStreamEvent).ToArray(),
-                    cancellationToken
+            try {
+                return await writer.AppendEvents(
+                        append.StreamName,
+                        append.ExpectedVersion,
+                        append.Events.Select(ToStreamEvent).ToArray(),
+                        cancellationToken
+                    )
+                    .NoContext();
+            } catch (Exception e) {
+                throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
+                    ? new OptimisticConcurrencyException(append.StreamName, e)
+                    : e;
+            }
+
+            NewStreamEvent ToStreamEvent(ProposedEvent evt) {
+                var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt.Data, evt.Metadata);
+
+                return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+            }
+        }
+
+        [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+        [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+        public async Task<AppendEventsResult[]> Store(
+                IReadOnlyCollection<ProposedAppend> appends,
+                AmendEvent?                         amendEvent,
+                CancellationToken                   cancellationToken
+            ) {
+            if (appends.Count == 0) return [];
+
+            var streamAppends = appends.Select(a => new NewStreamAppend(
+                        a.StreamName,
+                        a.ExpectedVersion,
+                        a.Events.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
+                    )
                 )
-                .NoContext();
-        } catch (Exception e) {
-            throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
-                ? new OptimisticConcurrencyException(append.StreamName, e)
-                : e;
-        }
+                .ToArray();
 
-        NewStreamEvent ToStreamEvent(ProposedEvent evt) {
-            var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt.Data, evt.Metadata);
+            try {
+                return await writer.AppendEvents(streamAppends, cancellationToken).NoContext();
+            } catch (Exception e) {
+                throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
+                    ? new OptimisticConcurrencyException(new(string.Join(", ", appends.Select(a => a.StreamName.ToString()))), e)
+                    : e;
+            }
 
-            return amendEvent?.Invoke(streamEvent) ?? streamEvent;
-        }
-    }
+            static NewStreamEvent ToStreamEvent(ProposedEvent evt, AmendEvent? amendEvent) {
+                var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt.Data, evt.Metadata);
 
-    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
-    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public static async Task<AppendEventsResult[]> Store(
-        this IEventWriter writer,
-        IReadOnlyCollection<ProposedAppend> appends,
-        AmendEvent? amendEvent,
-        CancellationToken cancellationToken
-    ) {
-        if (appends.Count == 0) return [];
-
-        var streamAppends = appends.Select(a => new NewStreamAppend(
-            a.StreamName,
-            a.ExpectedVersion,
-            a.Events.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
-        )).ToArray();
-
-        try {
-            return await writer.AppendEvents(streamAppends, cancellationToken).NoContext();
-        } catch (Exception e) {
-            throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
-                ? new OptimisticConcurrencyException(
-                    new StreamName(string.Join(", ", appends.Select(a => a.StreamName.ToString()))), e)
-                : e;
-        }
-
-        static NewStreamEvent ToStreamEvent(ProposedEvent evt, AmendEvent? amendEvent) {
-            var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt.Data, evt.Metadata);
-            return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+                return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+            }
         }
     }
 }

--- a/src/Core/src/Eventuous.Application/Persistence/WriterExtensions.cs
+++ b/src/Core/src/Eventuous.Application/Persistence/WriterExtensions.cs
@@ -42,11 +42,15 @@ static class WriterExtensions {
             ) {
             if (appends.Count == 0) return [];
 
-            var streamAppends = appends.Select(a => new NewStreamAppend(
-                        a.StreamName,
-                        a.ExpectedVersion,
-                        a.Events.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
-                    )
+            var streamAppends = appends.Select(a => {
+                        Ensure.NotNull(a.Events);
+
+                        return new NewStreamAppend(
+                            a.StreamName,
+                            a.ExpectedVersion,
+                            a.Events.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
+                        );
+                    }
                 )
                 .ToArray();
 

--- a/src/Core/src/Eventuous.Application/Persistence/WriterExtensions.cs
+++ b/src/Core/src/Eventuous.Application/Persistence/WriterExtensions.cs
@@ -31,4 +31,35 @@ static class WriterExtensions {
             return amendEvent?.Invoke(streamEvent) ?? streamEvent;
         }
     }
+
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public static async Task<AppendEventsResult[]> Store(
+        this IEventWriter writer,
+        IReadOnlyCollection<ProposedAppend> appends,
+        AmendEvent? amendEvent,
+        CancellationToken cancellationToken
+    ) {
+        if (appends.Count == 0) return [];
+
+        var streamAppends = appends.Select(a => new NewStreamAppend(
+            a.StreamName,
+            a.ExpectedVersion,
+            a.Events.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
+        )).ToArray();
+
+        try {
+            return await writer.AppendEvents(streamAppends, cancellationToken).NoContext();
+        } catch (Exception e) {
+            throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
+                ? new OptimisticConcurrencyException(
+                    new StreamName(string.Join(", ", appends.Select(a => a.StreamName.ToString()))), e)
+                : e;
+        }
+
+        static NewStreamEvent ToStreamEvent(ProposedEvent evt, AmendEvent? amendEvent) {
+            var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt.Data, evt.Metadata);
+            return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+        }
+    }
 }

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventStore.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventStore.cs
@@ -32,10 +32,7 @@ public class TracedEventStore(IEventStore eventStore) : BaseTracer, IEventStore 
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<AppendEventsResult[]> AppendEvents(
-            IReadOnlyCollection<NewStreamAppend> appends,
-            CancellationToken                    cancellationToken
-        )
+    public Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken)
         => Writer.AppendEvents(appends, cancellationToken);
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventStore.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventStore.cs
@@ -32,6 +32,14 @@ public class TracedEventStore(IEventStore eventStore) : BaseTracer, IEventStore 
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public Task<AppendEventsResult[]> AppendEvents(
+            IReadOnlyCollection<NewStreamAppend> appends,
+            CancellationToken                    cancellationToken
+        )
+        => Writer.AppendEvents(appends, cancellationToken);
+
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
     public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
         => Reader.ReadEvents(stream, start, count, failIfNotFound, cancellationToken);
 

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventWriter.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventWriter.cs
@@ -48,6 +48,8 @@ public class TracedEventWriter(IEventWriter writer) : BaseTracer, IEventWriter {
             IReadOnlyCollection<NewStreamAppend> appends,
             CancellationToken                    cancellationToken
         ) {
+        if (appends.Count == 0) return [];
+
         var streamNames = new StreamName(string.Join(", ", appends.Select(a => a.StreamName.ToString())));
         using var activity = StartActivity(streamNames, Operations.AppendEvents);
 

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventWriter.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventWriter.cs
@@ -44,22 +44,21 @@ public class TracedEventWriter(IEventWriter writer) : BaseTracer, IEventWriter {
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public async Task<AppendEventsResult[]> AppendEvents(
-            IReadOnlyCollection<NewStreamAppend> appends,
-            CancellationToken                    cancellationToken
-        ) {
+    public async Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken) {
         if (appends.Count == 0) return [];
 
-        var streamNames = new StreamName(string.Join(", ", appends.Select(a => a.StreamName.ToString())));
-        using var activity = StartActivity(streamNames, Operations.AppendEvents);
+        var       streamNames = new StreamName(string.Join(", ", appends.Select(a => a.StreamName.ToString())));
+        using var activity    = StartActivity(streamNames, Operations.AppendEvents);
 
         using var measure = Measure.Start(MetricsSource, new PersistenceMetricsContext(ComponentName, Operations.AppendEvents));
 
         var tracedAppends = appends.Select(a => new NewStreamAppend(
-            a.StreamName,
-            a.ExpectedVersion,
-            a.Events.Select(x => x with { Metadata = x.Metadata.AddActivityTags(activity) }).ToArray()
-        )).ToArray();
+                    a.StreamName,
+                    a.ExpectedVersion,
+                    a.Events.Select(x => x with { Metadata = x.Metadata.AddActivityTags(activity) }).ToArray()
+                )
+            )
+            .ToArray();
 
         try {
             var results = await writer.AppendEvents(tracedAppends, cancellationToken).NoContext();

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventWriter.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventWriter.cs
@@ -42,6 +42,36 @@ public class TracedEventWriter(IEventWriter writer) : BaseTracer, IEventWriter {
         }
     }
 
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public async Task<AppendEventsResult[]> AppendEvents(
+            IReadOnlyCollection<NewStreamAppend> appends,
+            CancellationToken                    cancellationToken
+        ) {
+        var streamNames = new StreamName(string.Join(", ", appends.Select(a => a.StreamName.ToString())));
+        using var activity = StartActivity(streamNames, Operations.AppendEvents);
+
+        using var measure = Measure.Start(MetricsSource, new PersistenceMetricsContext(ComponentName, Operations.AppendEvents));
+
+        var tracedAppends = appends.Select(a => new NewStreamAppend(
+            a.StreamName,
+            a.ExpectedVersion,
+            a.Events.Select(x => x with { Metadata = x.Metadata.AddActivityTags(activity) }).ToArray()
+        )).ToArray();
+
+        try {
+            var results = await writer.AppendEvents(tracedAppends, cancellationToken).NoContext();
+            activity?.SetActivityStatus(ActivityStatus.Ok());
+
+            return results;
+        } catch (Exception e) {
+            activity?.SetActivityStatus(ActivityStatus.Error(e));
+            measure.SetError();
+
+            throw;
+        }
+    }
+
     // ReSharper disable once ConvertToAutoProperty
     protected override string ComponentName => _componentName;
 }

--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventWriter.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventWriter.cs
@@ -21,4 +21,30 @@ public interface IEventWriter {
             IReadOnlyCollection<NewStreamEvent> events,
             CancellationToken                   cancellationToken
         );
+
+    /// <summary>
+    /// Append events to multiple streams. Default implementation calls single-stream AppendEvents
+    /// sequentially with fail-fast semantics (no cross-stream atomicity guarantee).
+    /// Stores that support atomic multi-stream writes should override this method.
+    /// </summary>
+    /// <param name="appends">Collection of stream appends to perform</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Array of append results, one per stream in the same order as input</returns>
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    async Task<AppendEventsResult[]> AppendEvents(
+        IReadOnlyCollection<NewStreamAppend> appends,
+        CancellationToken                    cancellationToken
+    ) {
+        var results = new AppendEventsResult[appends.Count];
+        var i = 0;
+
+        foreach (var append in appends) {
+            results[i++] = append.Events.Count == 0
+                ? AppendEventsResult.NoOp
+                : await AppendEvents(append.StreamName, append.ExpectedVersion, append.Events, cancellationToken);
+        }
+
+        return results;
+    }
 }

--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventWriter.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventWriter.cs
@@ -32,12 +32,9 @@ public interface IEventWriter {
     /// <returns>Array of append results, one per stream in the same order as input</returns>
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    async Task<AppendEventsResult[]> AppendEvents(
-        IReadOnlyCollection<NewStreamAppend> appends,
-        CancellationToken                    cancellationToken
-    ) {
+    async Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken) {
         var results = new AppendEventsResult[appends.Count];
-        var i = 0;
+        var i       = 0;
 
         foreach (var append in appends) {
             results[i++] = append.Events.Count == 0

--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventWriter.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventWriter.cs
@@ -37,9 +37,10 @@ public interface IEventWriter {
         var i       = 0;
 
         foreach (var append in appends) {
-            results[i++] = append.Events.Count == 0
-                ? AppendEventsResult.NoOp
-                : await AppendEvents(append.StreamName, append.ExpectedVersion, append.Events, cancellationToken);
+            Ensure.NotNull(append.Events);
+            if (append.Events.Count == 0) throw new InvalidOperationException($"Append to stream {append.StreamName} has no events");
+
+            results[i++] = await AppendEvents(append.StreamName, append.ExpectedVersion, append.Events, cancellationToken).NoContext();
         }
 
         return results;

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -62,11 +62,15 @@ public static class StoreFunctions {
             ) {
             if (streams.Count == 0) return [];
 
-            var appends = streams.Select(s => new NewStreamAppend(
-                        s.StreamName,
-                        s.ExpectedVersion,
-                        s.Changes.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
-                    )
+            var appends = streams.Select(s => {
+                        Ensure.NotNull(s.Changes);
+
+                        return new NewStreamAppend(
+                            s.StreamName,
+                            s.ExpectedVersion,
+                            s.Changes.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
+                        );
+                    }
                 )
                 .ToArray();
 

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -4,83 +4,88 @@
 namespace Eventuous;
 
 public static class StoreFunctions {
-    /// <summary>
-    /// Stores a collection of events to the event store
-    /// </summary>
     /// <param name="eventWriter">Event writer or event store</param>
-    /// <param name="streamName">Name of the stream where events will be appended to</param>
-    /// <param name="expectedStreamVersion">Expected version of the stream in the event store</param>
-    /// <param name="changes">Collection of events to store</param>
-    /// <param name="amendEvent">Optional: function to add extra information to an event before it gets stored</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Append events result</returns>
-    /// <exception cref="Exception">Any exception that occurred in the event store</exception>
-    /// <exception cref="OptimisticConcurrencyException">Gets thrown if the expected stream version mismatches with the given original stream version</exception>
-    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
-    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public static async Task<AppendEventsResult> Store(
-            this IEventWriter           eventWriter,
-            StreamName                  streamName,
-            ExpectedStreamVersion       expectedStreamVersion,
-            IReadOnlyCollection<object> changes,
-            AmendEvent?                 amendEvent        = null,
-            CancellationToken           cancellationToken = default
-        ) {
-        Ensure.NotNull(changes);
+    extension(IEventWriter eventWriter) {
+        /// <summary>
+        /// Stores a collection of events in the event store
+        /// </summary>
+        /// <param name="streamName">Name of the stream where events will be appended to</param>
+        /// <param name="expectedStreamVersion">Expected version of the stream in the event store</param>
+        /// <param name="changes">Collection of events to store</param>
+        /// <param name="amendEvent">Optional: function to add extra information to an event before it gets stored</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Append events result</returns>
+        /// <exception cref="Exception">Any exception that occurred in the event store</exception>
+        /// <exception cref="OptimisticConcurrencyException">Gets thrown if the expected stream version mismatches with the given original stream version</exception>
+        [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+        [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+        public async Task<AppendEventsResult> Store(
+                StreamName                  streamName,
+                ExpectedStreamVersion       expectedStreamVersion,
+                IReadOnlyCollection<object> changes,
+                AmendEvent?                 amendEvent        = null,
+                CancellationToken           cancellationToken = default
+            ) {
+            Ensure.NotNull(changes);
 
-        if (changes.Count == 0) return AppendEventsResult.NoOp;
+            if (changes.Count == 0) return AppendEventsResult.NoOp;
 
-        try {
-            var result = await eventWriter.AppendEvents(
-                    streamName,
-                    expectedStreamVersion,
-                    changes.Select(ToStreamEvent).ToArray(),
-                    cancellationToken
+            try {
+                var result = await eventWriter.AppendEvents(
+                        streamName,
+                        expectedStreamVersion,
+                        changes.Select(ToStreamEvent).ToArray(),
+                        cancellationToken
+                    )
+                    .NoContext();
+
+                return result;
+            } catch (Exception e) {
+                throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
+                    ? new OptimisticConcurrencyException(streamName, e)
+                    : e;
+            }
+
+            NewStreamEvent ToStreamEvent(object evt) {
+                var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt, new());
+
+                return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+            }
+        }
+
+        [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+        [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+        public async Task<AppendEventsResult[]> Store(
+                IReadOnlyCollection<(StreamName StreamName, ExpectedStreamVersion ExpectedVersion, IReadOnlyCollection<object> Changes)> streams,
+                AmendEvent?                                                                                                              amendEvent        = null,
+                CancellationToken                                                                                                        cancellationToken = default
+            ) {
+            if (streams.Count == 0) return [];
+
+            var appends = streams.Select(s => new NewStreamAppend(
+                        s.StreamName,
+                        s.ExpectedVersion,
+                        s.Changes.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
+                    )
                 )
-                .NoContext();
+                .ToArray();
 
-            return result;
-        } catch (Exception e) {
-            throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
-                ? new OptimisticConcurrencyException(streamName, e)
-                : e;
-        }
+            try {
+                return await eventWriter.AppendEvents(appends, cancellationToken).NoContext();
+            } catch (Exception e) {
+                throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
+                    ? new OptimisticConcurrencyException(
+                        new StreamName(string.Join(", ", streams.Select(s => s.StreamName.ToString()))),
+                        e
+                    )
+                    : e;
+            }
 
-        NewStreamEvent ToStreamEvent(object evt) {
-            var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt, new());
+            static NewStreamEvent ToStreamEvent(object evt, AmendEvent? amendEvent) {
+                var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt, new());
 
-            return amendEvent?.Invoke(streamEvent) ?? streamEvent;
-        }
-    }
-
-    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
-    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public static async Task<AppendEventsResult[]> Store(
-            this IEventWriter eventWriter,
-            IReadOnlyCollection<(StreamName StreamName, ExpectedStreamVersion ExpectedVersion, IReadOnlyCollection<object> Changes)> streams,
-            AmendEvent?       amendEvent        = null,
-            CancellationToken cancellationToken = default
-        ) {
-        if (streams.Count == 0) return [];
-
-        var appends = streams.Select(s => new NewStreamAppend(
-            s.StreamName,
-            s.ExpectedVersion,
-            s.Changes.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
-        )).ToArray();
-
-        try {
-            return await eventWriter.AppendEvents(appends, cancellationToken).NoContext();
-        } catch (Exception e) {
-            throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
-                ? new OptimisticConcurrencyException(
-                    new StreamName(string.Join(", ", streams.Select(s => s.StreamName.ToString()))), e)
-                : e;
-        }
-
-        static NewStreamEvent ToStreamEvent(object evt, AmendEvent? amendEvent) {
-            var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt, new());
-            return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+                return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+            }
         }
     }
 

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -53,6 +53,37 @@ public static class StoreFunctions {
         }
     }
 
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public static async Task<AppendEventsResult[]> Store(
+            this IEventWriter eventWriter,
+            IReadOnlyCollection<(StreamName StreamName, ExpectedStreamVersion ExpectedVersion, IReadOnlyCollection<object> Changes)> streams,
+            AmendEvent?       amendEvent        = null,
+            CancellationToken cancellationToken = default
+        ) {
+        if (streams.Count == 0) return [];
+
+        var appends = streams.Select(s => new NewStreamAppend(
+            s.StreamName,
+            s.ExpectedVersion,
+            s.Changes.Select(evt => ToStreamEvent(evt, amendEvent)).ToArray()
+        )).ToArray();
+
+        try {
+            return await eventWriter.AppendEvents(appends, cancellationToken).NoContext();
+        } catch (Exception e) {
+            throw e.InnerException?.Message.Contains("WrongExpectedVersion") == true
+                ? new OptimisticConcurrencyException(
+                    new StreamName(string.Join(", ", streams.Select(s => s.StreamName.ToString()))), e)
+                : e;
+        }
+
+        static NewStreamEvent ToStreamEvent(object evt, AmendEvent? amendEvent) {
+            var streamEvent = new NewStreamEvent(Guid.NewGuid(), evt, new());
+            return amendEvent?.Invoke(streamEvent) ?? streamEvent;
+        }
+    }
+
     /// <summary>
     /// Reads a stream from the event store to a collection of <seealso cref="StreamEvent"/>
     /// </summary>

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventStore.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventStore.cs
@@ -33,6 +33,13 @@ public class TieredEventStore(IEventStore hotStore, IEventReader archiveReader) 
             CancellationToken                   cancellationToken
         ) => hotStore.AppendEvents(stream, expectedVersion, events, cancellationToken);
 
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public Task<AppendEventsResult[]> AppendEvents(
+            IReadOnlyCollection<NewStreamAppend> appends,
+            CancellationToken                    cancellationToken
+        ) => hotStore.AppendEvents(appends, cancellationToken);
+
     public async Task<bool> StreamExists(StreamName stream, CancellationToken cancellationToken = default) {
         var hotExists     = await hotStore.StreamExists(stream, cancellationToken);
         var archiveExists = archiveReader is IEventStore store && await store.StreamExists(stream, cancellationToken);

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventStore.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventStore.cs
@@ -35,10 +35,8 @@ public class TieredEventStore(IEventStore hotStore, IEventReader archiveReader) 
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<AppendEventsResult[]> AppendEvents(
-            IReadOnlyCollection<NewStreamAppend> appends,
-            CancellationToken                    cancellationToken
-        ) => hotStore.AppendEvents(appends, cancellationToken);
+    public Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken)
+        => hotStore.AppendEvents(appends, cancellationToken);
 
     public async Task<bool> StreamExists(StreamName stream, CancellationToken cancellationToken = default) {
         var hotExists     = await hotStore.StreamExists(stream, cancellationToken);

--- a/src/Core/src/Eventuous.Persistence/StreamEvent.cs
+++ b/src/Core/src/Eventuous.Persistence/StreamEvent.cs
@@ -9,4 +9,11 @@ namespace Eventuous;
 public record struct NewStreamEvent(Guid Id, object? Payload, Metadata Metadata);
 
 [StructLayout(LayoutKind.Auto)]
+public record struct NewStreamAppend(
+    StreamName StreamName,
+    ExpectedStreamVersion ExpectedVersion,
+    IReadOnlyCollection<NewStreamEvent> Events
+);
+
+[StructLayout(LayoutKind.Auto)]
 public record struct StreamEvent(Guid Id, object? Payload, Metadata Metadata, string ContentType, long Revision, bool FromArchive = false);

--- a/src/Core/src/Eventuous.Persistence/StreamEvent.cs
+++ b/src/Core/src/Eventuous.Persistence/StreamEvent.cs
@@ -9,11 +9,14 @@ namespace Eventuous;
 public record struct NewStreamEvent(Guid Id, object? Payload, Metadata Metadata);
 
 [StructLayout(LayoutKind.Auto)]
-public record struct NewStreamAppend(
-    StreamName StreamName,
-    ExpectedStreamVersion ExpectedVersion,
-    IReadOnlyCollection<NewStreamEvent> Events
-);
+public record struct NewStreamAppend(StreamName StreamName, ExpectedStreamVersion ExpectedVersion, IReadOnlyCollection<NewStreamEvent> Events);
 
 [StructLayout(LayoutKind.Auto)]
-public record struct StreamEvent(Guid Id, object? Payload, Metadata Metadata, string ContentType, long Revision, bool FromArchive = false);
+public record struct StreamEvent(
+        Guid     Id,
+        object?  Payload,
+        Metadata Metadata,
+        string   ContentType,
+        long     Revision,
+        bool     FromArchive = false
+    );

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Fixtures/Helpers.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Fixtures/Helpers.cs
@@ -31,5 +31,8 @@ public static class Helpers {
 
         public Task<AppendEventsResult> StoreChanges(StreamName stream, object evt, ExpectedStreamVersion version)
             => fixture.EventStore.Store(stream, version, [evt]);
+
+        public Task<AppendEventsResult[]> AppendEventsToMultipleStreams(IReadOnlyCollection<NewStreamAppend> appends)
+            => fixture.EventStore.AppendEvents(appends, default);
     }
 }

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Append.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Append.cs
@@ -76,4 +76,52 @@ public abstract class StoreAppendTests<T> where T : StoreFixtureBase {
 
         await Assert.That(() => _fixture.StoreChanges(stream, evt, new(3))!).Throws<OptimisticConcurrencyException>();
     }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldAppendToMultipleStreams() {
+        var evt1    = Helpers.CreateEvent();
+        var evt2    = Helpers.CreateEvent();
+        var stream1 = Helpers.GetStreamName();
+        var stream2 = Helpers.GetStreamName();
+
+        var results = await _fixture.AppendEventsToMultipleStreams(
+            [
+                new NewStreamAppend(stream1, ExpectedStreamVersion.NoStream, [new NewStreamEvent(Guid.NewGuid(), evt1, new())]),
+                new NewStreamAppend(stream2, ExpectedStreamVersion.NoStream, [new NewStreamEvent(Guid.NewGuid(), evt2, new())])
+            ]
+        );
+
+        await Assert.That(results).HasCount().EqualTo(2);
+        await Assert.That(results[0].NextExpectedVersion).IsEqualTo(0);
+        await Assert.That(results[1].NextExpectedVersion).IsEqualTo(0);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldAppendToMultipleStreamsWithExistingStreams() {
+        var stream1 = Helpers.GetStreamName();
+        var stream2 = Helpers.GetStreamName();
+
+        var r1 = await _fixture.AppendEvent(stream1, Helpers.CreateEvent(), ExpectedStreamVersion.NoStream);
+        var r2 = await _fixture.AppendEvent(stream2, Helpers.CreateEvent(), ExpectedStreamVersion.NoStream);
+
+        var results = await _fixture.AppendEventsToMultipleStreams(
+            [
+                new NewStreamAppend(stream1, new(r1.NextExpectedVersion), [new NewStreamEvent(Guid.NewGuid(), Helpers.CreateEvent(), new())]),
+                new NewStreamAppend(stream2, new(r2.NextExpectedVersion), [new NewStreamEvent(Guid.NewGuid(), Helpers.CreateEvent(), new())])
+            ]
+        );
+
+        await Assert.That(results).HasCount().EqualTo(2);
+        await Assert.That(results[0].NextExpectedVersion).IsEqualTo(1);
+        await Assert.That(results[1].NextExpectedVersion).IsEqualTo(1);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReturnEmptyResultsForEmptyAppends() {
+        var results = await _fixture.AppendEventsToMultipleStreams([]);
+        await Assert.That(results).HasCount().EqualTo(0);
+    }
 }

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Append.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Append.cs
@@ -63,7 +63,6 @@ public abstract class StoreAppendTests<T> where T : StoreFixtureBase {
         await Assert.That(() => _fixture.AppendEvent(stream, evt, new(3))!).Throws<AppendToStreamException>();
     }
 
-
     [Test]
     [Category("Store")]
     public async Task ShouldFailOnWrongVersionWithOptimisticConcurrencyException() {
@@ -87,8 +86,8 @@ public abstract class StoreAppendTests<T> where T : StoreFixtureBase {
 
         var results = await _fixture.AppendEventsToMultipleStreams(
             [
-                new NewStreamAppend(stream1, ExpectedStreamVersion.NoStream, [new NewStreamEvent(Guid.NewGuid(), evt1, new())]),
-                new NewStreamAppend(stream2, ExpectedStreamVersion.NoStream, [new NewStreamEvent(Guid.NewGuid(), evt2, new())])
+                new(stream1, ExpectedStreamVersion.NoStream, [new(Guid.NewGuid(), evt1, new())]),
+                new(stream2, ExpectedStreamVersion.NoStream, [new(Guid.NewGuid(), evt2, new())])
             ]
         );
 
@@ -108,8 +107,8 @@ public abstract class StoreAppendTests<T> where T : StoreFixtureBase {
 
         var results = await _fixture.AppendEventsToMultipleStreams(
             [
-                new NewStreamAppend(stream1, new(r1.NextExpectedVersion), [new NewStreamEvent(Guid.NewGuid(), Helpers.CreateEvent(), new())]),
-                new NewStreamAppend(stream2, new(r2.NextExpectedVersion), [new NewStreamEvent(Guid.NewGuid(), Helpers.CreateEvent(), new())])
+                new(stream1, new(r1.NextExpectedVersion), [new(Guid.NewGuid(), Helpers.CreateEvent(), new())]),
+                new(stream2, new(r2.NextExpectedVersion), [new(Guid.NewGuid(), Helpers.CreateEvent(), new())])
             ]
         );
 

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -167,15 +167,13 @@ public partial class KurrentDBEventStore : IEventStore {
         return TryExecute(
             async () => {
                 var requests = appends.Select(a => new AppendStreamRequest(
-                    a.StreamName,
-                    ToStreamState(a.ExpectedVersion),
-                    a.Events.Select(ToEventData)
-                ));
+                        a.StreamName,
+                        ToStreamState(a.ExpectedVersion),
+                        a.Events.Select(ToEventData)
+                    )
+                );
 
-                var result = await _client.MultiStreamAppendAsync(
-                    ToAsyncEnumerable(requests),
-                    cancellationToken
-                ).AsTask().NoContext();
+                var result = await _client.MultiStreamAppendAsync(ToAsyncEnumerable(requests), cancellationToken).NoContext();
 
                 var responseMap = new Dictionary<string, long>();
 
@@ -184,14 +182,16 @@ public partial class KurrentDBEventStore : IEventStore {
                 }
 
                 return appends.Select(a => {
-                    if (a.Events.Count == 0) return AppendEventsResult.NoOp;
+                            if (a.Events.Count == 0) return AppendEventsResult.NoOp;
 
-                    var streamName = a.StreamName.ToString();
+                            var streamName = a.StreamName.ToString();
 
-                    return responseMap.TryGetValue(streamName, out var revision)
-                        ? new AppendEventsResult((ulong)result.Position, revision)
-                        : AppendEventsResult.NoOp;
-                }).ToArray();
+                            return responseMap.TryGetValue(streamName, out var revision)
+                                ? new AppendEventsResult((ulong)result.Position, revision)
+                                : AppendEventsResult.NoOp;
+                        }
+                    )
+                    .ToArray();
             },
             string.Join(", ", appends.Select(a => a.StreamName.ToString())),
             true,
@@ -202,6 +202,12 @@ public partial class KurrentDBEventStore : IEventStore {
                 return new AppendToStreamException(s, ex);
             }
         );
+
+        static async IAsyncEnumerable<AppendStreamRequest> ToAsyncEnumerable(IEnumerable<AppendStreamRequest> source) {
+            foreach (var item in source) {
+                yield return item;
+            }
+        }
 
         [RequiresDynamicCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
         [RequiresUnreferencedCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
@@ -215,12 +221,6 @@ public partial class KurrentDBEventStore : IEventStore {
                 _metaSerializer.Serialize(streamEvent.Metadata),
                 contentType
             );
-        }
-
-        static async IAsyncEnumerable<AppendStreamRequest> ToAsyncEnumerable(IEnumerable<AppendStreamRequest> source) {
-            foreach (var item in source) {
-                yield return item;
-            }
         }
     }
 

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -158,6 +158,75 @@ public partial class KurrentDBEventStore : IEventStore {
     /// <inheritdoc/>
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public Task<AppendEventsResult[]> AppendEvents(
+            IReadOnlyCollection<NewStreamAppend> appends,
+            CancellationToken                    cancellationToken = default
+        ) {
+        if (appends.Count == 0) return Task.FromResult(Array.Empty<AppendEventsResult>());
+
+        return TryExecute(
+            async () => {
+                var requests = appends.Select(a => new AppendStreamRequest(
+                    a.StreamName,
+                    ToStreamState(a.ExpectedVersion),
+                    a.Events.Select(ToEventData)
+                ));
+
+                var result = await _client.MultiStreamAppendAsync(
+                    ToAsyncEnumerable(requests),
+                    cancellationToken
+                ).AsTask().NoContext();
+
+                var responseMap = new Dictionary<string, long>();
+
+                foreach (var resp in result.Responses ?? []) {
+                    responseMap[resp.Stream] = resp.StreamRevision;
+                }
+
+                return appends.Select(a => {
+                    if (a.Events.Count == 0) return AppendEventsResult.NoOp;
+
+                    var streamName = a.StreamName.ToString();
+
+                    return responseMap.TryGetValue(streamName, out var revision)
+                        ? new AppendEventsResult((ulong)result.Position, revision)
+                        : AppendEventsResult.NoOp;
+                }).ToArray();
+            },
+            string.Join(", ", appends.Select(a => a.StreamName.ToString())),
+            true,
+            () => new("Unable to append events to multiple streams"),
+            (s, ex) => {
+                Log.UnableToAppendEvents(s, ex);
+
+                return new AppendToStreamException(s, ex);
+            }
+        );
+
+        [RequiresDynamicCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
+        [RequiresUnreferencedCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
+        EventData ToEventData(NewStreamEvent streamEvent) {
+            var (eventType, contentType, payload) = _serializer.SerializeEvent(streamEvent.Payload!);
+
+            return new(
+                Uuid.FromGuid(streamEvent.Id),
+                eventType,
+                payload,
+                _metaSerializer.Serialize(streamEvent.Metadata),
+                contentType
+            );
+        }
+
+        static async IAsyncEnumerable<AppendStreamRequest> ToAsyncEnumerable(IEnumerable<AppendStreamRequest> source) {
+            foreach (var item in source) {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
     public async Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken = default) {
         var read = _client.ReadStreamAsync(Direction.Forwards, stream, start.AsStreamPosition(), count, cancellationToken: cancellationToken);
 

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -182,13 +182,11 @@ public partial class KurrentDBEventStore : IEventStore {
                 }
 
                 return appends.Select(a => {
-                            if (a.Events.Count == 0) return AppendEventsResult.NoOp;
-
                             var streamName = a.StreamName.ToString();
 
                             return responseMap.TryGetValue(streamName, out var revision)
                                 ? new AppendEventsResult((ulong)result.Position, revision)
-                                : AppendEventsResult.NoOp;
+                                : throw new InvalidOperationException($"No response received for stream {streamName}");
                         }
                     )
                     .ToArray();

--- a/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
@@ -192,6 +192,61 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
     }
 
     /// <inheritdoc />
+    [RequiresDynamicCode(Constants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(Constants.DynamicSerializationMessage)]
+    public virtual async Task<AppendEventsResult[]> AppendEvents(
+            IReadOnlyCollection<NewStreamAppend> appends,
+            CancellationToken                    cancellationToken
+        ) {
+        if (appends.Count == 0) return [];
+
+        await using var connection  = await OpenConnection(cancellationToken).NoContext();
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken).NoContext();
+
+        try {
+            var results = new AppendEventsResult[appends.Count];
+            var i = 0;
+
+            foreach (var append in appends) {
+                if (append.Events.Count == 0) {
+                    results[i++] = AppendEventsResult.NoOp;
+
+                    continue;
+                }
+
+                var persistedEvents = append.Events.Where(x => x.Payload != null).Select(Convert).ToArray();
+                await using var cmd = GetAppendCommand(connection, (TTransaction)transaction, append.StreamName, append.ExpectedVersion, persistedEvents);
+
+                await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).NoContext();
+                await reader.ReadAsync(cancellationToken).NoContext();
+                results[i++] = new((ulong)reader.GetInt64(1), reader.GetInt32(0));
+            }
+
+            await transaction.CommitAsync(cancellationToken).NoContext();
+
+            return results;
+        } catch (Exception e) {
+            await transaction.RollbackAsync(cancellationToken).NoContext();
+
+            var streamNames = string.Join(", ", appends.Select(a => a.StreamName.ToString()));
+            PersistenceEventSource.Log.UnableToAppendEvents(streamNames, e);
+
+            throw IsConflict(e) ? new AppendToStreamException(streamNames, e) : e;
+        }
+
+        [RequiresUnreferencedCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
+        [RequiresDynamicCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
+        NewPersistedEvent Convert(NewStreamEvent evt) {
+            var data = Serializer.SerializeEvent(evt.Payload!);
+            var meta = MetaSerializer.Serialize(evt.Metadata);
+
+            return new(evt.Id, data.EventType, AsString(data.Payload), AsString(meta));
+        }
+
+        string AsString(ReadOnlySpan<byte> bytes) => Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <inheritdoc />
     public async Task<bool> StreamExists(StreamName stream, CancellationToken cancellationToken) {
         await using var connection = await OpenConnection(cancellationToken).NoContext();
         await using var cmd        = GetStreamExistsCommand(connection, stream);

--- a/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
@@ -143,6 +143,7 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
             FailedToDeserialize failed       => throw new SerializationException($"Can't deserialize {evt.MessageType}: {failed.Error}"),
             _                                => throw new("Unknown deserialization result")
         };
+
         StreamEvent AsStreamEvent(object payload) => new(evt.MessageId, payload, meta ?? new Metadata(), ContentType, evt.StreamPosition);
     }
 
@@ -194,10 +195,7 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
     /// <inheritdoc />
     [RequiresDynamicCode(Constants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(Constants.DynamicSerializationMessage)]
-    public virtual async Task<AppendEventsResult[]> AppendEvents(
-            IReadOnlyCollection<NewStreamAppend> appends,
-            CancellationToken                    cancellationToken
-        ) {
+    public virtual async Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken) {
         if (appends.Count == 0) return [];
 
         await using var connection  = await OpenConnection(cancellationToken).NoContext();
@@ -205,7 +203,7 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
 
         try {
             var results = new AppendEventsResult[appends.Count];
-            var i = 0;
+            var i       = 0;
 
             foreach (var append in appends) {
                 if (append.Events.Count == 0) {
@@ -215,6 +213,7 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
                 }
 
                 var persistedEvents = append.Events.Where(x => x.Payload != null).Select(Convert).ToArray();
+
                 await using var cmd = GetAppendCommand(connection, (TTransaction)transaction, append.StreamName, append.ExpectedVersion, persistedEvents);
 
                 await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).NoContext();

--- a/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
@@ -206,12 +206,6 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
             var i       = 0;
 
             foreach (var append in appends) {
-                if (append.Events.Count == 0) {
-                    results[i++] = AppendEventsResult.NoOp;
-
-                    continue;
-                }
-
                 var persistedEvents = append.Events.Where(x => x.Payload != null).Select(Convert).ToArray();
 
                 await using var cmd = GetAppendCommand(connection, (TTransaction)transaction, append.StreamName, append.ExpectedVersion, persistedEvents);

--- a/src/Sqlite/src/Eventuous.Sqlite/SqliteStore.cs
+++ b/src/Sqlite/src/Eventuous.Sqlite/SqliteStore.cs
@@ -90,82 +90,10 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
         await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken).NoContext();
 
         try {
-            // Ensure stream exists (idempotent insert)
-            await using (var insertStreamCmd = connection.GetTextCommand(
-                $"INSERT OR IGNORE INTO {Schema.StreamsTable} (stream_name, version) VALUES (@name, -1)", transaction
-            )) {
-                insertStreamCmd.Parameters.AddWithValue("@name", stream.ToString());
-                await insertStreamCmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
-            }
-
-            // Get current stream state
-            int streamId;
-            int currentVersion;
-
-            await using (var selectCmd = connection.GetTextCommand(
-                $"SELECT stream_id, version FROM {Schema.StreamsTable} WHERE stream_name = @name", transaction
-            )) {
-                selectCmd.Parameters.AddWithValue("@name", stream.ToString());
-                await using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).NoContext();
-                await reader.ReadAsync(cancellationToken).NoContext();
-                streamId       = reader.GetInt32(0);
-                currentVersion = reader.GetInt32(1);
-            }
-
-            // Validate expected version
-            if (expectedVersion != ExpectedStreamVersion.Any && currentVersion != expectedVersion.Value) {
-                throw new AppendToStreamException(
-                    stream,
-                    new InvalidOperationException(
-                        $"WrongExpectedVersion {expectedVersion.Value}, current version {currentVersion}"
-                    )
-                );
-            }
-
-            // Insert events
-            var  now                 = DateTime.UtcNow.ToString("o");
-            long lastGlobalPosition = 0;
-
-            for (var i = 0; i < persistedEvents.Length; i++) {
-                var evt            = persistedEvents[i];
-                var streamPosition = currentVersion + i + 1;
-
-                await using var insertCmd = connection.GetTextCommand(
-                    $"""
-                     INSERT INTO {Schema.MessagesTable}
-                         (message_id, message_type, stream_id, stream_position, json_data, json_metadata, created)
-                     VALUES (@message_id, @message_type, @stream_id, @stream_position, @json_data, @json_metadata, @created)
-                     RETURNING global_position
-                     """,
-                    transaction
-                );
-
-                insertCmd.Parameters.AddWithValue("@message_id", evt.MessageId.ToString());
-                insertCmd.Parameters.AddWithValue("@message_type", evt.MessageType);
-                insertCmd.Parameters.AddWithValue("@stream_id", streamId);
-                insertCmd.Parameters.AddWithValue("@stream_position", streamPosition);
-                insertCmd.Parameters.AddWithValue("@json_data", evt.JsonData);
-                insertCmd.Parameters.AddWithValue("@json_metadata", (object?)evt.JsonMetadata ?? DBNull.Value);
-                insertCmd.Parameters.AddWithValue("@created", now);
-
-                var result = await insertCmd.ExecuteScalarAsync(cancellationToken).NoContext();
-                lastGlobalPosition = System.Convert.ToInt64(result);
-            }
-
-            // Update stream version
-            var newVersion = currentVersion + persistedEvents.Length;
-
-            await using (var updateCmd = connection.GetTextCommand(
-                $"UPDATE {Schema.StreamsTable} SET version = @version WHERE stream_id = @id", transaction
-            )) {
-                updateCmd.Parameters.AddWithValue("@version", newVersion);
-                updateCmd.Parameters.AddWithValue("@id", streamId);
-                await updateCmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
-            }
-
+            var result = await AppendToStream(connection, transaction, stream, expectedVersion, persistedEvents, cancellationToken);
             await transaction.CommitAsync(cancellationToken).NoContext();
 
-            return new AppendEventsResult((ulong)lastGlobalPosition, newVersion);
+            return result;
         } catch (AppendToStreamException) {
             await transaction.RollbackAsync(cancellationToken).NoContext();
 
@@ -176,18 +104,148 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
 
             throw IsConflict(e) ? new AppendToStreamException(stream, e) : e;
         }
+    }
 
-        [RequiresUnreferencedCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
-        [RequiresDynamicCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
-        NewPersistedEvent Convert(NewStreamEvent evt) {
-            var data = Serializer.SerializeEvent(evt.Payload!);
-            var meta = MetaSerializer.Serialize(evt.Metadata);
+    /// <inheritdoc />
+    [RequiresDynamicCode("Only works with AOT when using DefaultStaticEventSerializer")]
+    [RequiresUnreferencedCode("Only works with AOT when using DefaultStaticEventSerializer")]
+    public override async Task<AppendEventsResult[]> AppendEvents(
+            IReadOnlyCollection<NewStreamAppend> appends,
+            CancellationToken                    cancellationToken
+        ) {
+        if (appends.Count == 0) return [];
 
-            return new(evt.Id, data.EventType, AsString(data.Payload), AsString(meta));
+        await using var connection  = await OpenConnection(cancellationToken).NoContext();
+        await using var transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken).NoContext();
+
+        try {
+            var results = new AppendEventsResult[appends.Count];
+            var i = 0;
+
+            foreach (var append in appends) {
+                if (append.Events.Count == 0) {
+                    results[i++] = AppendEventsResult.NoOp;
+
+                    continue;
+                }
+
+                var persistedEvents = append.Events.Where(x => x.Payload != null).Select(Convert).ToArray();
+
+                results[i++] = persistedEvents.Length == 0
+                    ? AppendEventsResult.NoOp
+                    : await AppendToStream(connection, transaction, append.StreamName, append.ExpectedVersion, persistedEvents, cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken).NoContext();
+
+            return results;
+        } catch (AppendToStreamException) {
+            await transaction.RollbackAsync(cancellationToken).NoContext();
+
+            throw;
+        } catch (Exception e) {
+            await transaction.RollbackAsync(cancellationToken).NoContext();
+            var streamNames = string.Join(", ", appends.Select(a => a.StreamName.ToString()));
+            PersistenceEventSource.Log.UnableToAppendEvents(streamNames, e);
+
+            throw IsConflict(e) ? new AppendToStreamException(streamNames, e) : e;
+        }
+    }
+
+    async Task<AppendEventsResult> AppendToStream(
+            SqliteConnection      connection,
+            SqliteTransaction     transaction,
+            StreamName            stream,
+            ExpectedStreamVersion expectedVersion,
+            NewPersistedEvent[]   persistedEvents,
+            CancellationToken     cancellationToken
+        ) {
+        // Ensure stream exists (idempotent insert)
+        await using (var insertStreamCmd = connection.GetTextCommand(
+            $"INSERT OR IGNORE INTO {Schema.StreamsTable} (stream_name, version) VALUES (@name, -1)", transaction
+        )) {
+            insertStreamCmd.Parameters.AddWithValue("@name", stream.ToString());
+            await insertStreamCmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
         }
 
-        string AsString(ReadOnlySpan<byte> bytes) => Encoding.UTF8.GetString(bytes);
+        // Get current stream state
+        int streamId;
+        int currentVersion;
+
+        await using (var selectCmd = connection.GetTextCommand(
+            $"SELECT stream_id, version FROM {Schema.StreamsTable} WHERE stream_name = @name", transaction
+        )) {
+            selectCmd.Parameters.AddWithValue("@name", stream.ToString());
+            await using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).NoContext();
+            await reader.ReadAsync(cancellationToken).NoContext();
+            streamId       = reader.GetInt32(0);
+            currentVersion = reader.GetInt32(1);
+        }
+
+        // Validate expected version
+        if (expectedVersion != ExpectedStreamVersion.Any && currentVersion != expectedVersion.Value) {
+            throw new AppendToStreamException(
+                stream,
+                new InvalidOperationException(
+                    $"WrongExpectedVersion {expectedVersion.Value}, current version {currentVersion}"
+                )
+            );
+        }
+
+        // Insert events
+        var  now                 = DateTime.UtcNow.ToString("o");
+        long lastGlobalPosition = 0;
+
+        for (var i = 0; i < persistedEvents.Length; i++) {
+            var evt            = persistedEvents[i];
+            var streamPosition = currentVersion + i + 1;
+
+            await using var insertCmd = connection.GetTextCommand(
+                $"""
+                 INSERT INTO {Schema.MessagesTable}
+                     (message_id, message_type, stream_id, stream_position, json_data, json_metadata, created)
+                 VALUES (@message_id, @message_type, @stream_id, @stream_position, @json_data, @json_metadata, @created)
+                 RETURNING global_position
+                 """,
+                transaction
+            );
+
+            insertCmd.Parameters.AddWithValue("@message_id", evt.MessageId.ToString());
+            insertCmd.Parameters.AddWithValue("@message_type", evt.MessageType);
+            insertCmd.Parameters.AddWithValue("@stream_id", streamId);
+            insertCmd.Parameters.AddWithValue("@stream_position", streamPosition);
+            insertCmd.Parameters.AddWithValue("@json_data", evt.JsonData);
+            insertCmd.Parameters.AddWithValue("@json_metadata", (object?)evt.JsonMetadata ?? DBNull.Value);
+            insertCmd.Parameters.AddWithValue("@created", now);
+
+            var result = await insertCmd.ExecuteScalarAsync(cancellationToken).NoContext();
+            lastGlobalPosition = System.Convert.ToInt64(result);
+        }
+
+        // Update stream version
+        var newVersion = currentVersion + persistedEvents.Length;
+
+        await using (var updateCmd = connection.GetTextCommand(
+            $"UPDATE {Schema.StreamsTable} SET version = @version WHERE stream_id = @id", transaction
+        )) {
+            updateCmd.Parameters.AddWithValue("@version", newVersion);
+            updateCmd.Parameters.AddWithValue("@id", streamId);
+            await updateCmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
+        }
+
+        return new AppendEventsResult((ulong)lastGlobalPosition, newVersion);
     }
+
+    [RequiresUnreferencedCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
+    [RequiresDynamicCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]
+    NewPersistedEvent Convert(NewStreamEvent evt) {
+        var data = Serializer.SerializeEvent(evt.Payload!);
+        var meta = MetaSerializer.Serialize(evt.Metadata);
+
+        return new(evt.Id, data.EventType, AsString(data.Payload), AsString(meta));
+    }
+
+    static string AsString(ReadOnlySpan<byte> bytes) => Encoding.UTF8.GetString(bytes);
 
     protected override bool IsStreamNotFound(Exception exception) => false;
 

--- a/src/Sqlite/src/Eventuous.Sqlite/SqliteStore.cs
+++ b/src/Sqlite/src/Eventuous.Sqlite/SqliteStore.cs
@@ -120,12 +120,6 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
             var i       = 0;
 
             foreach (var append in appends) {
-                if (append.Events.Count == 0) {
-                    results[i++] = AppendEventsResult.NoOp;
-
-                    continue;
-                }
-
                 var persistedEvents = append.Events.Where(x => x.Payload != null).Select(Convert).ToArray();
 
                 results[i++] = persistedEvents.Length == 0

--- a/src/Sqlite/src/Eventuous.Sqlite/SqliteStore.cs
+++ b/src/Sqlite/src/Eventuous.Sqlite/SqliteStore.cs
@@ -109,10 +109,7 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
     /// <inheritdoc />
     [RequiresDynamicCode("Only works with AOT when using DefaultStaticEventSerializer")]
     [RequiresUnreferencedCode("Only works with AOT when using DefaultStaticEventSerializer")]
-    public override async Task<AppendEventsResult[]> AppendEvents(
-            IReadOnlyCollection<NewStreamAppend> appends,
-            CancellationToken                    cancellationToken
-        ) {
+    public override async Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken) {
         if (appends.Count == 0) return [];
 
         await using var connection  = await OpenConnection(cancellationToken).NoContext();
@@ -120,7 +117,7 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
 
         try {
             var results = new AppendEventsResult[appends.Count];
-            var i = 0;
+            var i       = 0;
 
             foreach (var append in appends) {
                 if (append.Events.Count == 0) {
@@ -162,8 +159,9 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
         ) {
         // Ensure stream exists (idempotent insert)
         await using (var insertStreamCmd = connection.GetTextCommand(
-            $"INSERT OR IGNORE INTO {Schema.StreamsTable} (stream_name, version) VALUES (@name, -1)", transaction
-        )) {
+                         $"INSERT OR IGNORE INTO {Schema.StreamsTable} (stream_name, version) VALUES (@name, -1)",
+                         transaction
+                     )) {
             insertStreamCmd.Parameters.AddWithValue("@name", stream.ToString());
             await insertStreamCmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
         }
@@ -173,8 +171,9 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
         int currentVersion;
 
         await using (var selectCmd = connection.GetTextCommand(
-            $"SELECT stream_id, version FROM {Schema.StreamsTable} WHERE stream_name = @name", transaction
-        )) {
+                         $"SELECT stream_id, version FROM {Schema.StreamsTable} WHERE stream_name = @name",
+                         transaction
+                     )) {
             selectCmd.Parameters.AddWithValue("@name", stream.ToString());
             await using var reader = await selectCmd.ExecuteReaderAsync(cancellationToken).NoContext();
             await reader.ReadAsync(cancellationToken).NoContext();
@@ -193,7 +192,7 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
         }
 
         // Insert events
-        var  now                 = DateTime.UtcNow.ToString("o");
+        var  now                = DateTime.UtcNow.ToString("o");
         long lastGlobalPosition = 0;
 
         for (var i = 0; i < persistedEvents.Length; i++) {
@@ -226,14 +225,15 @@ public class SqliteStore : SqlEventStoreBase<SqliteConnection, SqliteTransaction
         var newVersion = currentVersion + persistedEvents.Length;
 
         await using (var updateCmd = connection.GetTextCommand(
-            $"UPDATE {Schema.StreamsTable} SET version = @version WHERE stream_id = @id", transaction
-        )) {
+                         $"UPDATE {Schema.StreamsTable} SET version = @version WHERE stream_id = @id",
+                         transaction
+                     )) {
             updateCmd.Parameters.AddWithValue("@version", newVersion);
             updateCmd.Parameters.AddWithValue("@id", streamId);
             await updateCmd.ExecuteNonQueryAsync(cancellationToken).NoContext();
         }
 
-        return new AppendEventsResult((ulong)lastGlobalPosition, newVersion);
+        return new((ulong)lastGlobalPosition, newVersion);
     }
 
     [RequiresUnreferencedCode("Calls Eventuous.IEventSerializer.SerializeEvent(Object)")]

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -28,16 +28,14 @@ public class InMemoryEventStore : IEventStore {
     }
 
     /// <inheritdoc />
-    public Task<AppendEventsResult[]> AppendEvents(
-        IReadOnlyCollection<NewStreamAppend> appends,
-        CancellationToken cancellationToken
-    ) {
+    public Task<AppendEventsResult[]> AppendEvents(IReadOnlyCollection<NewStreamAppend> appends, CancellationToken cancellationToken) {
         var results = new AppendEventsResult[appends.Count];
-        var i = 0;
+        var i       = 0;
 
         foreach (var append in appends) {
             if (append.Events.Count == 0) {
                 results[i++] = AppendEventsResult.NoOp;
+
                 continue;
             }
 

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -33,12 +33,6 @@ public class InMemoryEventStore : IEventStore {
         var i       = 0;
 
         foreach (var append in appends) {
-            if (append.Events.Count == 0) {
-                results[i++] = AppendEventsResult.NoOp;
-
-                continue;
-            }
-
             var existing = _storage.GetOrAdd(append.StreamName, s => new(s));
             existing.AppendEvents(append.ExpectedVersion, append.Events);
             _global.AddRange(append.Events.Select((x, j) => new StreamEvent(x.Id, x.Payload, x.Metadata, "application/json", _global.Count + j)));

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -28,6 +28,29 @@ public class InMemoryEventStore : IEventStore {
     }
 
     /// <inheritdoc />
+    public Task<AppendEventsResult[]> AppendEvents(
+        IReadOnlyCollection<NewStreamAppend> appends,
+        CancellationToken cancellationToken
+    ) {
+        var results = new AppendEventsResult[appends.Count];
+        var i = 0;
+
+        foreach (var append in appends) {
+            if (append.Events.Count == 0) {
+                results[i++] = AppendEventsResult.NoOp;
+                continue;
+            }
+
+            var existing = _storage.GetOrAdd(append.StreamName, s => new(s));
+            existing.AppendEvents(append.ExpectedVersion, append.Events);
+            _global.AddRange(append.Events.Select((x, j) => new StreamEvent(x.Id, x.Payload, x.Metadata, "application/json", _global.Count + j)));
+            results[i++] = new AppendEventsResult((ulong)(_global.Count - 1), existing.Version);
+        }
+
+        return Task.FromResult(results);
+    }
+
+    /// <inheritdoc />
     public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
         => Task.FromResult(FindStream(stream, failIfNotFound).GetEvents(start, count).ToArray());
 


### PR DESCRIPTION
## Summary

- Add `NewStreamAppend` type and `AppendEvents(IReadOnlyCollection<NewStreamAppend>, CancellationToken)` overload to `IEventWriter` with a default sequential fail-fast fallback
- **KurrentDB**: native atomic via `MultiStreamAppendAsync` (requires KurrentDB 25.1+)
- **PostgreSQL / SQL Server**: atomic via single DB transaction in `SqlEventStoreBase`
- **SQLite**: atomic via single DB transaction (refactored to extract shared `AppendToStream` method)
- **InMemoryEventStore**: explicit implementation for testing
- Decorators (`TracedEventWriter`, `TracedEventStore`, `TieredEventStore`) delegate to underlying store
- Application layer `Store` extension overloads for `ProposedAppend[]` and raw event collections
- Documentation updated with atomicity guarantees per store

## Test plan

- [x] Base test class `StoreAppendTests` — 3 new tests inherited by all stores
- [x] SQLite: 27/27 passed
- [x] PostgreSQL: 35/35 passed
- [x] SQL Server: 39/39 passed
- [x] KurrentDB: 53/53 passed (including native multi-stream)
- [x] Core tests: 26/26 passed
- [x] Full solution build: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)