### PR TITLE
Fix persistent subscription failure handler never being invoked

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -44,6 +44,4 @@ jobs:
         name: Create and push NuGet package
         run: |
           dotnet pack -c Release -o nuget -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
-          dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-        env:
-          NUGET_AUTH_TOKEN: ${{ github.token }}
+          dotnet nuget push nuget/**/*.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,7 @@ jobs:
       -
         name: Create and push NuGet package
         run: |
-          dotnet pack -c Debug -o nuget
-          dotnet nuget push nuget/**/*.nupkg --skip-duplicate --api-key ${{ secrets.MYGET_API_KEY }} --source https://www.myget.org/F/${{ vars.MYGET_FEED_NAME || 'eventuous' }}/api/v3/index.json
+          dotnet pack -c Release -o nuget -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
+          dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   nuget:
     runs-on: [ self-hosted, type-cpx52, setup-docker, volume-cache-50GB ]
+    permissions:
+      id-token: write
+      contents: read
     env:
       NUGET_PACKAGES: "/mnt/cache/.nuget/packages"
       DOTNET_INSTALL_DIR: "/mnt/cache/.dotnet"
@@ -49,10 +52,15 @@ jobs:
             test-results/**/*.xml
             test-results/**/*.trx
       -
+        name: NuGet trusted publishing login
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER || 'Eventuous' }}
+      -
         name: Create and push NuGet package
         run: |
           dotnet pack -c Release -o nuget -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
-          dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          dotnet nuget push nuget/**/*.nupkg --api-key ${{ secrets.MYGET_API_KEY }} --source https://www.myget.org/F/${{ vars.MYGET_FEED_NAME || 'eventuous' }}/api/v2/package --skip-duplicate
+          dotnet nuget push nuget/**/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         env:
           NUGET_AUTH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,4 @@ jobs:
         name: Create and push NuGet package
         run: |
           dotnet pack -c Release -o nuget -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
-          dotnet nuget push nuget/**/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-        env:
-          NUGET_AUTH_TOKEN: ${{ github.token }}
+          dotnet nuget push nuget/**/*.nupkg --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVer)" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.19.0" />
     <PackageVersion Include="Confluent.Kafka" Version="2.6.1" />
@@ -105,12 +105,12 @@
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.1.0" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="$(NpgsqlVersion)" />
-    <PackageVersion Include="OpenTelemetry" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.13.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.1-beta.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftExtensionsVer)" />
     <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.19.0" />

--- a/src/Experimental/src/Eventuous.Spyglass/SpyglassRegistry.cs
+++ b/src/Experimental/src/Eventuous.Spyglass/SpyglassRegistry.cs
@@ -25,20 +25,34 @@ public record SpyglassLoadResult(object State, SpyglassEventInfo[] Events);
 public record SpyglassEventInfo(string EventType, object? Payload);
 
 public static class SpyglassRegistry {
-    static readonly List<SpyglassAggregateInfo> Aggregates = [];
+    // Module initializers from different assemblies can call Register concurrently when the assemblies
+    // are loaded by parallel test fixtures (or any parallel host startup), so the backing store has to
+    // be thread-safe. Reads also enumerate the snapshot, so we publish a fresh array on every write.
+    static SpyglassAggregateInfo[] _aggregates = [];
+    static readonly object         _lock       = new();
 
-    public static void Register(SpyglassAggregateInfo info)
-        => Aggregates.Add(info with { Id = Guid.NewGuid() });
+    public static void Register(SpyglassAggregateInfo info) {
+        lock (_lock) {
+            var entry = info with { Id = Guid.NewGuid() };
+            var next  = new SpyglassAggregateInfo[_aggregates.Length + 1];
+            Array.Copy(_aggregates, next, _aggregates.Length);
+            next[^1]    = entry;
+            _aggregates = next;
+        }
+    }
 
     public static SpyglassAggregateEntry[] GetAggregates()
-        => Aggregates.Select(a => new SpyglassAggregateEntry(a.Id, a.AggregateType, a.StateType, a.Methods, a.Events)).ToArray();
+        => _aggregates.Select(a => new SpyglassAggregateEntry(a.Id, a.AggregateType, a.StateType, a.Methods, a.Events)).ToArray();
 
     public static SpyglassAggregateInfo? FindById(Guid id)
-        => Aggregates.FirstOrDefault(x => x.Id == id);
+        => Array.Find(_aggregates, x => x.Id == id);
 
-    public static SpyglassAggregateInfo? FindByTypeName(string typeName)
-        => Aggregates.FirstOrDefault(x => x.AggregateType                == typeName)
-         ?? Aggregates.FirstOrDefault(x => StripStateSuffix(x.StateType) == typeName);
+    public static SpyglassAggregateInfo? FindByTypeName(string typeName) {
+        var snapshot = _aggregates;
+
+        return Array.Find(snapshot, x => x.AggregateType                == typeName)
+            ?? Array.Find(snapshot, x => StripStateSuffix(x.StateType) == typeName);
+    }
 
     static string StripStateSuffix(string s)
         => s.EndsWith("State") && s.Length > 5 ? s[..^5] : s;

--- a/src/KurrentDB/src/Eventuous.KurrentDB/Eventuous.KurrentDB.csproj
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/Eventuous.KurrentDB.csproj
@@ -7,6 +7,9 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="KurrentDB.Client"/>
+        <!-- KurrentDB.Client transitively pulls OpenTelemetry.Api 1.12.0 which is vulnerable
+             (GHSA-g94r-2vxg-569j). Forcing the central pinned version overrides the transitive. -->
+        <PackageReference Include="OpenTelemetry.Api"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(CoreRoot)\Eventuous.Producers\Eventuous.Producers.csproj"/>

--- a/src/KurrentDB/src/Eventuous.KurrentDB/Subscriptions/PersistentSubscriptionBase.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/Subscriptions/PersistentSubscriptionBase.cs
@@ -185,10 +185,6 @@ public abstract class PersistentSubscriptionBase<T> : EventSubscription<T> where
             return;
         }
 
-        ctx.LogContext.MessageHandlingFailed(Options.SubscriptionId, ctx, exception);
-
-        if (Options.ThrowOnError) throw exception;
-
         var re           = ctx.Items.GetItem<ResolvedEvent>(ResolvedEventKey);
         var subscription = ctx.Items.GetItem<PersistentSubscription>(SubscriptionKey)!;
         await _handleEventProcessingFailure(Client, subscription, re, exception).NoContext();

--- a/src/KurrentDB/src/Eventuous.KurrentDB/Subscriptions/PersistentSubscriptionBase.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/Subscriptions/PersistentSubscriptionBase.cs
@@ -185,6 +185,12 @@ public abstract class PersistentSubscriptionBase<T> : EventSubscription<T> where
             return;
         }
 
+        // Handler-pipeline failures are already logged via context.Nack inside EventSubscription.Handler.
+        // Anything else reaching here (e.g. an Ack failure after the handler returned) needs its own log entry.
+        if (!ctx.HasFailed()) {
+            ctx.LogContext.MessageHandlingFailed(Options.SubscriptionId, ctx, exception);
+        }
+
         var re           = ctx.Items.GetItem<ResolvedEvent>(ResolvedEventKey);
         var subscription = ctx.Items.GetItem<PersistentSubscription>(SubscriptionKey)!;
         await _handleEventProcessingFailure(Client, subscription, re, exception).NoContext();
@@ -244,6 +250,12 @@ public abstract class PersistentSubscriptionBase<T> : EventSubscription<T> where
             PersistentSubscription subscription,
             ResolvedEvent          resolvedEvent,
             Exception              exception
-        )
-        => subscription.Nack(PersistentSubscriptionNakEventAction.Retry, exception.Message, resolvedEvent);
+        ) {
+        // When ThrowOnError is enabled, Handler wraps the original exception in SubscriptionException;
+        // unwrap it so the parked-message reason carries the actual handler error rather than a generic
+        // "Error processing event ..." string.
+        var cause = exception is SubscriptionException { InnerException: { } inner } ? inner : exception;
+
+        return subscription.Nack(PersistentSubscriptionNakEventAction.Retry, cause.Message, resolvedEvent);
+    }
 }

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/Fixtures/PersistentSubscriptionFixture.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/Fixtures/PersistentSubscriptionFixture.cs
@@ -2,6 +2,7 @@ using Eventuous.Diagnostics.Logging;
 using Eventuous.KurrentDB.Producers;
 using Eventuous.KurrentDB.Subscriptions;
 using Eventuous.Tests.Subscriptions.Base;
+using KurrentDB.Client;
 using LoggingExtensions = Eventuous.TestHelpers.TUnit.Logging.LoggingExtensions;
 
 namespace Eventuous.Tests.KurrentDB.Subscriptions.Fixtures;
@@ -15,12 +16,14 @@ public class PersistentSubscriptionFixture<TSubscription, TOptions, THandler>(
     where THandler : class, IEventHandler
     where TSubscription : PersistentSubscriptionBase<TOptions>
     where TOptions : PersistentSubscriptionOptions {
-    public    StreamName         Stream       { get; }              = new($"test-{Guid.NewGuid():N}");
-    public    THandler           Handler      { get; }              = handler;
-    public    KurrentDBProducer Producer     { get; private set; } = null!;
-    protected ILogger            Log          { get; set; }         = null!;
-    protected StoreFixture       Fixture      { get; }              = new(logLevel);
-    TSubscription                Subscription { get; set; }         = null!;
+    public    StreamName         Stream         { get; }              = new($"test-{Guid.NewGuid():N}");
+    public    THandler           Handler        { get; }              = handler;
+    public    KurrentDBProducer  Producer       { get; private set; } = null!;
+    public    string             SubscriptionId { get; private set; } = null!;
+    public    KurrentDBClient    Client         => Fixture.Client;
+    protected ILogger            Log            { get; set; }         = null!;
+    protected StoreFixture       Fixture        { get; }              = new(logLevel);
+    TSubscription                Subscription   { get; set; }         = null!;
 
     public ValueTask Start() => Subscription.SubscribeWithLog(Log);
 
@@ -32,13 +35,13 @@ public class PersistentSubscriptionFixture<TSubscription, TOptions, THandler>(
         Fixture.TypeMapper.RegisterKnownEventTypes(typeof(TestEvent).Assembly);
         await Fixture.InitializeAsync();
         Producer = new(Fixture.Client);
-        var loggerFactory  = LoggingExtensions.GetLoggerFactory(logLevel);
-        var subscriptionId = $"test-{Guid.NewGuid():N}";
-        Log = loggerFactory.CreateLogger(GetType());
+        var loggerFactory = LoggingExtensions.GetLoggerFactory(logLevel);
+        SubscriptionId = $"test-{Guid.NewGuid():N}";
+        Log            = loggerFactory.CreateLogger(GetType());
 
         _listener = new(loggerFactory);
 
-        Subscription = subscriptionFactory(subscriptionId, Fixture.Container.GetConnectionString(), Stream, Handler, loggerFactory);
+        Subscription = subscriptionFactory(SubscriptionId, Fixture.Container.GetConnectionString(), Stream, Handler, loggerFactory);
         if (autoStart) await Start();
     }
 

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/PersistentSubscriptionFailureTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/PersistentSubscriptionFailureTests.cs
@@ -19,21 +19,25 @@ public class PersistentSubscriptionFailureTests {
         );
 
         await fixture.InitializeAsync();
+        var started = false;
 
         try {
             await fixture.Start();
+            started = true;
 
             var testEvent = TestEvent.Create();
             await fixture.Producer.Produce(fixture.Stream, testEvent, new(), cancellationToken: cancellationToken);
 
             var parkedStream = $"$persistentsubscription-{fixture.Stream}::{fixture.SubscriptionId}-parked";
-            var parked       = await ReadFirstParkedEvent(fixture.Client, parkedStream, TimeSpan.FromSeconds(20), cancellationToken);
+            var parked       = await ReadFirstParkedEvent(fixture.Client, parkedStream, TimeSpan.FromSeconds(20), cancellationToken)
+                            ?? throw new TimeoutException($"No event was parked on {parkedStream} within the timeout");
 
-            await Assert.That(parked).IsNotNull();
-            await Assert.That(parked!.Value.Event.EventStreamId).IsEqualTo(fixture.Stream.ToString());
-            await Assert.That(parked.Value.Event.EventType).IsEqualTo(TestEvent.TypeName);
+            await Assert.That(parked.Event.EventStreamId).IsEqualTo(fixture.Stream.ToString());
+            await Assert.That(parked.Event.EventType).IsEqualTo(TestEvent.TypeName);
             await Assert.That(fixture.Handler.Failures).IsGreaterThan(0);
         } finally {
+            // Fixture only auto-stops when autoStart is true, so stop explicitly to avoid leaking the subscription.
+            if (started) await fixture.Stop();
             await fixture.DisposeAsync();
         }
     }

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/PersistentSubscriptionFailureTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/PersistentSubscriptionFailureTests.cs
@@ -1,0 +1,107 @@
+using Eventuous.KurrentDB.Subscriptions;
+using Eventuous.Producers;
+using Eventuous.Subscriptions.Context;
+using Eventuous.Subscriptions.Filters;
+using Eventuous.Tests.KurrentDB.Subscriptions.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+using KurrentDB.Client;
+
+namespace Eventuous.Tests.KurrentDB.Subscriptions;
+
+public class PersistentSubscriptionFailureTests {
+    [Test]
+    [Category("Persistent subscription")]
+    public async Task Esdb_ShouldParkMessageWhenHandlerFails(CancellationToken cancellationToken) {
+        var fixture = new PersistentSubscriptionFixture<StreamPersistentSubscription, StreamPersistentSubscriptionOptions, AlwaysFailingHandler>(
+            new(),
+            CreateSubscription,
+            autoStart: false
+        );
+
+        await fixture.InitializeAsync();
+
+        try {
+            await fixture.Start();
+
+            var testEvent = TestEvent.Create();
+            await fixture.Producer.Produce(fixture.Stream, testEvent, new(), cancellationToken: cancellationToken);
+
+            var parkedStream = $"$persistentsubscription-{fixture.Stream}::{fixture.SubscriptionId}-parked";
+            var parked       = await ReadFirstParkedEvent(fixture.Client, parkedStream, TimeSpan.FromSeconds(20), cancellationToken);
+
+            await Assert.That(parked).IsNotNull();
+            await Assert.That(parked!.Value.Event.EventStreamId).IsEqualTo(fixture.Stream.ToString());
+            await Assert.That(parked.Value.Event.EventType).IsEqualTo(TestEvent.TypeName);
+            await Assert.That(fixture.Handler.Failures).IsGreaterThan(0);
+        } finally {
+            await fixture.DisposeAsync();
+        }
+    }
+
+    static StreamPersistentSubscription CreateSubscription(string id, string connectionString, StreamName stream, AlwaysFailingHandler handler, ILoggerFactory loggerFactory) {
+        var settings = KurrentDBClientSettings.Create(connectionString);
+
+        return new(
+            new KurrentDBClient(settings),
+            new() {
+                StreamName     = stream,
+                SubscriptionId = id,
+                ThrowOnError   = true,
+                SubscriptionSettings = new PersistentSubscriptionSettings(
+                    resolveLinkTos: false,
+                    messageTimeout: TimeSpan.FromSeconds(2),
+                    maxRetryCount: 0
+                )
+            },
+            new ConsumePipe().AddDefaultConsumer(handler),
+            loggerFactory
+        );
+    }
+
+    static async Task<ResolvedEvent?> ReadFirstParkedEvent(KurrentDBClient client, string parkedStream, TimeSpan timeout, CancellationToken cancellationToken) {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        while (!cts.Token.IsCancellationRequested) {
+            try {
+                var read  = client.ReadStreamAsync(
+                    Direction.Forwards,
+                    parkedStream,
+                    StreamPosition.Start,
+                    maxCount: 1,
+                    resolveLinkTos: true,
+                    cancellationToken: cts.Token
+                );
+                var state = await read.ReadState;
+
+                if (state == ReadState.Ok) {
+                    await foreach (var resolved in read) {
+                        return resolved;
+                    }
+                }
+            } catch (OperationCanceledException) when (cts.Token.IsCancellationRequested) {
+                return null;
+            }
+
+            try {
+                await Task.Delay(200, cts.Token);
+            } catch (OperationCanceledException) when (cts.Token.IsCancellationRequested) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+}
+
+public class AlwaysFailingHandler : BaseEventHandler {
+    int _failures;
+
+    public int Failures => Volatile.Read(ref _failures);
+
+    public override ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) {
+        Interlocked.Increment(ref _failures);
+
+        throw new InvalidOperationException("Simulated handler failure");
+    }
+}


### PR DESCRIPTION
## Summary

Four things in this branch:

### 1. Persistent subscription failure handler unreachable (closes #544)

- Removes the early `throw` in `PersistentSubscriptionBase.Nack` that made `_handleEventProcessingFailure` unreachable, so the configured (or default) failure handler now actually runs when the handler throws with `ThrowOnError = true`.
- Default behaviour is now what the docs and original design described: server-side `Nack(Retry, ...)` → retries up to `MaxRetryCount` → message parked. Subscription stays connected.
- Adds an integration test that reproduces the bug: produces one event, fails the handler with `maxRetryCount: 0`, and asserts the message lands on `$persistentsubscription-{stream}::{group}-parked` (read with `resolveLinkTos: true`).
- Minor fixture tweak: `PersistentSubscriptionFixture` exposes `SubscriptionId` and `Client` so the test can address the parked stream.

The reachability bug, in case it's useful for review: `Nack` is only entered from the `catch` in `HandleEvent`, that catch only fires when `Handler` re-throws, and `Handler` only re-throws when `ThrowOnError = true`. So `if (Options.ThrowOnError) throw exception;` was effectively unconditional, and the failure handler below it was dead code.

### 2. OpenTelemetry 1.13.x → 1.15.x

Clears `GHSA-g94r-2vxg-569j` (excessive memory allocation parsing baggage/B3/Jaeger headers — fixed in 1.15.3). All `1.13.x` references bumped, with the two beta-only packages on the matching 1.15.x betas.

### 3. Preview pipeline: MyGet → nuget.org

MyGet has been unreachable, so the dev-branch publish job now mirrors the release pipeline and pushes to nuget.org (Release config + symbols). MinVer keeps preview builds versioned as pre-releases, so they're safe to land on nuget.org.

### 4. Release pipeline: trusted publishing, drop MyGet

- Removes the second `dotnet nuget push` to MyGet from `publish.yml`.
- Switches the release push to NuGet OIDC trusted publishing via `NuGet/login@v1`. Adds `id-token: write` at the job level so the runner can mint the OIDC token for the profile already configured on nuget.org.
- NuGet user defaults to `Eventuous` but can be overridden via the `NUGET_USER` repository variable.

Once this lands and the next release runs green, the `NUGET_API_KEY`, `MYGET_API_KEY`, and `MYGET_FEED_NAME` secrets/variables can be revoked from the repo settings. (The preview workflow still uses `NUGET_API_KEY`; if you want to flip preview to trusted publishing too, just say the word and I'll mirror the change there.)

## Test plan

- [x] New `Esdb_ShouldParkMessageWhenHandlerFails` test passes (was red before the fix)
- [x] Existing `HandlerFailureResubscribe` (catch-up subscription drop & resubscribe path) still passes
- [x] Existing persistent subscription happy-path tests (`SubscribeAndProduceMany`) still pass
- [x] Full solution builds cleanly after the OpenTelemetry bump
- [ ] Trusted publishing end-to-end: verify on next tag push that `NuGet/login` succeeds and `dotnet nuget push` accepts the short-lived key