### PR TITLE
Change IEventReader to return IAsyncEnumerable

### DIFF
--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/BaseTracer.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/BaseTracer.cs
@@ -57,8 +57,25 @@ public abstract class BaseTracer {
         using var activity = StartActivity(stream, operation);
         using var measure  = Measure.Start(MetricsSource, new PersistenceMetricsContext(ComponentName, operation));
 
-        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false)) {
-            yield return item;
+        var enumerator = source.GetAsyncEnumerator(cancellationToken);
+
+        await using (enumerator.ConfigureAwait(false)) {
+            while (true) {
+                bool moved;
+
+                try {
+                    moved = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                } catch (Exception e) {
+                    activity?.SetActivityStatus(ActivityStatus.Error(e));
+                    measure.SetError();
+
+                    throw;
+                }
+
+                if (!moved) break;
+
+                yield return enumerator.Current;
+            }
         }
 
         activity?.SetActivityStatus(ActivityStatus.Ok());

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/BaseTracer.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/BaseTracer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Eventuous.Diagnostics.Metrics;
 
 namespace Eventuous.Diagnostics.Tracing;
@@ -45,6 +46,22 @@ public abstract class BaseTracer {
 
             throw;
         }
+    }
+
+    protected async IAsyncEnumerable<T> TraceEnumerable<T>(
+            StreamName             stream,
+            string                 operation,
+            IAsyncEnumerable<T>    source,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default
+        ) {
+        using var activity = StartActivity(stream, operation);
+        using var measure  = Measure.Start(MetricsSource, new PersistenceMetricsContext(ComponentName, operation));
+
+        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false)) {
+            yield return item;
+        }
+
+        activity?.SetActivityStatus(ActivityStatus.Ok());
     }
 
     protected static Activity? StartActivity(StreamName stream, string operationName) {

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventReader.cs
@@ -16,13 +16,13 @@ public class TracedEventReader(IEventReader reader) : BaseTracer, IEventReader {
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => Trace(stream, Operations.ReadEvents, () => Inner.ReadEvents(stream, start, count, failIfNotFound, cancellationToken));
+    public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+        => TraceEnumerable(stream, Operations.ReadEvents, Inner.ReadEvents(stream, start, count, cancellationToken));
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => Trace(stream, Operations.ReadEvents, () => Inner.ReadEventsBackwards(stream, start, count, failIfNotFound, cancellationToken));
+    public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+        => TraceEnumerable(stream, Operations.ReadEvents, Inner.ReadEventsBackwards(stream, start, count, cancellationToken));
 
     // ReSharper disable once ConvertToAutoProperty
     protected override string ComponentName => _componentName;

--- a/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventStore.cs
+++ b/src/Core/src/Eventuous.Persistence/Diagnostics/Tracing/TracedEventStore.cs
@@ -37,13 +37,13 @@ public class TracedEventStore(IEventStore eventStore) : BaseTracer, IEventStore 
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => Reader.ReadEvents(stream, start, count, failIfNotFound, cancellationToken);
+    public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+        => Reader.ReadEvents(stream, start, count, cancellationToken);
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => Reader.ReadEventsBackwards(stream, start, count, failIfNotFound, cancellationToken);
+    public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+        => Reader.ReadEventsBackwards(stream, start, count, cancellationToken);
 
     public Task TruncateStream(
             StreamName             stream,

--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
@@ -5,28 +5,28 @@ namespace Eventuous;
 
 public interface IEventReader {
     /// <summary>
-    /// Read a fixed number of events from an existing stream to an array
+    /// Read a fixed number of events from an existing stream as an async enumerable.
+    /// Throws <see cref="StreamNotFound"/> if the stream does not exist.
     /// </summary>
     /// <param name="stream">Stream name</param>
     /// <param name="start">Where to start reading events</param>
     /// <param name="count">How many events to read</param>
-    /// <param name="failIfNotFound">Throw an exception if the stream is not found</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>An array with events retrieved from the stream</returns>
+    /// <returns>An async enumerable of events retrieved from the stream</returns>
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken);
+    IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Read a number of events from a given stream, backwards (from the stream end)
+    /// Read a number of events from a given stream, backwards (from the stream end).
+    /// Throws <see cref="StreamNotFound"/> if the stream does not exist.
     /// </summary>
     /// <param name="stream">Stream name</param>
     /// <param name="start">Where to start reading events</param>
     /// <param name="count">How many events to read</param>
-    /// <param name="failIfNotFound">Throw an exception if the stream is not found</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>An array with events retrieved from the stream</returns>
+    /// <returns>An async enumerable of events retrieved from the stream</returns>
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken);
+    IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken);
 }

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -94,6 +94,74 @@ public static class StoreFunctions {
     }
 
     /// <summary>
+    /// Read a fixed number of events from an existing stream to an array.
+    /// Returns an empty array when the stream is not found and <paramref name="failIfNotFound"/> is false.
+    /// </summary>
+    /// <param name="eventReader">Event reader or event store</param>
+    /// <param name="stream">Stream name</param>
+    /// <param name="start">Where to start reading events</param>
+    /// <param name="count">How many events to read</param>
+    /// <param name="failIfNotFound">Throw an exception if the stream is not found</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>An array with events retrieved from the stream</returns>
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public static async Task<StreamEvent[]> ReadEvents(
+            this IEventReader  eventReader,
+            StreamName         stream,
+            StreamReadPosition start,
+            int                count,
+            bool               failIfNotFound,
+            CancellationToken  cancellationToken
+        ) {
+        try {
+            var result = new List<StreamEvent>();
+
+            await foreach (var evt in eventReader.ReadEvents(stream, start, count, cancellationToken).ConfigureAwait(false)) {
+                result.Add(evt);
+            }
+
+            return result.ToArray();
+        } catch (StreamNotFound) when (!failIfNotFound) {
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Read a number of events from a given stream, backwards (from the stream end), to an array.
+    /// Returns an empty array when the stream is not found and <paramref name="failIfNotFound"/> is false.
+    /// </summary>
+    /// <param name="eventReader">Event reader or event store</param>
+    /// <param name="stream">Stream name</param>
+    /// <param name="start">Where to start reading events</param>
+    /// <param name="count">How many events to read</param>
+    /// <param name="failIfNotFound">Throw an exception if the stream is not found</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>An array with events retrieved from the stream</returns>
+    [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
+    [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
+    public static async Task<StreamEvent[]> ReadEventsBackwards(
+            this IEventReader  eventReader,
+            StreamName         stream,
+            StreamReadPosition start,
+            int                count,
+            bool               failIfNotFound,
+            CancellationToken  cancellationToken
+        ) {
+        try {
+            var result = new List<StreamEvent>();
+
+            await foreach (var evt in eventReader.ReadEventsBackwards(stream, start, count, cancellationToken).ConfigureAwait(false)) {
+                result.Add(evt);
+            }
+
+            return result.ToArray();
+        } catch (StreamNotFound) when (!failIfNotFound) {
+            return [];
+        }
+    }
+
+    /// <summary>
     /// Reads a stream from the event store to a collection of <seealso cref="StreamEvent"/>
     /// </summary>
     /// <param name="eventReader">Event reader or event store</param>

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using System.Runtime.CompilerServices;
+
 namespace Eventuous;
 
 /// <summary>
@@ -12,18 +14,21 @@ namespace Eventuous;
 public class TieredEventReader(IEventReader hotReader, IEventReader archiveReader) : IEventReader {
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public async Task<StreamEvent[]> ReadEvents(StreamName streamName, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
-        var hotEvents = await LoadStreamEvents(hotReader, start, count, true).NoContext();
+    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName streamName, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        var hotEvents = await LoadStreamEvents(hotReader, start, count).NoContext();
 
         var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Revision > start.Value
-            ? await LoadStreamEvents(archiveReader, start, (int)hotEvents[0].Revision, !failIfNotFound).NoContext()
+            ? (await LoadStreamEvents(archiveReader, start, (int)hotEvents[0].Revision).NoContext())
+                .Select(x => x with { FromArchive = true })
             : Enumerable.Empty<StreamEvent>();
 
-        return archivedEvents.Select(x => x with { FromArchive = true }).Concat(hotEvents).Distinct(Comparer).ToArray();
+        foreach (var evt in archivedEvents.Concat(hotEvents).Distinct(Comparer)) {
+            yield return evt;
+        }
 
-        async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount, bool ignore) {
+        async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount) {
             try {
-                return await reader.ReadEvents(streamName, startPosition, localCount, !ignore, cancellationToken).NoContext();
+                return await reader.ReadEvents(streamName, startPosition, localCount, true, cancellationToken).NoContext();
             } catch (StreamNotFound) {
                 return [];
             }
@@ -32,18 +37,21 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public async Task<StreamEvent[]> ReadEventsBackwards(StreamName streamName, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
-        var hotEvents = await LoadStreamEvents(hotReader, start, count, true).NoContext();
+    public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName streamName, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        var hotEvents = await LoadStreamEvents(hotReader, start, count).NoContext();
 
         var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Revision > start.Value - count
-            ? await LoadStreamEvents(archiveReader, new(hotEvents[0].Revision - 1), count - hotEvents.Length, failIfNotFound).NoContext()
+            ? (await LoadStreamEvents(archiveReader, new(hotEvents[0].Revision - 1), count - hotEvents.Length).NoContext())
+                .Select(x => x with { FromArchive = true })
             : Enumerable.Empty<StreamEvent>();
 
-        return hotEvents.Concat(archivedEvents.Select(x => x with { FromArchive = true })).Distinct(Comparer).ToArray();
+        foreach (var evt in hotEvents.Concat(archivedEvents).Distinct(Comparer)) {
+            yield return evt;
+        }
 
-        async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount, bool ignore) {
+        async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount) {
             try {
-                return await reader.ReadEventsBackwards(streamName, startPosition, localCount, !ignore, cancellationToken).NoContext();
+                return await reader.ReadEventsBackwards(streamName, startPosition, localCount, true, cancellationToken).NoContext();
             } catch (StreamNotFound) {
                 return [];
             }

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -15,46 +15,78 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName streamName, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
-        var hotEvents = await LoadStreamEvents(hotReader, start, count).NoContext();
+        var hotEvents = await LoadStreamEvents(hotReader, streamName, start, count, cancellationToken).NoContext();
 
-        var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Revision > start.Value
-            ? (await LoadStreamEvents(archiveReader, start, (int)hotEvents[0].Revision).NoContext())
-                .Select(x => x with { FromArchive = true })
-            : Enumerable.Empty<StreamEvent>();
+        IEnumerable<StreamEvent> archivedEvents;
 
-        foreach (var evt in archivedEvents.Concat(hotEvents).Distinct(Comparer)) {
+        if (hotEvents.Length > 0 && hotEvents[0].Revision > start.Value) {
+            // Hot store has events but they start after the requested position, fill the gap from archive
+            archivedEvents = (await LoadStreamEvents(archiveReader, streamName, start, (int)hotEvents[0].Revision, cancellationToken).NoContext())
+                .Select(x => x with { FromArchive = true });
+        } else if (hotEvents.Length == 0) {
+            // Hot store has no events, try archive for the full range
+            archivedEvents = (await LoadStreamEvents(archiveReader, streamName, start, count, cancellationToken).NoContext())
+                .Select(x => x with { FromArchive = true });
+        } else {
+            archivedEvents = [];
+        }
+
+        var combined = archivedEvents.Concat(hotEvents).Distinct(Comparer);
+        var any      = false;
+
+        foreach (var evt in combined) {
+            any = true;
             yield return evt;
         }
 
-        async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount) {
-            try {
-                return await reader.ReadEvents(streamName, startPosition, localCount, true, cancellationToken).NoContext();
-            } catch (StreamNotFound) {
-                return [];
-            }
-        }
+        if (!any) throw new StreamNotFound(streamName);
     }
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
     public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName streamName, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
-        var hotEvents = await LoadStreamEvents(hotReader, start, count).NoContext();
+        var hotEvents = await LoadStreamEvents(hotReader, streamName, start, count, cancellationToken, backwards: true).NoContext();
 
-        var archivedEvents = hotEvents.Length == 0 || hotEvents[0].Revision > start.Value - count
-            ? (await LoadStreamEvents(archiveReader, new(hotEvents[0].Revision - 1), count - hotEvents.Length).NoContext())
-                .Select(x => x with { FromArchive = true })
-            : Enumerable.Empty<StreamEvent>();
+        IEnumerable<StreamEvent> archivedEvents;
 
-        foreach (var evt in hotEvents.Concat(archivedEvents).Distinct(Comparer)) {
+        if (hotEvents.Length > 0 && hotEvents.Length < count) {
+            // Hot store returned fewer events than requested, fill the gap from archive
+            var lastHotRevision = hotEvents[^1].Revision;
+            archivedEvents = (await LoadStreamEvents(archiveReader, streamName, new(lastHotRevision - 1), count - hotEvents.Length, cancellationToken, backwards: true).NoContext())
+                .Select(x => x with { FromArchive = true });
+        } else if (hotEvents.Length == 0) {
+            // Hot store has no events, try archive for the full range
+            archivedEvents = (await LoadStreamEvents(archiveReader, streamName, start, count, cancellationToken, backwards: true).NoContext())
+                .Select(x => x with { FromArchive = true });
+        } else {
+            archivedEvents = [];
+        }
+
+        var combined = hotEvents.Concat(archivedEvents).Distinct(Comparer);
+        var any      = false;
+
+        foreach (var evt in combined) {
+            any = true;
             yield return evt;
         }
 
-        async Task<StreamEvent[]> LoadStreamEvents(IEventReader reader, StreamReadPosition startPosition, int localCount) {
-            try {
-                return await reader.ReadEventsBackwards(streamName, startPosition, localCount, true, cancellationToken).NoContext();
-            } catch (StreamNotFound) {
-                return [];
-            }
+        if (!any) throw new StreamNotFound(streamName);
+    }
+
+    static async Task<StreamEvent[]> LoadStreamEvents(
+            IEventReader      reader,
+            StreamName        streamName,
+            StreamReadPosition startPosition,
+            int               localCount,
+            CancellationToken cancellationToken,
+            bool              backwards = false
+        ) {
+        try {
+            return backwards
+                ? await reader.ReadEventsBackwards(streamName, startPosition, localCount, true, cancellationToken).NoContext()
+                : await reader.ReadEvents(streamName, startPosition, localCount, true, cancellationToken).NoContext();
+        } catch (StreamNotFound) {
+            return [];
         }
     }
 

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventStore.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventStore.cs
@@ -16,13 +16,13 @@ public class TieredEventStore(IEventStore hotStore, IEventReader archiveReader) 
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => _tieredReader.ReadEvents(stream, start, count, failIfNotFound, cancellationToken);
+    public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+        => _tieredReader.ReadEvents(stream, start, count, cancellationToken);
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => _tieredReader.ReadEventsBackwards(stream, start, count, failIfNotFound, cancellationToken);
+    public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+        => _tieredReader.ReadEventsBackwards(stream, start, count, cancellationToken);
 
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
@@ -36,11 +36,11 @@ public abstract class TieredStoreTestsBase<TContainer> where TContainer : Docker
     }
 
     class ArchiveStore(IEventStore original) : IEventReader, IEventWriter {
-        public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-            => original.ReadEvents(GetArchiveStreamName(stream), start, count, failIfNotFound, cancellationToken);
+        public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+            => original.ReadEvents(GetArchiveStreamName(stream), start, count, cancellationToken);
 
-        public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-            => original.ReadEventsBackwards(GetArchiveStreamName(stream), start, count, failIfNotFound, cancellationToken);
+        public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
+            => original.ReadEventsBackwards(GetArchiveStreamName(stream), start, count, cancellationToken);
 
         static StreamName GetArchiveStreamName(string streamName) => new($"Archive-{streamName}");
 

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
@@ -49,7 +49,9 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
             cancellationToken
         );
 
-        if (response.Length == 0) throw new StreamNotFound(stream);
+        if (response.Length == 0 && !await StreamExists(stream, cancellationToken)) {
+            throw new StreamNotFound(stream);
+        }
 
         foreach (var evt in response) yield return evt;
     }
@@ -66,7 +68,9 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
             cancellationToken
         );
 
-        if (response.Length == 0) throw new StreamNotFound(stream);
+        if (response.Length == 0 && !await StreamExists(stream, cancellationToken)) {
+            throw new StreamNotFound(stream);
+        }
 
         foreach (var evt in response.OrderByDescending(x => x.Revision)) yield return evt;
     }

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticEventStore.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using System.Runtime.CompilerServices;
+
 namespace Eventuous.ElasticSearch.Store;
 
 public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? options = null) : IEventStore {
@@ -35,8 +37,8 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
             );
     }
 
-    public async Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
-        var response = await ReadEvents(
+    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        var response = await ReadEventsInternal(
             q => q.Bool(
                 b => b.Must(
                     mu => mu.Term(x => x.Stream, stream.ToString()),
@@ -47,11 +49,13 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
             cancellationToken
         );
 
-        return response.Length == 0 && failIfNotFound ? throw new StreamNotFound(stream) : response;
+        if (response.Length == 0) throw new StreamNotFound(stream);
+
+        foreach (var evt in response) yield return evt;
     }
 
-    public async Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
-        var response = await ReadEvents(
+    public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        var response = await ReadEventsInternal(
             q => q.Bool(
                 b => b.Must(
                     mu => mu.Term(x => x.Stream, stream.ToString()),
@@ -62,11 +66,13 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
             cancellationToken
         );
 
-        return response.Length == 0 && failIfNotFound ? throw new StreamNotFound(stream) : response.OrderByDescending(x => x.Revision).ToArray();
+        if (response.Length == 0) throw new StreamNotFound(stream);
+
+        foreach (var evt in response.OrderByDescending(x => x.Revision)) yield return evt;
     }
 
     public async Task<bool> StreamExists(StreamName stream, CancellationToken cancellationToken) {
-        var response = await ReadEvents(
+        var response = await ReadEventsInternal(
             q => q.Bool(b => b.Must(mu => mu.Term(x => x.Stream, stream.ToString()))),
             1,
             cancellationToken
@@ -75,7 +81,7 @@ public class ElasticEventStore(IElasticClient client, ElasticEventStoreOptions? 
         return response.Length == 1;
     }
 
-    async Task<StreamEvent[]> ReadEvents(Func<QueryContainerDescriptor<PersistedEvent>, QueryContainer> query, int count, CancellationToken cancellationToken) {
+    async Task<StreamEvent[]> ReadEventsInternal(Func<QueryContainerDescriptor<PersistedEvent>, QueryContainer> query, int count, CancellationToken cancellationToken) {
         var response = await client.SearchAsync<PersistedEvent>(d => d.Index(_options.IndexName).Query(query).Take(count), cancellationToken);
 
         if (!response.IsValid) throw new ApplicationException($"Unable to read events: {response.DebugInformation}");

--- a/src/Extensions/test/Eventuous.Tests.DependencyInjection/Sut/FakeStore.cs
+++ b/src/Extensions/test/Eventuous.Tests.DependencyInjection/Sut/FakeStore.cs
@@ -5,9 +5,9 @@ public class FakeStore : IEventStore {
 
     public Task<AppendEventsResult> AppendEvents(StreamName stream, ExpectedStreamVersion expectedVersion, IReadOnlyCollection<NewStreamEvent> events, CancellationToken cancellationToken) => default!;
 
-    public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) => default!;
+    public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken) => default!;
 
-    public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) => default!;
+    public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken) => default!;
 
     public Task TruncateStream(StreamName stream, StreamTruncatePosition truncatePosition, ExpectedStreamVersion expectedVersion, CancellationToken cancellationToken) => default!;
 

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -225,34 +225,28 @@ public partial class KurrentDBEventStore : IEventStore {
     /// <inheritdoc/>
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public async Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken = default) {
+    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
         var read = _client.ReadStreamAsync(Direction.Forwards, stream, start.AsStreamPosition(), count, cancellationToken: cancellationToken);
 
-        try {
-            return await TryExecute(
-                async () => {
-                    var resolvedEvents = await read.ToArrayAsync(cancellationToken).NoContext();
+        var events = await TryExecute(
+            async () => {
+                var resolvedEvents = await read.ToArrayAsync(cancellationToken).NoContext();
 
-                    return ToStreamEvents(resolvedEvents);
-                },
-                stream,
-                failIfNotFound,
-                () => new("Unable to read {Count} starting at {Start} events from {Stream}", count, start, stream),
-                (s, ex) => new ReadFromStreamException(s, ex)
-            );
-        } catch (StreamNotFound) {
-            if (failIfNotFound) {
-                throw;
-            }
+                return ToStreamEvents(resolvedEvents);
+            },
+            stream,
+            true,
+            () => new("Unable to read {Count} starting at {Start} events from {Stream}", count, start, stream),
+            (s, ex) => new ReadFromStreamException(s, ex)
+        );
 
-            return [];
-        }
+        foreach (var evt in events) yield return evt;
     }
 
     /// <inheritdoc/>
     [RequiresDynamicCode(AttrConstants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(AttrConstants.DynamicSerializationMessage)]
-    public async Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken = default) {
+    public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
         var read = _client.ReadStreamAsync(
             Direction.Backwards,
             stream,
@@ -262,25 +256,19 @@ public partial class KurrentDBEventStore : IEventStore {
             cancellationToken: cancellationToken
         );
 
-        try {
-            return await TryExecute(
-                async () => {
-                    var resolvedEvents = await read.ToArrayAsync(cancellationToken).NoContext();
+        var events = await TryExecute(
+            async () => {
+                var resolvedEvents = await read.ToArrayAsync(cancellationToken).NoContext();
 
-                    return ToStreamEvents(resolvedEvents);
-                },
-                stream,
-                failIfNotFound,
-                () => new("Unable to read {Count} events backwards from {Stream}", count, stream),
-                (s, ex) => new ReadFromStreamException(s, ex)
-            );
-        } catch (StreamNotFound) {
-            if (failIfNotFound) {
-                throw;
-            }
+                return ToStreamEvents(resolvedEvents);
+            },
+            stream,
+            true,
+            () => new("Unable to read {Count} events backwards from {Stream}", count, stream),
+            (s, ex) => new ReadFromStreamException(s, ex)
+        );
 
-            return [];
-        }
+        foreach (var evt in events) yield return evt;
     }
 
     /// <inheritdoc/>

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using static Eventuous.DeserializationResult;
@@ -35,22 +36,26 @@ public class RedisStore : IEventReader, IEventWriter {
 
     const string ContentType = "application/json";
 
-    public async Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
+    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        StreamEvent[] events;
+
         try {
             var result = await _getDatabase().StreamReadAsync(stream.ToString(), start.Value.ToRedisValue(), count).NoContext();
 
             if (result == null! || result.Length == 0) {
-                return failIfNotFound ? throw new StreamNotFound(stream) : [];
+                throw new StreamNotFound(stream);
             }
 
-            return result.Select(x => ToStreamEvent(x, _serializer, _metaSerializer)).ToArray();
+            events = result.Select(x => ToStreamEvent(x, _serializer, _metaSerializer)).ToArray();
         } catch (InvalidOperationException e) when (e.Message.Contains("Reading is not allowed after reader was completed") ||
                                                     cancellationToken.IsCancellationRequested) {
             throw new OperationCanceledException("Redis read operation terminated", e, cancellationToken);
         }
+
+        foreach (var evt in events) yield return evt;
     }
 
-    public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
+    public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
         => throw new NotImplementedException();
 
     public async Task<AppendEventsResult> AppendEvents(

--- a/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Data.Common;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using Eventuous.Diagnostics;
@@ -92,30 +93,46 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
     /// <inheritdoc />
     [RequiresDynamicCode(Constants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(Constants.DynamicSerializationMessage)]
-    public async Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
-        if (count <= 0 || start == StreamReadPosition.End) return [];
+    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        if (count <= 0 || start == StreamReadPosition.End) yield break;
 
-        await using var connection = await OpenConnection(cancellationToken).NoContext();
-        await using var cmd        = GetReadCommand(connection, stream, start, count);
+        var events = await ReadInternal(stream, start, count, cancellationToken).NoContext();
 
-        return await ReadInternal(cmd, stream, failIfNotFound, cancellationToken).NoContext();
+        foreach (var evt in events) yield return evt;
     }
 
     /// <inheritdoc />
     [RequiresDynamicCode(Constants.DynamicSerializationMessage)]
     [RequiresUnreferencedCode(Constants.DynamicSerializationMessage)]
-    public async Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken) {
-        if (count <= 0) return [];
+    public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        if (count <= 0) yield break;
 
-        await using var connection = await OpenConnection(cancellationToken).NoContext();
-        await using var cmd        = GetReadBackwardsCommand(connection, stream, start, count);
+        var events = await ReadInternalBackwards(stream, start, count, cancellationToken).NoContext();
 
-        return await ReadInternal(cmd, stream, failIfNotFound, cancellationToken).NoContext();
+        foreach (var evt in events) yield return evt;
     }
 
     [RequiresDynamicCode("Calls Eventuous.Sql.Base.SqlEventStoreBase<TConnection, TTransaction>.ToStreamEvent(PersistedEvent)")]
     [RequiresUnreferencedCode("Calls Eventuous.Sql.Base.SqlEventStoreBase<TConnection, TTransaction>.ToStreamEvent(PersistedEvent)")]
-    async Task<StreamEvent[]> ReadInternal(DbCommand cmd, StreamName stream, bool failIfNotFound, CancellationToken cancellationToken) {
+    async Task<StreamEvent[]> ReadInternal(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken) {
+        await using var connection = await OpenConnection(cancellationToken).NoContext();
+        await using var cmd        = GetReadCommand(connection, stream, start, count);
+
+        return await ReadFromCommand(cmd, stream, cancellationToken).NoContext();
+    }
+
+    [RequiresDynamicCode("Calls Eventuous.Sql.Base.SqlEventStoreBase<TConnection, TTransaction>.ToStreamEvent(PersistedEvent)")]
+    [RequiresUnreferencedCode("Calls Eventuous.Sql.Base.SqlEventStoreBase<TConnection, TTransaction>.ToStreamEvent(PersistedEvent)")]
+    async Task<StreamEvent[]> ReadInternalBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken) {
+        await using var connection = await OpenConnection(cancellationToken).NoContext();
+        await using var cmd        = GetReadBackwardsCommand(connection, stream, start, count);
+
+        return await ReadFromCommand(cmd, stream, cancellationToken).NoContext();
+    }
+
+    [RequiresDynamicCode("Calls Eventuous.Sql.Base.SqlEventStoreBase<TConnection, TTransaction>.ToStreamEvent(PersistedEvent)")]
+    [RequiresUnreferencedCode("Calls Eventuous.Sql.Base.SqlEventStoreBase<TConnection, TTransaction>.ToStreamEvent(PersistedEvent)")]
+    async Task<StreamEvent[]> ReadFromCommand(DbCommand cmd, StreamName stream, CancellationToken cancellationToken) {
         try {
             await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).NoContext();
 
@@ -123,9 +140,7 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
 
             return await result.Select(ToStreamEvent).ToArrayAsync(cancellationToken).NoContext();
         } catch (Exception e) {
-            if (IsStreamNotFound(e)) {
-                return failIfNotFound ? throw new StreamNotFound(stream) : [];
-            }
+            if (IsStreamNotFound(e)) throw new StreamNotFound(stream);
 
             throw new ReadFromStreamException(stream, e);
         }

--- a/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
+++ b/src/Testing/src/Eventuous.Testing/InMemoryEventStore.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 namespace Eventuous.Testing;
 
@@ -45,12 +46,20 @@ public class InMemoryEventStore : IEventStore {
     }
 
     /// <inheritdoc />
-    public Task<StreamEvent[]> ReadEvents(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => Task.FromResult(FindStream(stream, failIfNotFound).GetEvents(start, count).ToArray());
+#pragma warning disable CS1998 // Async method lacks 'await' operators
+    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        foreach (var evt in FindStream(stream, true).GetEvents(start, count)) {
+            yield return evt;
+        }
+    }
 
     /// <inheritdoc />
-    public Task<StreamEvent[]> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, bool failIfNotFound, CancellationToken cancellationToken)
-        => Task.FromResult(FindStream(stream, failIfNotFound).GetEventsBackwards(start, count).ToArray());
+    public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
+        foreach (var evt in FindStream(stream, true).GetEventsBackwards(start, count)) {
+            yield return evt;
+        }
+    }
+#pragma warning restore CS1998
 
     /// <inheritdoc />
     public Task TruncateStream(


### PR DESCRIPTION
## Summary
- `IEventReader.ReadEvents` and `ReadEventsBackwards` now return `IAsyncEnumerable<StreamEvent>` instead of `Task<StreamEvent[]>`, with the `failIfNotFound` parameter removed from the interface
- The previous signatures (with `failIfNotFound`, returning `Task<StreamEvent[]>`) are preserved as extension methods in `StoreFunctions`, so **all downstream callers compile and work unchanged**
- All implementations updated: KurrentDB, SQL (Postgres/SqlServer/Sqlite), Redis, Elastic, InMemory, Tiered, and Traced decorators

## Test plan
- [x] Full solution builds with 0 errors
- [x] Core tests pass (26/26)
- [x] Application tests pass (21/21)
- [x] Subscription tests pass (30/30)
- [x] DI tests pass (3/3)
- [x] ASP.NET Core extension tests pass (9/9)
- [x] Spyglass tests pass (5/5)
- [ ] Integration tests with infrastructure (EventStoreDB, Postgres, SQL Server, Redis) should be validated in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)