### PR TITLE
Fix source generator event type detection (#538)

### DIFF
--- a/docs/superpowers/plans/2026-04-06-source-generator-event-detection.md
+++ b/docs/superpowers/plans/2026-04-06-source-generator-event-detection.md
@@ -1,0 +1,385 @@
+# Source Generator Event Type Detection Fixes
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two source generators so they detect event types registered via `EventHandler.On<T>()` and similar patterns, and add `[EventType]` attribute discovery as a fallback for indirect registration patterns.
+
+**Architecture:** Three changes across two generator files. Change 1 adds `EventHandler.On<T>()` detection to the `EventUsageAnalyzer` diagnostic. Change 2 replaces the name-based heuristic in `ConsumeContextConverterGenerator` with a containing-type check. Change 3 adds `[EventType]` attribute discovery from current and referenced assemblies to the converter generator.
+
+**Tech Stack:** Roslyn source generators (IIncrementalGenerator), Roslyn analyzers (DiagnosticAnalyzer), Microsoft.CodeAnalysis.CSharp, netstandard2.0
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs` | Modify | Add `BaseEventHandler` to `KnownTypeSymbols`, add `IsEventHandler()`, add case 1d |
+| `src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs` | Modify | Replace name heuristic with containing-type check, add `[EventType]` discovery path |
+| `src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzed.cs` | Modify | Add `EventHandler.On<T>()` test fixture |
+| `src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzer_Ev001_Tests.cs` | Modify | Add test for EventHandler case |
+| `src/Core/test/Eventuous.Tests.Shared.Analyzers/Eventuous.Tests.Shared.Analyzers.csproj` | Modify | Add Subscriptions project reference |
+
+---
+
+### Task 1: Add `EventHandler.On<T>()` detection to `EventUsageAnalyzer`
+
+**Files:**
+- Modify: `src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs:49-58` (KnownTypeSymbols)
+- Modify: `src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs:142-151` (add case 1d)
+- Modify: `src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs:270-290` (add IsEventHandler)
+
+- [ ] **Step 1: Add `BaseEventHandler` to `KnownTypeSymbols`**
+
+In `EventUsageAnalyzer.cs`, add to the `KnownTypeSymbols` class (after line 57):
+
+```csharp
+public INamedTypeSymbol? BaseEventHandler { get; } = compilation.GetTypeByMetadataName("Eventuous.Subscriptions.BaseEventHandler");
+```
+
+- [ ] **Step 2: Add `IsEventHandler()` helper**
+
+After the `IsState()` method (after line 290), add:
+
+```csharp
+static bool IsEventHandler(INamedTypeSymbol? type, KnownTypeSymbols knownTypes) {
+    if (type == null) return false;
+
+    for (var t = type; t != null; t = t.BaseType) {
+        if (knownTypes.BaseEventHandler != null) {
+            if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, knownTypes.BaseEventHandler)) {
+                return true;
+            }
+        }
+        else {
+            if (t is { Name: "BaseEventHandler", Arity: 0 } && t.ContainingNamespace?.ToDisplayString() == "Eventuous.Subscriptions") {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+```
+
+- [ ] **Step 3: Add case 1d in the method switch**
+
+In `AnalyzeInvocation`, after case 1c (after line 151, before the closing `}`  of the switch on line 152), add:
+
+```csharp
+// Case 1d: EventHandler.On<T>(...) handler registrations
+case { Name: "On", TypeArguments.Length: 1 } when IsEventHandler(method.ContainingType, knownTypes): {
+    var eventType = method.TypeArguments[0];
+
+    if (IsConcreteEvent(eventType) && !HasEventTypeAttribute(eventType, knownTypes) && !IsExplicitlyRegistered(eventType, ctx, knownTypes)) {
+        ctx.ReportDiagnostic(Diagnostic.Create(MissingEventTypeAttribute, inv.Syntax.GetLocation(), eventType.ToDisplayString()));
+    }
+
+    return;
+}
+```
+
+- [ ] **Step 4: Build the generator project**
+
+Run: `dotnet build src/Core/gen/Eventuous.Shared.Generators/Eventuous.Shared.Generators.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs
+git commit -m "fix(analyzers): detect EventHandler.On<T>() for missing EventType warning"
+```
+
+---
+
+### Task 2: Add analyzer test for `EventHandler.On<T>()` detection
+
+**Files:**
+- Modify: `src/Core/test/Eventuous.Tests.Shared.Analyzers/Eventuous.Tests.Shared.Analyzers.csproj`
+- Modify: `src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzed.cs`
+- Modify: `src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzer_Ev001_Tests.cs`
+
+- [ ] **Step 1: Add Subscriptions project reference**
+
+In `Eventuous.Tests.Shared.Analyzers.csproj`, add after the existing `ProjectReference` entries (after line 21):
+
+```xml
+<ProjectReference Include="$(LocalRoot)\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj"/>
+```
+
+- [ ] **Step 2: Add EventHandler fixture to `Analyzed.cs`**
+
+Add the following after the existing `Events` class (after line 23):
+
+```csharp
+file class TestEventHandler : Eventuous.Subscriptions.EventHandler {
+    public TestEventHandler() {
+        On<Events.RoomBooked>(ctx => new ValueTask());
+    }
+}
+```
+
+- [ ] **Step 3: Add metadata reference in `Analyzer_Ev001_Tests.cs`**
+
+In the `CreateCompilation` method, add to the `refs` list (after line 56):
+
+```csharp
+MetadataReference.CreateFromFile(typeof(Eventuous.Subscriptions.EventHandler).Assembly.Location),
+```
+
+- [ ] **Step 4: Update test assertion to expect 3 diagnostics**
+
+In `Should_warn_for_unannotated_events_in_state_and_aggregate`, update the assertion at line 29:
+
+```csharp
+await Assert.That(ev001.Length).IsGreaterThanOrEqualTo(3);
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `dotnet test src/Core/test/Eventuous.Tests.Shared.Analyzers/Eventuous.Tests.Shared.Analyzers.csproj --filter "FullyQualifiedName~Analyzer_Ev001_Tests" -f net10.0`
+Expected: PASS — 3 EV001 diagnostics including one for `EventHandler.On<RoomBooked>`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Core/test/Eventuous.Tests.Shared.Analyzers/
+git commit -m "test(analyzers): add EventHandler.On<T>() detection test"
+```
+
+---
+
+### Task 3: Replace name heuristic in `ConsumeContextConverterGenerator`
+
+**Files:**
+- Modify: `src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs`
+
+- [ ] **Step 1: Add `BaseEventHandler` symbol resolution to the pipeline**
+
+In `Initialize()`, add a second symbol resolution alongside the existing `messageConsumeContextSymbol` (after line 20):
+
+```csharp
+var baseEventHandlerSymbol = context.CompilationProvider
+    .Select(static (c, _) => c.GetTypeByMetadataName("Eventuous.Subscriptions.BaseEventHandler"));
+```
+
+- [ ] **Step 2: Combine both symbols into the pipeline**
+
+Replace the existing pipeline (lines 22-29) to thread both symbols through. Change the `.Combine(messageConsumeContextSymbol)` to combine both:
+
+```csharp
+var knownSymbols = messageConsumeContextSymbol
+    .Combine(baseEventHandlerSymbol)
+    .Select(static (pair, _) => new KnownSymbols(pair.Left, pair.Right));
+
+var candidateTypes = context.SyntaxProvider
+    .CreateSyntaxProvider(IsPotentialUsage, Transform)
+    .Where(static t => t is not null)
+    .Combine(knownSymbols)
+    .Select(static (pair, _) => TransformWithSymbol(pair.Left, pair.Right))
+    .Where(static t => t is not null)
+    .Select(static (t, _) => t!)
+    .Collect();
+```
+
+- [ ] **Step 3: Add `KnownSymbols` record**
+
+Add inside the class (e.g., after line 15):
+
+```csharp
+sealed record KnownSymbols(INamedTypeSymbol? MessageConsumeContext, INamedTypeSymbol? BaseEventHandler);
+```
+
+- [ ] **Step 4: Update `TransformWithSymbol` signature**
+
+Change the signature from:
+
+```csharp
+static string? TransformWithSymbol(GeneratorSyntaxContext? ctx, INamedTypeSymbol? messageConsumeContextSymbol)
+```
+
+to:
+
+```csharp
+static string? TransformWithSymbol(GeneratorSyntaxContext? ctx, KnownSymbols known)
+```
+
+Update all references to `messageConsumeContextSymbol` inside the method to `known.MessageConsumeContext`. Pass `known.BaseEventHandler` to the `On<T>` check.
+
+- [ ] **Step 5: Replace `ShouldTreatGenericOnAsEvent`**
+
+Replace the existing method (lines 135-143) with:
+
+```csharp
+static bool IsEventHandlerOnMethod(IMethodSymbol method, INamedTypeSymbol? baseEventHandlerSymbol) {
+    if (method is not { Name: "On" }) return false;
+    var def = method.OriginalDefinition;
+    if (def.TypeParameters.Length != 1) return false;
+
+    var containingType = def.ContainingType;
+
+    for (var t = containingType; t != null; t = t.BaseType) {
+        if (baseEventHandlerSymbol != null) {
+            if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, baseEventHandlerSymbol)) {
+                return true;
+            }
+        }
+        else {
+            if (t is { Name: "BaseEventHandler", Arity: 0 } && t.ContainingNamespace?.ToDisplayString() == "Eventuous.Subscriptions") {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+```
+
+- [ ] **Step 6: Update the call site in `TransformWithSymbol`**
+
+In Case 2 (around line 75), change:
+
+```csharp
+if (method?.TypeArguments.Length == 1 && ShouldTreatGenericOnAsEvent(method)) {
+```
+
+to:
+
+```csharp
+if (method?.TypeArguments.Length == 1 && IsEventHandlerOnMethod(method, known.BaseEventHandler)) {
+```
+
+- [ ] **Step 7: Build the generator project**
+
+Run: `dotnet build src/Core/gen/Eventuous.Subscriptions.Generators/Eventuous.Subscriptions.Generators.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+git commit -m "fix(generators): replace name heuristic with containing-type check for On<T>"
+```
+
+---
+
+### Task 4: Add `[EventType]` discovery path to `ConsumeContextConverterGenerator`
+
+**Files:**
+- Modify: `src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs`
+
+- [ ] **Step 1: Add `EventTypeAttribute` symbol resolution**
+
+In `Initialize()`, add after the `baseEventHandlerSymbol` resolution:
+
+```csharp
+var eventTypeAttributeSymbol = context.CompilationProvider
+    .Select(static (c, _) => c.GetTypeByMetadataName("Eventuous.EventTypeAttribute"));
+```
+
+- [ ] **Step 2: Add the `[EventType]` discovery pipeline**
+
+After the existing `candidateTypes` pipeline, add:
+
+```csharp
+var eventTypeCandidates = eventTypeAttributeSymbol
+    .Combine(context.CompilationProvider)
+    .Select(static (pair, _) => DiscoverEventTypes(pair.Right, pair.Left));
+```
+
+- [ ] **Step 3: Merge both candidate sources**
+
+Replace the `context.RegisterSourceOutput(candidateTypes, Generate);` line with:
+
+```csharp
+var mergedCandidates = candidateTypes
+    .Combine(eventTypeCandidates)
+    .Select(static (pair, _) => pair.Left.AddRange(pair.Right));
+
+context.RegisterSourceOutput(mergedCandidates, Generate);
+```
+
+- [ ] **Step 4: Add `DiscoverEventTypes` method**
+
+Add after the `Generate` method:
+
+```csharp
+static ImmutableArray<string> DiscoverEventTypes(Compilation compilation, INamedTypeSymbol? eventTypeAttributeSymbol) {
+    if (eventTypeAttributeSymbol is null) return ImmutableArray<string>.Empty;
+
+    var builder = ImmutableArray.CreateBuilder<string>();
+
+    ProcessNamespace(compilation.Assembly.GlobalNamespace);
+
+    foreach (var ra in compilation.SourceModule.ReferencedAssemblySymbols) {
+        ProcessNamespace(ra.GlobalNamespace);
+    }
+
+    return builder.ToImmutable();
+
+    void ProcessType(INamedTypeSymbol type) {
+        if (HasEventTypeAttribute(type)) {
+            var name = GetTypeSyntax(type);
+            if (name is not null) builder.Add(name);
+        }
+
+        foreach (var nt in type.GetTypeMembers()) {
+            ProcessType(nt);
+        }
+    }
+
+    void ProcessNamespace(INamespaceSymbol ns) {
+        foreach (var member in ns.GetMembers()) {
+            switch (member) {
+                case INamespaceSymbol cns:
+                    ProcessNamespace(cns);
+                    break;
+                case INamedTypeSymbol type:
+                    ProcessType(type);
+                    break;
+            }
+        }
+    }
+
+    bool HasEventTypeAttribute(INamedTypeSymbol type) =>
+        type.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, eventTypeAttributeSymbol));
+}
+```
+
+- [ ] **Step 5: Build the generator project**
+
+Run: `dotnet build src/Core/gen/Eventuous.Subscriptions.Generators/Eventuous.Subscriptions.Generators.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+git commit -m "fix(generators): add EventType attribute discovery for consume context converters"
+```
+
+---
+
+### Task 5: Verify full solution builds and existing tests pass
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build full solution**
+
+Run: `dotnet build Eventuous.slnx`
+Expected: Build succeeded
+
+- [ ] **Step 2: Run analyzer tests**
+
+Run: `dotnet test src/Core/test/Eventuous.Tests.Shared.Analyzers/Eventuous.Tests.Shared.Analyzers.csproj -f net10.0`
+Expected: All tests pass
+
+- [ ] **Step 3: Run existing context conversion tests**
+
+Run: `dotnet test src/Mongo/test/Eventuous.Tests.Projections.MongoDB/Eventuous.Tests.Projections.MongoDB.csproj --filter "FullyQualifiedName~ContextConversions" -f net10.0`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit (if any fixups needed)**
+
+Only if build or tests required adjustments.

--- a/docs/superpowers/specs/2026-04-06-source-generator-event-detection-design.md
+++ b/docs/superpowers/specs/2026-04-06-source-generator-event-detection-design.md
@@ -19,7 +19,7 @@ Two generators fail to detect event types registered via `EventHandler.On<T>()` 
 
 Add `BaseEventHandler` (or `EventHandler`) to `KnownTypeSymbols`:
 ```csharp
-public INamedTypeSymbol? BaseEventHandler { get; } = compilation.GetTypeByMetadataName($"{BaseNamespace}.BaseEventHandler");
+public INamedTypeSymbol? BaseEventHandler { get; } = compilation.GetTypeByMetadataName("Eventuous.Subscriptions.BaseEventHandler");
 ```
 
 Add `IsEventHandler()` helper mirroring the existing `IsState()` pattern (lines 270-290) — walk the `ContainingType` base type chain checking against the resolved symbol, with string-based fallback.

--- a/docs/superpowers/specs/2026-04-06-source-generator-event-detection-design.md
+++ b/docs/superpowers/specs/2026-04-06-source-generator-event-detection-design.md
@@ -1,0 +1,69 @@
+# Source Generator Event Type Detection Fixes
+
+**Issue:** [#538](https://github.com/Eventuous/eventuous/issues/538)
+**Date:** 2026-04-06
+
+## Problem
+
+Two generators fail to detect event types registered via `EventHandler.On<T>()` and its derivatives:
+
+1. **`EventUsageAnalyzer`** — warns about missing `[EventType]` for `State<T>.On<TEvent>()` but has no case for `EventHandler.On<T>()`. Events registered in handler subclasses get no diagnostic.
+
+2. **`ConsumeContextConverterGenerator`** — uses a name-based heuristic (`ShouldTreatGenericOnAsEvent`) that requires the type parameter to contain "Event". Fails for `EventHandler.On<T>()`, `SqliteProjector.On<T>()`, `PostgresProjector.On<T>()`, `SqlServerProjector.On<T>()` — all use `T` not `TEvent`. Additionally, user-defined wrapper methods like `OnSessionOrAgent<T>()` that internally call `On<T>()` can never be detected through call-site tracing.
+
+## Changes
+
+### Change 1: Add `EventHandler.On<T>()` detection to `EventUsageAnalyzer`
+
+**File:** `src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs`
+
+Add `BaseEventHandler` (or `EventHandler`) to `KnownTypeSymbols`:
+```csharp
+public INamedTypeSymbol? BaseEventHandler { get; } = compilation.GetTypeByMetadataName($"{BaseNamespace}.BaseEventHandler");
+```
+
+Add `IsEventHandler()` helper mirroring the existing `IsState()` pattern (lines 270-290) — walk the `ContainingType` base type chain checking against the resolved symbol, with string-based fallback.
+
+Add a new case in `AnalyzeInvocation` alongside case 1c:
+```csharp
+// Case 1d: EventHandler.On<T>(...) handler registrations
+case { Name: "On", TypeArguments.Length: 1 } when IsEventHandler(method.ContainingType, knownTypes):
+```
+
+Same diagnostic (`MissingEventTypeAttribute`) and same `IsExplicitlyRegistered` suppression logic.
+
+### Change 2: Fix `ShouldTreatGenericOnAsEvent` in `ConsumeContextConverterGenerator`
+
+**File:** `src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs`
+
+Replace the type-parameter-name heuristic with a containing-type check. Resolve `BaseEventHandler` symbol via `CompilationProvider` alongside the existing `IMessageConsumeContext` symbol. Pass it through the pipeline to `TransformWithSymbol`.
+
+In `ShouldTreatGenericOnAsEvent` (or its replacement), walk `method.ContainingType.BaseType` chain checking against the resolved `BaseEventHandler` symbol, with string-based fallback.
+
+Keep the existing `TEvent` name check as a secondary fallback for third-party base classes.
+
+### Change 3: Add `[EventType]` discovery to `ConsumeContextConverterGenerator`
+
+**File:** `src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs`
+
+Add a second discovery path using the same approach as `TypeMappingsGenerator.DiscoverFromCompilation` (lines 153-190 of `TypeMappingsGenerator.cs`):
+
+- Resolve `EventTypeAttribute` symbol via `CompilationProvider`
+- Walk `compilation.SourceModule.ReferencedAssemblySymbols` + current assembly global namespace
+- Collect fully-qualified type names for all types with `[EventType]`
+
+Merge with the existing syntax-based candidates before deduplication in `Generate()`. The pipeline mirrors `TypeMappingsGenerator`'s structure where `syntaxCandidates.Combine(symbolCandidates)` are merged.
+
+This catches all event types regardless of how handlers are registered — direct `On<T>()`, wrapper methods, or any other indirection.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `EventUsageAnalyzer.cs` | Add `BaseEventHandler` to `KnownTypeSymbols`, add `IsEventHandler()`, add case 1d |
+| `ConsumeContextConverterGenerator.cs` | Fix containing-type check in `ShouldTreatGenericOnAsEvent`, add `[EventType]` discovery path |
+
+## Tradeoffs
+
+- Change 3 may generate switch arms for `[EventType]` types from referenced assemblies that aren't consumed in this compilation. Cost is negligible — dead pattern match arms optimized by JIT.
+- Changes 1 and 2 only improve direct `On<T>()` detection. Change 3 is what makes the converter generator complete for indirect patterns.

--- a/docs/superpowers/specs/2026-04-06-source-generator-event-detection-design.md
+++ b/docs/superpowers/specs/2026-04-06-source-generator-event-detection-design.md
@@ -38,9 +38,7 @@ Same diagnostic (`MissingEventTypeAttribute`) and same `IsExplicitlyRegistered` 
 
 Replace the type-parameter-name heuristic with a containing-type check. Resolve `BaseEventHandler` symbol via `CompilationProvider` alongside the existing `IMessageConsumeContext` symbol. Pass it through the pipeline to `TransformWithSymbol`.
 
-In `ShouldTreatGenericOnAsEvent` (or its replacement), walk `method.ContainingType.BaseType` chain checking against the resolved `BaseEventHandler` symbol, with string-based fallback.
-
-Keep the existing `TEvent` name check as a secondary fallback for third-party base classes.
+Replace `ShouldTreatGenericOnAsEvent` entirely — the type parameter name is irrelevant. The only check needed: is this an `On` method with 1 type argument whose containing type derives from `BaseEventHandler`? Walk `method.ContainingType.BaseType` chain against the resolved symbol, with string-based fallback. Remove all parameter name heuristics.
 
 ### Change 3: Add `[EventType]` discovery to `ConsumeContextConverterGenerator`
 

--- a/src/Azure/test/Eventuous.Tests.Azure.ServiceBus/AzureServiceBusFixture.cs
+++ b/src/Azure/test/Eventuous.Tests.Azure.ServiceBus/AzureServiceBusFixture.cs
@@ -3,6 +3,7 @@ using Eventuous.Azure.ServiceBus.Subscriptions;
 using Eventuous.Subscriptions;
 using Eventuous.Subscriptions.Filters;
 using Microsoft.Extensions.Logging.Abstractions;
+using DotNet.Testcontainers.Builders;
 using Testcontainers.ServiceBus;
 using TUnit.Core.Interfaces;
 
@@ -14,6 +15,8 @@ public class AzureServiceBusFixture : IAsyncInitializer, IAsyncDisposable {
     public ServiceBusContainer Container { get; } = new ServiceBusBuilder()
         .WithImage("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest")
         .WithAcceptLicenseAgreement(true)
+        .WithWaitStrategy(Wait.ForUnixContainer()
+            .UntilMessageIsLogged("Emulator Service is Successfully Up!", w => w.WithTimeout(TimeSpan.FromMinutes(5))))
         .Build();
 
     public async Task InitializeAsync() {

--- a/src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs
+++ b/src/Core/gen/Eventuous.Shared.Generators/EventUsageAnalyzer.cs
@@ -55,6 +55,7 @@ public sealed class EventUsageAnalyzer : DiagnosticAnalyzer {
         public INamedTypeSymbol? IDefineExecution        { get; } = compilation.GetTypeByMetadataName($"{BaseNamespace}.IDefineExecution");
         public INamedTypeSymbol? ICommandHandlerBuilder  { get; } = compilation.GetTypeByMetadataName($"{BaseNamespace}.ICommandHandlerBuilder");
         public INamedTypeSymbol? IDefineStoreOrExecution { get; } = compilation.GetTypeByMetadataName($"{BaseNamespace}.IDefineStoreOrExecution");
+        public INamedTypeSymbol? BaseEventHandler       { get; } = compilation.GetTypeByMetadataName("Eventuous.Subscriptions.BaseEventHandler");
     }
 
     static ImmutableHashSet<ITypeSymbol> GetExplicitRegistrations(OperationAnalysisContext ctx, KnownTypeSymbols knownTypes) {
@@ -141,6 +142,16 @@ public sealed class EventUsageAnalyzer : DiagnosticAnalyzer {
             }
             // Case 1c: State<T>.On<TEvent>(...) handler registrations
             case { Name: "On", TypeArguments.Length: 1 } when IsState(method.ContainingType, knownTypes): {
+                var eventType = method.TypeArguments[0];
+
+                if (IsConcreteEvent(eventType) && !HasEventTypeAttribute(eventType, knownTypes) && !IsExplicitlyRegistered(eventType, ctx, knownTypes)) {
+                    ctx.ReportDiagnostic(Diagnostic.Create(MissingEventTypeAttribute, inv.Syntax.GetLocation(), eventType.ToDisplayString()));
+                }
+
+                return;
+            }
+            // Case 1d: EventHandler.On<T>(...) handler registrations
+            case { Name: "On", TypeArguments.Length: 1 } when IsEventHandler(method.ContainingType, knownTypes): {
                 var eventType = method.TypeArguments[0];
 
                 if (IsConcreteEvent(eventType) && !HasEventTypeAttribute(eventType, knownTypes) && !IsExplicitlyRegistered(eventType, ctx, knownTypes)) {
@@ -281,6 +292,25 @@ public sealed class EventUsageAnalyzer : DiagnosticAnalyzer {
             else {
                 // Fallback to string comparison
                 if (t is { Name: "State", Arity: 1 } && t.ContainingNamespace.ToDisplayString() == BaseNamespace) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static bool IsEventHandler(INamedTypeSymbol? type, KnownTypeSymbols knownTypes) {
+        if (type == null) return false;
+
+        for (var t = type; t != null; t = t.BaseType) {
+            if (knownTypes.BaseEventHandler != null) {
+                if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, knownTypes.BaseEventHandler)) {
+                    return true;
+                }
+            }
+            else {
+                if (t is { Name: "BaseEventHandler", Arity: 0 } && t.ContainingNamespace?.ToDisplayString() == "Eventuous.Subscriptions") {
                     return true;
                 }
             }

--- a/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+++ b/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
@@ -27,6 +27,9 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
         var baseEventHandlerSymbol = context.CompilationProvider
             .Select(static (c, _) => c.GetTypeByMetadataName("Eventuous.Subscriptions.BaseEventHandler"));
 
+        var eventTypeAttributeSymbol = context.CompilationProvider
+            .Select(static (c, _) => c.GetTypeByMetadataName("Eventuous.EventTypeAttribute"));
+
         var knownSymbols = messageConsumeContextSymbol
             .Combine(baseEventHandlerSymbol)
             .Select(static (pair, _) => new KnownSymbols(pair.Left, pair.Right));
@@ -40,7 +43,15 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
             .Select(static (t, _) => t!)
             .Collect();
 
-        context.RegisterSourceOutput(candidateTypes, Generate);
+        var eventTypeCandidates = eventTypeAttributeSymbol
+            .Combine(context.CompilationProvider)
+            .Select(static (pair, _) => DiscoverEventTypes(pair.Right, pair.Left));
+
+        var mergedCandidates = candidateTypes
+            .Combine(eventTypeCandidates)
+            .Select(static (pair, _) => pair.Left.AddRange(pair.Right));
+
+        context.RegisterSourceOutput(mergedCandidates, Generate);
     }
 
     static bool IsPotentialUsage(SyntaxNode node, CancellationToken _) {
@@ -219,5 +230,46 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
         sb.AppendLine("}");
 
         context.AddSource("MessageConsumeContext_Converters.g.cs", sb.ToString());
+    }
+
+    static ImmutableArray<string> DiscoverEventTypes(Compilation compilation, INamedTypeSymbol? eventTypeAttributeSymbol) {
+        if (eventTypeAttributeSymbol is null) return ImmutableArray<string>.Empty;
+
+        var builder = ImmutableArray.CreateBuilder<string>();
+
+        ProcessNamespace(compilation.Assembly.GlobalNamespace);
+
+        foreach (var ra in compilation.SourceModule.ReferencedAssemblySymbols) {
+            ProcessNamespace(ra.GlobalNamespace);
+        }
+
+        return builder.ToImmutable();
+
+        void ProcessType(INamedTypeSymbol type) {
+            if (HasEventTypeAttribute(type)) {
+                var name = GetTypeSyntax(type);
+                if (name is not null) builder.Add(name);
+            }
+
+            foreach (var nt in type.GetTypeMembers()) {
+                ProcessType(nt);
+            }
+        }
+
+        void ProcessNamespace(INamespaceSymbol ns) {
+            foreach (var member in ns.GetMembers()) {
+                switch (member) {
+                    case INamespaceSymbol cns:
+                        ProcessNamespace(cns);
+                        break;
+                    case INamedTypeSymbol type:
+                        ProcessType(type);
+                        break;
+                }
+            }
+        }
+
+        bool HasEventTypeAttribute(INamedTypeSymbol type) =>
+            type.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, eventTypeAttributeSymbol));
     }
 }

--- a/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+++ b/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
@@ -14,15 +14,27 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
     const string InterfaceName      = "IMessageConsumeContext";
     const string InterfaceFqn       = $"{InterfaceNamespace}.{InterfaceName}`1";
 
+    readonly struct KnownSymbols(INamedTypeSymbol? messageConsumeContext, INamedTypeSymbol? baseEventHandler) {
+        public INamedTypeSymbol? MessageConsumeContext { get; } = messageConsumeContext;
+        public INamedTypeSymbol? BaseEventHandler      { get; } = baseEventHandler;
+    }
+
     public void Initialize(IncrementalGeneratorInitializationContext context) {
         // Resolve the IMessageConsumeContext<> symbol from the compilation
         var messageConsumeContextSymbol = context.CompilationProvider
             .Select(static (c, _) => c.GetTypeByMetadataName(InterfaceFqn));
 
+        var baseEventHandlerSymbol = context.CompilationProvider
+            .Select(static (c, _) => c.GetTypeByMetadataName("Eventuous.Subscriptions.BaseEventHandler"));
+
+        var knownSymbols = messageConsumeContextSymbol
+            .Combine(baseEventHandlerSymbol)
+            .Select(static (pair, _) => new KnownSymbols(pair.Left, pair.Right));
+
         var candidateTypes = context.SyntaxProvider
             .CreateSyntaxProvider(IsPotentialUsage, Transform)
             .Where(static t => t is not null)
-            .Combine(messageConsumeContextSymbol)
+            .Combine(knownSymbols)
             .Select(static (pair, _) => TransformWithSymbol(pair.Left, pair.Right))
             .Where(static t => t is not null)
             .Select(static (t, _) => t!)
@@ -48,7 +60,7 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
         return ctx;
     }
 
-    static string? TransformWithSymbol(GeneratorSyntaxContext? ctx, INamedTypeSymbol? messageConsumeContextSymbol) {
+    static string? TransformWithSymbol(GeneratorSyntaxContext? ctx, KnownSymbols known) {
         if (ctx is not { } context) return null;
 
         // Explicit generic type usage: IMessageConsumeContext<T>
@@ -59,7 +71,7 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
 
             if (symbol != null) {
                 var def = symbol.OriginalDefinition;
-                if (IsTargetInterface(def, messageConsumeContextSymbol) && symbol.TypeArguments.Length == 1) {
+                if (IsTargetInterface(def, known.MessageConsumeContext) && symbol.TypeArguments.Length == 1) {
                     var arg = symbol.TypeArguments[0];
                     return GetTypeSyntax(arg);
                 }
@@ -72,7 +84,7 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
                 if (inv != null) {
                     var symbolInfo = context.SemanticModel.GetSymbolInfo(inv).Symbol;
                     var method = symbolInfo as IMethodSymbol;
-                    if (method?.TypeArguments.Length == 1 && ShouldTreatGenericOnAsEvent(method)) {
+                    if (method?.TypeArguments.Length == 1 && IsEventHandlerOnMethod(method, known.BaseEventHandler)) {
                         var tArg = method.TypeArguments[0];
                         if (tArg.IsReferenceType) return GetTypeSyntax(tArg);
                     }
@@ -88,7 +100,7 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
 
             if (symbol != null) {
                 var def = symbol.OriginalDefinition;
-                if (IsTargetInterface(def, messageConsumeContextSymbol) && symbol.TypeArguments.Length == 1) {
+                if (IsTargetInterface(def, known.MessageConsumeContext) && symbol.TypeArguments.Length == 1) {
                     var arg = symbol.TypeArguments[0];
                     return GetTypeSyntax(arg);
                 }
@@ -102,7 +114,7 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
             var invoke = delegateType?.DelegateInvokeMethod;
             if (invoke is not null) {
                 foreach (var p in invoke.Parameters) {
-                    if (TryExtractTypeArgFromIMessageConsumeContext(p.Type, messageConsumeContextSymbol, out var typeArg)) {
+                    if (TryExtractTypeArgFromIMessageConsumeContext(p.Type, known.MessageConsumeContext, out var typeArg)) {
                         return GetTypeSyntax(typeArg);
                     }
                 }
@@ -132,14 +144,27 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
                def.ContainingNamespace?.ToDisplayString() == InterfaceNamespace;
     }
 
-    static bool ShouldTreatGenericOnAsEvent(IMethodSymbol method) {
+    static bool IsEventHandlerOnMethod(IMethodSymbol method, INamedTypeSymbol? baseEventHandlerSymbol) {
         if (method is not { Name: "On" }) return false;
         var def = method.OriginalDefinition;
         if (def.TypeParameters.Length != 1) return false;
-        var paramName = def.TypeParameters[0].Name;
-        // Heuristic: only treat as event when the generic parameter name indicates an Event
-        // e.g., TEvent, TIntegrationEvent, etc. Skip TCommand, T, etc.
-        return paramName.IndexOf("Event", StringComparison.OrdinalIgnoreCase) >= 0;
+
+        var containingType = def.ContainingType;
+
+        for (var t = containingType; t != null; t = t.BaseType) {
+            if (baseEventHandlerSymbol != null) {
+                if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, baseEventHandlerSymbol)) {
+                    return true;
+                }
+            }
+            else {
+                if (t is { Name: "BaseEventHandler", Arity: 0 } && t.ContainingNamespace?.ToDisplayString() == "Eventuous.Subscriptions") {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     static bool TryExtractTypeArgFromIMessageConsumeContext(

--- a/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+++ b/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
@@ -88,7 +88,7 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
                 }
             }
 
-            // Case 2: On<TSomething>(...) where generic parameter name indicates an Event (e.g., TEvent, TIntegrationEvent)
+            // Case 2: On<T>(...) on BaseEventHandler-derived types (EventHandler, projectors, etc.)
             if (g.Identifier.Text == "On" && g.TypeArgumentList.Arguments.Count == 1) {
                 // Try to get T from the generic method symbol On<T>(...)
                 var inv = g.Parent as InvocationExpressionSyntax ?? g.Parent?.Parent as InvocationExpressionSyntax;

--- a/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+++ b/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
@@ -139,9 +139,26 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
         // Skip unresolved generic type parameters (e.g. T in IMessageConsumeContext<T>)
         if (symbol.TypeKind == TypeKind.TypeParameter) return null;
 
+        // Skip types that are inaccessible from module-level generated code
+        // (e.g. private nested classes can't be referenced from the generated converter)
+        if (!IsAccessibleFromGeneratedCode(symbol)) return null;
+
         // Use fully qualified name with global:: prefix
         var name = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         return name.StartsWith("global::", StringComparison.Ordinal) ? name : $"global::{name}";
+    }
+
+    static bool IsAccessibleFromGeneratedCode(ITypeSymbol symbol) {
+        // Walk the type and all containing types to ensure none is private or protected
+        for (var current = symbol; current != null; current = current.ContainingType) {
+            switch (current.DeclaredAccessibility) {
+                case Accessibility.Private:
+                case Accessibility.Protected:
+                case Accessibility.ProtectedAndInternal:
+                    return false;
+            }
+        }
+        return true;
     }
 
     static bool IsTargetInterface(INamedTypeSymbol def, INamedTypeSymbol? messageConsumeContextSymbol) {

--- a/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
+++ b/src/Core/gen/Eventuous.Subscriptions.Generators/ConsumeContextConverterGenerator.cs
@@ -254,36 +254,43 @@ public sealed class ConsumeContextConverterGenerator : IIncrementalGenerator {
 
         var builder = ImmutableArray.CreateBuilder<string>();
 
-        ProcessNamespace(compilation.Assembly.GlobalNamespace);
+        ProcessNamespace(compilation.Assembly.GlobalNamespace, isReferenced: false);
 
         foreach (var ra in compilation.SourceModule.ReferencedAssemblySymbols) {
-            ProcessNamespace(ra.GlobalNamespace);
+            ProcessNamespace(ra.GlobalNamespace, isReferenced: true);
         }
 
         return builder.ToImmutable();
 
-        void ProcessType(INamedTypeSymbol type) {
-            if (HasEventTypeAttribute(type)) {
+        void ProcessType(INamedTypeSymbol type, bool isReferenced) {
+            if (HasEventTypeAttribute(type) && (!isReferenced || IsPublicType(type))) {
                 var name = GetTypeSyntax(type);
                 if (name is not null) builder.Add(name);
             }
 
             foreach (var nt in type.GetTypeMembers()) {
-                ProcessType(nt);
+                ProcessType(nt, isReferenced);
             }
         }
 
-        void ProcessNamespace(INamespaceSymbol ns) {
+        void ProcessNamespace(INamespaceSymbol ns, bool isReferenced) {
             foreach (var member in ns.GetMembers()) {
                 switch (member) {
                     case INamespaceSymbol cns:
-                        ProcessNamespace(cns);
+                        ProcessNamespace(cns, isReferenced);
                         break;
                     case INamedTypeSymbol type:
-                        ProcessType(type);
+                        ProcessType(type, isReferenced);
                         break;
                 }
             }
+        }
+
+        static bool IsPublicType(INamedTypeSymbol type) {
+            for (var t = (ITypeSymbol)type; t != null; t = t.ContainingType) {
+                if (t.DeclaredAccessibility != Accessibility.Public) return false;
+            }
+            return true;
         }
 
         bool HasEventTypeAttribute(INamedTypeSymbol type) =>

--- a/src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzed.cs
+++ b/src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzed.cs
@@ -17,6 +17,12 @@ file class TestAggregate : Aggregate<TestState> {
     public void Process() => Apply(new Events.RoomBooked("1", DateTime.Now, DateTime.Now.AddDays(1), 100));
 }
 
+file class TestEventHandler : Eventuous.Subscriptions.EventHandler {
+    public TestEventHandler() {
+        On<Events.RoomBooked>(ctx => new System.Threading.Tasks.ValueTask());
+    }
+}
+
 file static class Events {
     [PublicAPI]
     public record RoomBooked(string RoomId, DateTime CheckIn, DateTime CheckOut, decimal Price);

--- a/src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzer_Ev001_Tests.cs
+++ b/src/Core/test/Eventuous.Tests.Shared.Analyzers/Analyzer_Ev001_Tests.cs
@@ -21,12 +21,13 @@ public class Analyzer_Ev001_Tests {
 
         var diagnostics = await GetAnalyzerDiagnosticsAsync(compilation, analyzer);
 
-        // We expect at least two EV001 diagnostics:
+        // We expect at least three EV001 diagnostics:
         // - State<TestState>.On<Events.RoomBooked>(...)
         // - Aggregate.Apply(new Events.RoomBooked(...))
+        // - EventHandler.On<Events.RoomBooked>(...)
         var ev001 = diagnostics.Where(d => d.Id == EventUsageAnalyzer.DiagnosticId).ToArray();
 
-        await Assert.That(ev001.Length).IsGreaterThanOrEqualTo(2);
+        await Assert.That(ev001.Length).IsGreaterThanOrEqualTo(3);
 
         // Optional: verify diagnostic messages mention the event type name
         await Assert.That(ev001.Any(d => d.GetMessage().Contains("RoomBooked"))).IsTrue();
@@ -53,14 +54,17 @@ public class Analyzer_Ev001_Tests {
             MetadataReference.CreateFromFile(typeof(Enumerable).GetTypeInfo().Assembly.Location),
             MetadataReference.CreateFromFile(typeof(State<>).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(Aggregate<>).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(EventTypeAttribute).Assembly.Location)
+            MetadataReference.CreateFromFile(typeof(EventTypeAttribute).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Eventuous.Subscriptions.EventHandler).Assembly.Location)
         };
 
-        // Some frameworks need additional facades depending on runtime; try to add them if present
-        TryAddRef(refs, "System.Runtime");
-        TryAddRef(refs, "System.Collections");
-        TryAddRef(refs, "System.Linq");
-        TryAddRef(refs, "System.Private.CoreLib");
+        // Add runtime assemblies to resolve core types (DateTime, ValueTask, etc.)
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        foreach (var dll in Directory.GetFiles(runtimeDir, "System.*.dll")) {
+            refs.Add(MetadataReference.CreateFromFile(dll));
+        }
+
+        TryAddRef(refs, "netstandard");
 
         var compilation = CSharpCompilation.Create(
             assemblyName: "Analyzer_Ev001_Tests_Assembly",

--- a/src/Core/test/Eventuous.Tests.Shared.Analyzers/Eventuous.Tests.Shared.Analyzers.csproj
+++ b/src/Core/test/Eventuous.Tests.Shared.Analyzers/Eventuous.Tests.Shared.Analyzers.csproj
@@ -19,5 +19,6 @@
         <ProjectReference Include="$(LocalRoot)\Eventuous.Application\Eventuous.Application.csproj"/>
         <ProjectReference Include="$(SrcRoot)\Testing\src\Eventuous.Testing\Eventuous.Testing.csproj"/>
         <ProjectReference Include="$(LocalGenRoot)\Eventuous.Shared.Generators\Eventuous.Shared.Generators.csproj" />
+        <ProjectReference Include="$(LocalRoot)\Eventuous.Subscriptions\Eventuous.Subscriptions.csproj"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- **EventUsageAnalyzer**: Added `EventHandler.On<T>()` detection (case 1d) so the analyzer now warns about missing `[EventType]` on event types registered in subscription handlers, not just `State<T>.On<TEvent>()`
- **ConsumeContextConverterGenerator**: Replaced the fragile name-based heuristic (`ShouldTreatGenericOnAsEvent` checking if type parameter name contains "Event") with a containing-type check that walks the base type chain for `BaseEventHandler`
- **ConsumeContextConverterGenerator**: Added `[EventType]` attribute discovery from current and referenced assemblies as a fallback for indirect registration patterns (e.g., wrapper methods like `OnSessionOrAgent<T>()`)
- Added accessibility filter to skip private/protected nested types discovered via `[EventType]` scanning

Closes #538

## Test plan

- [x] Analyzer test updated to verify `EventHandler.On<T>()` detection (3 diagnostics now expected)
- [x] Full solution build passes
- [x] Existing context conversion tests pass (MongoDB projections)
- [ ] Manual verification with a project using `EventHandler.On<T>()` directly
- [ ] Manual verification with wrapper patterns like `OnSessionOrAgent<T>()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)