### PR TITLE
Fix source generators not included in NuGet packages

### DIFF
--- a/props/PackAsAnalyzer.targets
+++ b/props/PackAsAnalyzer.targets
@@ -4,16 +4,16 @@
         ProjectReferences with PackAsAnalyzer="true" will:
           1. Be treated as analyzers during build (OutputItemType=Analyzer)
           2. Have their DLL included in analyzers/dotnet/cs/ in the NuGet package
+
+        Must be imported from Directory.Build.targets (not .props) so that
+        ProjectReference items are already defined when the ItemGroup update
+        below is evaluated — before ResolveProjectReferences consumes them.
     -->
-    <Target Name="_ResolveAnalyzerProjectReferences"
-            BeforeTargets="CoreCompile"
-            Condition="@(ProjectReference->AnyHaveMetadataValue('PackAsAnalyzer', 'true'))">
-        <ItemGroup>
-            <ProjectReference Condition="'%(ProjectReference.PackAsAnalyzer)' == 'true'"
-                              OutputItemType="Analyzer"
-                              SetTargetFramework="TargetFramework=netstandard2.0" />
-        </ItemGroup>
-    </Target>
+    <ItemGroup>
+        <ProjectReference Update="@(ProjectReference->WithMetadataValue('PackAsAnalyzer', 'true'))"
+                          OutputItemType="Analyzer"
+                          SetTargetFramework="TargetFramework=netstandard2.0" />
+    </ItemGroup>
 
     <Target Name="_IncludeAnalyzersInPackage"
             BeforeTargets="_GetPackageFiles"

--- a/props/PackAsAnalyzer.targets
+++ b/props/PackAsAnalyzer.targets
@@ -1,0 +1,33 @@
+<Project>
+    <!--
+        Implements the PackAsAnalyzer convention used by dotnet/runtime.
+        ProjectReferences with PackAsAnalyzer="true" will:
+          1. Be treated as analyzers during build (OutputItemType=Analyzer)
+          2. Have their DLL included in analyzers/dotnet/cs/ in the NuGet package
+    -->
+    <Target Name="_ResolveAnalyzerProjectReferences"
+            BeforeTargets="CoreCompile"
+            Condition="@(ProjectReference->AnyHaveMetadataValue('PackAsAnalyzer', 'true'))">
+        <ItemGroup>
+            <ProjectReference Condition="'%(ProjectReference.PackAsAnalyzer)' == 'true'"
+                              OutputItemType="Analyzer"
+                              SetTargetFramework="TargetFramework=netstandard2.0" />
+        </ItemGroup>
+    </Target>
+
+    <Target Name="_IncludeAnalyzersInPackage"
+            BeforeTargets="_GetPackageFiles"
+            Condition="'$(IsPackable)' == 'true' and @(ProjectReference->AnyHaveMetadataValue('PackAsAnalyzer', 'true'))">
+        <MSBuild Projects="@(ProjectReference->WithMetadataValue('PackAsAnalyzer', 'true'))"
+                 Targets="GetTargetPath"
+                 Properties="TargetFramework=netstandard2.0">
+            <Output TaskParameter="TargetOutputs" ItemName="_AnalyzerDll" />
+        </MSBuild>
+        <ItemGroup>
+            <None Include="@(_AnalyzerDll)"
+                  Pack="true"
+                  PackagePath="analyzers/dotnet/cs"
+                  Visible="false" />
+        </ItemGroup>
+    </Target>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,7 @@
         <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
     </PropertyGroup>
     <Import Project="$(RepoRoot)\props\Common.props"/>
+    <Import Project="$(RepoRoot)\props\PackAsAnalyzer.targets"/>
     <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('Eventuous.Tests'))">
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,7 +23,6 @@
         <Optimize Condition=" '$(Optimize)' == '' ">false</Optimize>
     </PropertyGroup>
     <Import Project="$(RepoRoot)\props\Common.props"/>
-    <Import Project="$(RepoRoot)\props\PackAsAnalyzer.targets"/>
     <PropertyGroup Condition="$(MSBuildProjectName.StartsWith('Eventuous.Tests'))">
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+    <Import Project="$(RepoRoot)\props\PackAsAnalyzer.targets"/>
+</Project>


### PR DESCRIPTION
## Summary

- `PackAsAnalyzer="true"` on `ProjectReference` is a custom convention from `dotnet/runtime`'s private build infrastructure (`eng/packaging.targets` + `eng/generatorProjects.targets`) — it is **not part of the .NET SDK** and was silently ignored
- Source generator DLLs were missing from the `analyzers/dotnet/cs/` folder in published NuGet packages, so consumers had no source generation
- Added `props/PackAsAnalyzer.targets` that implements the convention properly:
  - At **build time**: sets `OutputItemType=Analyzer` + `SetTargetFramework=netstandard2.0` so the generator runs during compilation
  - At **pack time**: resolves the generator DLL via `GetTargetPath` and includes it in `analyzers/dotnet/cs/`
- All four projects using `PackAsAnalyzer` (`Shared`, `Subscriptions`, `Extensions.AspNetCore`, `Spyglass`) now correctly ship their generators — no `.csproj` changes needed

## Verification

```
$ unzip -l Eventuous.Shared.0.16.3-alpha.0.1.nupkg | grep dll

  lib/net10.0/Eventuous.Shared.dll
  lib/net8.0/Eventuous.Shared.dll
  lib/net9.0/Eventuous.Shared.dll
  analyzers/dotnet/cs/Eventuous.Shared.Generators.dll   ← was missing before
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)