### PR TITLE
Add Created timestamp to StreamEvent

### DIFF
--- a/docs/src/content/docs/persistence/serialisation.md
+++ b/docs/src/content/docs/persistence/serialisation.md
@@ -52,18 +52,29 @@ Then, you can call this code in your bootstrap code:
 BookingEvents.MapBookingEvents();
 ```
 
-### Auto-registration of types
+### Auto-registration with source generator
 
-For convenience purposes, you can avoid manual mapping between type names and types by using the `EventType` attribute.
+The recommended way to register event types is to use the `[EventType]` attribute combined with the Eventuous source generator. The generator automatically discovers all types decorated with `[EventType]` in your project and generates a module initializer that registers them at startup — no manual registration code needed.
 
-Annotate your events with it like this:
+Annotate your events with the `[EventType]` attribute:
 
 ```csharp
 [EventType("V1.FullyPaid")]
 public record BookingFullyPaid(string BookingId, DateTimeOffset FullyPaidAt);
+
+[EventType("V1.RoomBooked")]
+public record RoomBooked(string RoomId, LocalDate CheckIn, LocalDate CheckOut, float Price);
 ```
 
-Then, use the registration code in the bootstrap code:
+That's it. The source generator produces a module initializer class per assembly, which calls `TypeMap.Instance.AddType(...)` for each annotated event type. Registration happens automatically when the assembly is loaded — you don't need to write any startup code.
+
+:::tip
+Eventuous also includes a diagnostic analyzer (`EVTC001`) that warns you when an event type is used in aggregates or state projections but is missing the `[EventType]` attribute.
+:::
+
+### Reflection-based registration
+
+As an alternative to the source generator, you can use reflection-based registration. This scans assemblies at runtime for types decorated with `[EventType]`:
 
 ```csharp
 TypeMap.RegisterKnownEventTypes();
@@ -75,23 +86,9 @@ The registration won't work if event classes are defined in another assembly, wh
 TypeMap.RegisterKnownEventTypes(typeof(BookingFullyPaid).Assembly);
 ```
 
-If you use the .NET version that supports module initializers, you can register event types in the module. For example, if the domain event classes are located in a separate project, add the file `DomainModule.cs` to that project with the following code:
-
-```csharp title="DomainModule.cs"
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using Eventuous;
-
-namespace Bookings.Domain; 
-
-static class DomainModule {
-    [ModuleInitializer]
-    [SuppressMessage("Usage", "CA2255", MessageId = "The \'ModuleInitializer\' attribute should not be used in libraries")]
-    internal static void InitializeDomainModule() => TypeMap.RegisterKnownEventTypes();
-}
-```
-
-Then, you won't need to call the `TypeMap` registration in the application code at all.
+:::note
+With the source generator in place, calling `RegisterKnownEventTypes()` is typically unnecessary. The generator handles registration at compile time, which is both more reliable and avoids the overhead of runtime assembly scanning.
+:::
 
 ### Default serializer
 

--- a/src/Core/src/Eventuous.Persistence/StreamEvent.cs
+++ b/src/Core/src/Eventuous.Persistence/StreamEvent.cs
@@ -18,5 +18,6 @@ public record struct StreamEvent(
         Metadata Metadata,
         string   ContentType,
         long     Revision,
+        DateTime Created     = default,
         bool     FromArchive = false
     );

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
@@ -31,7 +31,7 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
                 (ulong)position + 1,
                 evt.Payload,
                 evt.Metadata.ToHeaders(),
-                DateTime.Now
+                DateTime.UtcNow
             );
     }
 

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
@@ -87,7 +87,8 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
                     x.Message,
                     Metadata.FromHeaders(x.Metadata),
                     x.ContentType,
-                    x.StreamPosition
+                    x.StreamPosition,
+                    x.Created
                 )
             )
             .ToArray();

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -382,7 +382,8 @@ public partial class KurrentDBEventStore : IEventStore {
                 payload,
                 DeserializeMetadata() ?? new Metadata(),
                 resolvedEvent.Event.ContentType,
-                resolvedEvent.Event.EventNumber.ToInt64()
+                resolvedEvent.Event.EventNumber.ToInt64(),
+                resolvedEvent.Event.Created
             );
     }
 

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -127,6 +127,6 @@ public class RedisStore : IEventReader, IEventWriter {
         };
 
         StreamEvent AsStreamEvent(object payload)
-            => new(Guid.Parse(evt[MessageId].ToString()), payload, meta ?? new Metadata(), ContentType, evt.Id.ToLong());
+            => new(Guid.Parse(evt[MessageId].ToString()), payload, meta ?? new Metadata(), ContentType, evt.Id.ToLong(), DateTime.Parse(evt[Created]!, CultureInfo.InvariantCulture));
     }
 }

--- a/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
@@ -144,7 +144,7 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
             _                                => throw new("Unknown deserialization result")
         };
 
-        StreamEvent AsStreamEvent(object payload) => new(evt.MessageId, payload, meta ?? new Metadata(), ContentType, evt.StreamPosition);
+        StreamEvent AsStreamEvent(object payload) => new(evt.MessageId, payload, meta ?? new Metadata(), ContentType, evt.StreamPosition, evt.Created);
     }
 
     /// <inheritdoc />

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -22,7 +22,8 @@ public class InMemoryEventStore : IEventStore {
         ) {
         var existing = _storage.GetOrAdd(stream, s => new(s));
         existing.AppendEvents(expectedVersion, events);
-        _global.AddRange(events.Select((x, i) => new StreamEvent(x.Id, x.Payload, x.Metadata, "application/json", _global.Count + i)));
+        var now = DateTime.UtcNow;
+        _global.AddRange(events.Select((x, i) => new StreamEvent(x.Id, x.Payload, x.Metadata, "application/json", _global.Count + i, now)));
 
         return Task.FromResult(new AppendEventsResult((ulong)(_global.Count - 1), existing.Version));
     }
@@ -33,9 +34,10 @@ public class InMemoryEventStore : IEventStore {
         var i       = 0;
 
         foreach (var append in appends) {
+            var now      = DateTime.UtcNow;
             var existing = _storage.GetOrAdd(append.StreamName, s => new(s));
             existing.AppendEvents(append.ExpectedVersion, append.Events);
-            _global.AddRange(append.Events.Select((x, j) => new StreamEvent(x.Id, x.Payload, x.Metadata, "application/json", _global.Count + j)));
+            _global.AddRange(append.Events.Select((x, j) => new StreamEvent(x.Id, x.Payload, x.Metadata, "application/json", _global.Count + j, now)));
             results[i++] = new AppendEventsResult((ulong)(_global.Count - 1), existing.Version);
         }
 
@@ -97,7 +99,7 @@ class InMemoryStream(StreamName name) {
 
         foreach (var newEvent in events) {
             var version     = ++Version;
-            var streamEvent = new StreamEvent(newEvent.Id, newEvent.Payload, newEvent.Metadata, "application/json", version);
+            var streamEvent = new StreamEvent(newEvent.Id, newEvent.Payload, newEvent.Metadata, "application/json", version, DateTime.UtcNow);
             _events.Add(new(streamEvent, version));
         }
     }


### PR DESCRIPTION
## Summary
- Add `DateTime Created` field to the `StreamEvent` record struct, populated from the underlying store's timestamp data
- All store implementations (KurrentDB, PostgreSQL, SQL Server, SQLite, Redis, ElasticSearch, InMemory) now pass the creation timestamp through to `StreamEvent`
- Update serialisation docs to document the source generator for type registration and the `EVTC001` diagnostic analyzer

## Test plan
- [x] Solution builds with zero errors across all target frameworks
- [ ] Verify existing tests pass (no breaking change — `Created` defaults to `default`)
- [ ] Verify `StreamEvent.Created` is populated when reading from each store

🤖 Generated with [Claude Code](https://claude.com/claude-code)