### PR TITLE
test: subscription drop/resubscribe + health; fix relational end-of-stream measure (#308, #548)

### DIFF
--- a/src/Core/src/Eventuous.Subscriptions/Diagnostics/SubscriptionHealth.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Diagnostics/SubscriptionHealth.cs
@@ -1,6 +1,7 @@
 // Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Eventuous.Subscriptions.Diagnostics;
@@ -12,7 +13,10 @@ public interface ISubscriptionHealth {
 }
 
 public class SubscriptionHealthCheck : ISubscriptionHealth, IHealthCheck {
-    readonly Dictionary<string, HealthReport> _healthReports = new();
+    // Reports are written from subscription subscribed/dropped callbacks (background threads) while
+    // CheckHealthAsync enumerates them from the health endpoint. A plain Dictionary throws
+    // "Collection was modified" on concurrent access; ConcurrentDictionary makes both sides safe.
+    readonly ConcurrentDictionary<string, HealthReport> _healthReports = new();
 
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default) {
         var        unhealthy  = new List<string>();

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/Fixtures/SubscriptionFixtureBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/Fixtures/SubscriptionFixtureBase.cs
@@ -1,6 +1,7 @@
 using DotNet.Testcontainers.Containers;
 using Eventuous.Subscriptions;
 using Eventuous.Subscriptions.Checkpoints;
+using Eventuous.Subscriptions.Diagnostics;
 using Eventuous.Sut.Domain;
 using Eventuous.Tests.Persistence.Base.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,9 +31,31 @@ public abstract class SubscriptionFixtureBase<TContainer, TSubscription, TSubscr
     IMessageSubscription                Subscription    { get; set; }         = null!;
     protected internal ILoggerFactory   LoggerFactory   { get; set; }         = null!;
 
+    /// <summary>
+    /// Health check fed by the subscription's subscribed/dropped callbacks. Lets tests assert that a dropped
+    /// subscription reports unhealthy and that it recovers to healthy after resubscription.
+    /// </summary>
+    protected internal SubscriptionHealthCheck Health { get; } = new();
+
+    /// <summary>
+    /// True when the subscription has detected a drop and is trying to resubscribe.
+    /// </summary>
+    public bool IsDropped => ((EventSubscription<TSubscriptionOptions>)Subscription).IsDropped;
+
     public string SubscriptionId { get; } = $"test-{Guid.NewGuid():N}";
 
-    protected internal ValueTask StartSubscription() => Subscription.SubscribeWithLog(Log);
+    protected internal ValueTask StartSubscription()
+        => Subscription.Subscribe(
+            id => {
+                Health.ReportHealthy(id);
+                Log.LogInformation("{Subscription} subscribed", id);
+            },
+            (id, reason, ex) => {
+                Health.ReportUnhealthy(id, ex);
+                Log.LogWarning(ex, "{Subscription} dropped {Reason}", id, reason);
+            },
+            CancellationToken.None
+        );
 
     protected internal ValueTask StopSubscription() => Subscription.UnsubscribeWithLog(Log);
 

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/Fixtures/SubscriptionFixtureBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/Fixtures/SubscriptionFixtureBase.cs
@@ -42,6 +42,11 @@ public abstract class SubscriptionFixtureBase<TContainer, TSubscription, TSubscr
     /// </summary>
     public bool IsDropped => ((EventSubscription<TSubscriptionOptions>)Subscription).IsDropped;
 
+    /// <summary>
+    /// Returns the subscription's end-of-stream measure delegate (requires an <see cref="IMeasuredSubscription"/>).
+    /// </summary>
+    protected internal GetSubscriptionEndOfStream GetMeasure() => ((IMeasuredSubscription)Subscription).GetMeasure();
+
     public string SubscriptionId { get; } = $"test-{Guid.NewGuid():N}";
 
     protected internal ValueTask StartSubscription()

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/Fixtures/TestEventHandler.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/Fixtures/TestEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Bogus;
 using Eventuous.Subscriptions;
 using Eventuous.Subscriptions.Context;
@@ -28,22 +29,33 @@ public class TestEventHandler(TestEventHandlerOptions? options) : BaseEventHandl
 
     public int Count { get; private set; }
 
-    readonly Observer<object> _observer = new();
+    readonly Observer<object>       _observer = new();
+    readonly ConcurrentQueue<object> _handled = new();
 
     public On<object> AssertThat() => Hypothesis.On(_observer);
 
     public Hypothesis<object> AssertCollection(TimeSpan deadline, List<object> collection)
         => Hypothesis.On(_observer).Timebox(deadline).Exactly(collection.Count).Match(collection.Contains);
 
+    /// <summary>
+    /// Messages handled so far. Backed by a concurrent queue so tests can poll it while the subscription
+    /// keeps handling on background threads.
+    /// </summary>
+    public IReadOnlyCollection<object> Handled => _handled.ToArray();
+
     public override async ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) {
         await Task.Delay(_delay);
         await _observer.Add(context.Message!, context.CancellationToken);
+        _handled.Enqueue(context.Message!);
         Count++;
 
         return EventHandlingStatus.Success;
     }
 
-    public void Reset() => Count = 0;
+    public void Reset() {
+        Count = 0;
+        _handled.Clear();
+    }
 }
 
 public record TestEventHandlerOptions(TimeSpan? Delay = null);

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionDropBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionDropBase.cs
@@ -1,0 +1,114 @@
+using DotNet.Testcontainers.Containers;
+using Eventuous.Subscriptions;
+using Eventuous.Subscriptions.Checkpoints;
+using Eventuous.Sut.App;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Eventuous.Tests.Subscriptions.Base;
+
+/// <summary>
+/// Base test that verifies a subscription drops and resubscribes when the underlying infrastructure
+/// connection is lost and later restored, and that the subscription health check reports
+/// <see cref="HealthStatus.Unhealthy"/> while dropped and <see cref="HealthStatus.Healthy"/> again after
+/// recovery. The connection loss is simulated by pausing the infrastructure container (Docker pause), which
+/// freezes the database process while keeping the published port intact, so the same connection string keeps
+/// working once the container is unpaused. Reproduces the scenario from GitHub #308 (and #307).
+/// </summary>
+public abstract class SubscriptionDropBase<TContainer, TSubscription, TSubscriptionOptions, TCheckpointStore>(
+        SubscriptionFixtureBase<TContainer, TSubscription, TSubscriptionOptions, TCheckpointStore, TestEventHandler> fixture
+    ) : SubscriptionTestBase(fixture)
+    where TContainer : DockerContainer
+    where TSubscription : EventSubscription<TSubscriptionOptions>
+    where TSubscriptionOptions : SubscriptionOptions
+    where TCheckpointStore : class, ICheckpointStore {
+    const int BatchSize = 5;
+
+    // The poll/connection failure that follows a pause surfaces only after the provider's command/connection
+    // timeout elapses, so give detection (and recovery) a generous window.
+    static readonly TimeSpan DropTimeout = TimeSpan.FromSeconds(90);
+
+    /// <summary>
+    /// Produces and consumes events, drops the connection by pausing the container, asserts the subscription is
+    /// reported unhealthy, restores the connection, then asserts that the subscription resubscribes, reports
+    /// healthy again, and resumes processing newly produced events.
+    /// </summary>
+    protected async Task ShouldResubscribeAfterConnectionDrop(CancellationToken cancellationToken) {
+        // 1. Produce and consume an initial batch; the subscription must be healthy.
+        await GenerateAndHandleCommands(BatchSize);
+        await fixture.StartSubscription();
+        var consumedInitial = await WaitUntil(() => fixture.Handler.Count >= BatchSize, DropTimeout, cancellationToken);
+        await Assert.That(consumedInitial).IsTrue();
+        await Assert.That(await GetHealthStatus(cancellationToken)).IsEqualTo(HealthStatus.Healthy);
+
+        // 2. Drop the connection by pausing the container.
+        WriteLine("Pausing the container to drop the connection");
+        await fixture.Container.PauseAsync(cancellationToken);
+
+        // 3. The subscription must detect the drop and report unhealthy.
+        var dropped = await WaitUntil(() => fixture.IsDropped, DropTimeout, cancellationToken);
+        await Assert.That(dropped).IsTrue();
+        var unhealthy = await WaitUntil(async () => await GetHealthStatus(cancellationToken) == HealthStatus.Unhealthy, DropTimeout, cancellationToken);
+        await Assert.That(unhealthy).IsTrue();
+        WriteLine("Subscription dropped and reported unhealthy");
+
+        // 4. Restore the connection.
+        WriteLine("Unpausing the container to restore the connection");
+        await fixture.Container.UnpauseAsync(cancellationToken);
+
+        // 5. The subscription must resubscribe and report healthy again.
+        var recovered = await WaitUntil(() => !fixture.IsDropped, DropTimeout, cancellationToken);
+        await Assert.That(recovered).IsTrue();
+        var healthy = await WaitUntil(async () => await GetHealthStatus(cancellationToken) == HealthStatus.Healthy, DropTimeout, cancellationToken);
+        await Assert.That(healthy).IsTrue();
+        WriteLine("Subscription resubscribed and reported healthy");
+
+        // 6. Events produced after recovery must be processed.
+        var countBeforeRecovery = fixture.Handler.Count;
+        await GenerateAndHandleCommands(BatchSize);
+        var resumed = await WaitUntil(() => fixture.Handler.Count >= countBeforeRecovery + BatchSize, DropTimeout, cancellationToken);
+
+        await fixture.StopSubscription();
+
+        await Assert.That(resumed).IsTrue();
+        WriteLine("Processed {0} events after recovery", fixture.Handler.Count - countBeforeRecovery);
+    }
+
+    async Task<HealthStatus> GetHealthStatus(CancellationToken cancellationToken) {
+        var result = await fixture.Health.CheckHealthAsync(new(), cancellationToken);
+
+        return result.Status;
+    }
+
+    static Task<bool> WaitUntil(Func<bool> condition, TimeSpan timeout, CancellationToken cancellationToken)
+        => WaitUntil(() => Task.FromResult(condition()), timeout, cancellationToken);
+
+    static async Task<bool> WaitUntil(Func<Task<bool>> condition, TimeSpan timeout, CancellationToken cancellationToken) {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        try {
+            while (!await condition()) {
+                await Task.Delay(200, cts.Token);
+            }
+
+            return true;
+        } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+            return false;
+        }
+    }
+
+    async Task GenerateAndHandleCommands(int count) {
+        var commands = Enumerable
+            .Range(0, count)
+            .Select(_ => DomainFixture.CreateImportBooking())
+            .ToList();
+
+        var service = new BookingService(fixture.EventStore);
+
+        foreach (var cmd in commands) {
+            var result = await service.Handle(cmd, default);
+            result.ThrowIfError();
+        }
+    }
+}

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionDropBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionDropBase.cs
@@ -34,44 +34,88 @@ public abstract class SubscriptionDropBase<TContainer, TSubscription, TSubscript
     /// healthy again, and resumes processing newly produced events.
     /// </summary>
     protected async Task ShouldResubscribeAfterConnectionDrop(CancellationToken cancellationToken) {
-        // 1. Produce and consume an initial batch; the subscription must be healthy.
-        await GenerateAndHandleCommands(BatchSize);
-        await fixture.StartSubscription();
-        var consumedInitial = await WaitUntil(() => fixture.Handler.Count >= BatchSize, DropTimeout, cancellationToken);
-        await Assert.That(consumedInitial).IsTrue();
-        await Assert.That(await GetHealthStatus(cancellationToken)).IsEqualTo(HealthStatus.Healthy);
+        var subscriptionStarted = false;
+        var containerPaused     = false;
 
-        // 2. Drop the connection by pausing the container.
-        WriteLine("Pausing the container to drop the connection");
-        await fixture.Container.PauseAsync(cancellationToken);
+        try {
+            // 1. Produce and consume an initial batch; the subscription must be healthy.
+            await GenerateAndHandleCommands(BatchSize);
+            await fixture.StartSubscription();
+            subscriptionStarted = true;
+            var consumedInitial = await WaitUntil(() => fixture.Handler.Count >= BatchSize, DropTimeout, cancellationToken);
+            await Assert.That(consumedInitial).IsTrue();
+            await Assert.That(await GetHealthStatus(cancellationToken)).IsEqualTo(HealthStatus.Healthy);
 
-        // 3. The subscription must detect the drop and report unhealthy.
-        var dropped = await WaitUntil(() => fixture.IsDropped, DropTimeout, cancellationToken);
-        await Assert.That(dropped).IsTrue();
-        var unhealthy = await WaitUntil(async () => await GetHealthStatus(cancellationToken) == HealthStatus.Unhealthy, DropTimeout, cancellationToken);
-        await Assert.That(unhealthy).IsTrue();
-        WriteLine("Subscription dropped and reported unhealthy");
+            // Wait until the initial batch is committed to the checkpoint. Otherwise the subscription
+            // replays those uncommitted events on resubscribe, and the replay could satisfy the
+            // post-recovery assertion below without any newly produced event ever being processed.
+            var lastPosition = await fixture.GetLastPosition();
+            var checkpointed = await WaitUntil(
+                async () => {
+                    var checkpoint = await fixture.CheckpointStore.GetLastCheckpoint(fixture.SubscriptionId, cancellationToken);
 
-        // 4. Restore the connection.
-        WriteLine("Unpausing the container to restore the connection");
-        await fixture.Container.UnpauseAsync(cancellationToken);
+                    return checkpoint.Position >= lastPosition;
+                },
+                DropTimeout,
+                cancellationToken
+            );
+            await Assert.That(checkpointed).IsTrue();
 
-        // 5. The subscription must resubscribe and report healthy again.
-        var recovered = await WaitUntil(() => !fixture.IsDropped, DropTimeout, cancellationToken);
-        await Assert.That(recovered).IsTrue();
-        var healthy = await WaitUntil(async () => await GetHealthStatus(cancellationToken) == HealthStatus.Healthy, DropTimeout, cancellationToken);
-        await Assert.That(healthy).IsTrue();
-        WriteLine("Subscription resubscribed and reported healthy");
+            // 2. Drop the connection by pausing the container.
+            WriteLine("Pausing the container to drop the connection");
+            await fixture.Container.PauseAsync(cancellationToken);
+            containerPaused = true;
 
-        // 6. Events produced after recovery must be processed.
-        var countBeforeRecovery = fixture.Handler.Count;
-        await GenerateAndHandleCommands(BatchSize);
-        var resumed = await WaitUntil(() => fixture.Handler.Count >= countBeforeRecovery + BatchSize, DropTimeout, cancellationToken);
+            // 3. The subscription must detect the drop and report unhealthy.
+            var dropped = await WaitUntil(() => fixture.IsDropped, DropTimeout, cancellationToken);
+            await Assert.That(dropped).IsTrue();
+            var unhealthy = await WaitUntil(async () => await GetHealthStatus(cancellationToken) == HealthStatus.Unhealthy, DropTimeout, cancellationToken);
+            await Assert.That(unhealthy).IsTrue();
+            WriteLine("Subscription dropped and reported unhealthy");
 
-        await fixture.StopSubscription();
+            // 4. Restore the connection.
+            WriteLine("Unpausing the container to restore the connection");
+            await fixture.Container.UnpauseAsync(cancellationToken);
+            containerPaused = false;
 
-        await Assert.That(resumed).IsTrue();
-        WriteLine("Processed {0} events after recovery", fixture.Handler.Count - countBeforeRecovery);
+            // 5. The subscription must resubscribe and report healthy again.
+            var recovered = await WaitUntil(() => !fixture.IsDropped, DropTimeout, cancellationToken);
+            await Assert.That(recovered).IsTrue();
+            var healthy = await WaitUntil(async () => await GetHealthStatus(cancellationToken) == HealthStatus.Healthy, DropTimeout, cancellationToken);
+            await Assert.That(healthy).IsTrue();
+            WriteLine("Subscription resubscribed and reported healthy");
+
+            // 6. Events produced after recovery must be processed. The initial batch is already
+            // checkpointed, so it cannot be replayed and this count only advances for new events.
+            var countBeforeRecovery = fixture.Handler.Count;
+            await GenerateAndHandleCommands(BatchSize);
+            var resumed = await WaitUntil(() => fixture.Handler.Count >= countBeforeRecovery + BatchSize, DropTimeout, cancellationToken);
+
+            await fixture.StopSubscription();
+            subscriptionStarted = false;
+
+            await Assert.That(resumed).IsTrue();
+            WriteLine("Processed {0} events after recovery", fixture.Handler.Count - countBeforeRecovery);
+        } finally {
+            // Undo the destructive steps even if an assertion fails or the test is cancelled mid-flight:
+            // a container left paused, or a subscription left resubscribing, would contaminate later tests.
+            // These fixtures use autoStart=false, so fixture disposal won't stop the subscription either.
+            if (containerPaused) {
+                try {
+                    await fixture.Container.UnpauseAsync(CancellationToken.None);
+                } catch (Exception ex) {
+                    WriteLine("Cleanup: failed to unpause the container: {0}", ex.Message);
+                }
+            }
+
+            if (subscriptionStarted) {
+                try {
+                    await fixture.StopSubscription();
+                } catch (Exception ex) {
+                    WriteLine("Cleanup: failed to stop the subscription: {0}", ex.Message);
+                }
+            }
+        }
     }
 
     async Task<HealthStatus> GetHealthStatus(CancellationToken cancellationToken) {

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionDropBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionDropBase.cs
@@ -4,6 +4,8 @@ using Eventuous.Subscriptions.Checkpoints;
 using Eventuous.Sut.App;
 using Eventuous.Tests.Persistence.Base.Fixtures;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using static Eventuous.Sut.App.Commands;
+using static Eventuous.Sut.Domain.BookingEvents;
 
 namespace Eventuous.Tests.Subscriptions.Base;
 
@@ -46,21 +48,6 @@ public abstract class SubscriptionDropBase<TContainer, TSubscription, TSubscript
             await Assert.That(consumedInitial).IsTrue();
             await Assert.That(await GetHealthStatus(cancellationToken)).IsEqualTo(HealthStatus.Healthy);
 
-            // Wait until the initial batch is committed to the checkpoint. Otherwise the subscription
-            // replays those uncommitted events on resubscribe, and the replay could satisfy the
-            // post-recovery assertion below without any newly produced event ever being processed.
-            var lastPosition = await fixture.GetLastPosition();
-            var checkpointed = await WaitUntil(
-                async () => {
-                    var checkpoint = await fixture.CheckpointStore.GetLastCheckpoint(fixture.SubscriptionId, cancellationToken);
-
-                    return checkpoint.Position >= lastPosition;
-                },
-                DropTimeout,
-                cancellationToken
-            );
-            await Assert.That(checkpointed).IsTrue();
-
             // 2. Drop the connection by pausing the container.
             WriteLine("Pausing the container to drop the connection");
             await fixture.Container.PauseAsync(cancellationToken);
@@ -85,17 +72,27 @@ public abstract class SubscriptionDropBase<TContainer, TSubscription, TSubscript
             await Assert.That(healthy).IsTrue();
             WriteLine("Subscription resubscribed and reported healthy");
 
-            // 6. Events produced after recovery must be processed. The initial batch is already
-            // checkpointed, so it cannot be replayed and this count only advances for new events.
-            var countBeforeRecovery = fixture.Handler.Count;
-            await GenerateAndHandleCommands(BatchSize);
-            var resumed = await WaitUntil(() => fixture.Handler.Count >= countBeforeRecovery + BatchSize, DropTimeout, cancellationToken);
+            // 6. Events produced after recovery must be processed. Assert the specific post-recovery
+            // events are handled (by identity), so a replay of the initial batch on resubscribe can't
+            // satisfy this — only genuinely new events count. This is provider-agnostic, unlike comparing
+            // the committed checkpoint to GetLastPosition ($all includes system events the subscription
+            // skips, so its checkpoint never reaches that head).
+            var expected = (await GenerateAndHandleCommands(BatchSize)).Select(ToEvent).ToList();
+            var resumed = await WaitUntil(
+                () => {
+                    var handled = fixture.Handler.Handled;
+
+                    return expected.All(e => handled.Contains(e));
+                },
+                DropTimeout,
+                cancellationToken
+            );
 
             await fixture.StopSubscription();
             subscriptionStarted = false;
 
             await Assert.That(resumed).IsTrue();
-            WriteLine("Processed {0} events after recovery", fixture.Handler.Count - countBeforeRecovery);
+            WriteLine("Processed {0} events after recovery", expected.Count);
         } finally {
             // Undo the destructive steps even if an assertion fails or the test is cancelled mid-flight:
             // a container left paused, or a subscription left resubscribing, would contaminate later tests.
@@ -142,7 +139,7 @@ public abstract class SubscriptionDropBase<TContainer, TSubscription, TSubscript
         }
     }
 
-    async Task GenerateAndHandleCommands(int count) {
+    async Task<List<ImportBooking>> GenerateAndHandleCommands(int count) {
         var commands = Enumerable
             .Range(0, count)
             .Select(_ => DomainFixture.CreateImportBooking())
@@ -154,5 +151,9 @@ public abstract class SubscriptionDropBase<TContainer, TSubscription, TSubscript
             var result = await service.Handle(cmd, default);
             result.ThrowIfError();
         }
+
+        return commands;
     }
+
+    static BookingImported ToEvent(ImportBooking cmd) => new(cmd.RoomId, cmd.Price, cmd.CheckIn, cmd.CheckOut);
 }

--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionMeasureBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionMeasureBase.cs
@@ -1,0 +1,53 @@
+using DotNet.Testcontainers.Containers;
+using Eventuous.Subscriptions;
+using Eventuous.Subscriptions.Checkpoints;
+using Eventuous.Subscriptions.Diagnostics;
+using Eventuous.Sut.App;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+
+namespace Eventuous.Tests.Subscriptions.Base;
+
+/// <summary>
+/// Base test for the subscription end-of-stream measure used by the gap/lag diagnostics. Verifies that the
+/// measure reports a valid position both on an empty store and after events are appended. Reproduces GitHub
+/// #548, where the relational implementation queried the wrong column, threw on 32-bit position columns, and
+/// failed on the <c>NULL</c> returned by <c>MAX(...)</c> over an empty table.
+/// </summary>
+public abstract class SubscriptionMeasureBase<TContainer, TSubscription, TSubscriptionOptions, TCheckpointStore>(
+        SubscriptionFixtureBase<TContainer, TSubscription, TSubscriptionOptions, TCheckpointStore, TestEventHandler> fixture
+    ) : SubscriptionTestBase(fixture)
+    where TContainer : DockerContainer
+    where TSubscription : EventSubscription<TSubscriptionOptions>
+    where TSubscriptionOptions : SubscriptionOptions
+    where TCheckpointStore : class, ICheckpointStore {
+    protected async Task ShouldMeasureEndOfStream(CancellationToken cancellationToken) {
+        var measure = fixture.GetMeasure();
+
+        // An empty store must yield a valid measure at position zero, not EndOfStream.Invalid.
+        var empty = await measure(cancellationToken);
+        await Assert.That(empty.SubscriptionId).IsEqualTo(fixture.SubscriptionId);
+        await Assert.That(empty.Position).IsEqualTo(0ul);
+
+        // After appending events, the measure must report the global end position.
+        await GenerateAndHandleCommands(10);
+        var last = await fixture.GetLastPosition();
+
+        var measured = await measure(cancellationToken);
+        await Assert.That(measured.SubscriptionId).IsEqualTo(fixture.SubscriptionId);
+        await Assert.That(measured.Position).IsEqualTo(last);
+    }
+
+    async Task GenerateAndHandleCommands(int count) {
+        var commands = Enumerable
+            .Range(0, count)
+            .Select(_ => DomainFixture.CreateImportBooking())
+            .ToList();
+
+        var service = new BookingService(fixture.EventStore);
+
+        foreach (var cmd in commands) {
+            var result = await service.Handle(cmd, default);
+            result.ThrowIfError();
+        }
+    }
+}

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/SubscriptionDropTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Subscriptions/SubscriptionDropTests.cs
@@ -1,0 +1,21 @@
+using Eventuous.KurrentDB.Subscriptions;
+using Eventuous.Tests.KurrentDB.Subscriptions.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+using Testcontainers.KurrentDb;
+
+namespace Eventuous.Tests.KurrentDB.Subscriptions;
+
+public class SubscriptionDrop()
+    : SubscriptionDropBase<KurrentDbContainer, AllStreamSubscription, AllStreamSubscriptionOptions, TestCheckpointStore>(
+        new CatchUpSubscriptionFixture<AllStreamSubscription, AllStreamSubscriptionOptions, TestEventHandler>(
+            _ => { },
+            new("$all"),
+            false
+        )
+    ) {
+    [Test]
+    [Retry(3)]
+    public async Task Esdb_ShouldResubscribeAfterConnectionDrop(CancellationToken cancellationToken) {
+        await ShouldResubscribeAfterConnectionDrop(cancellationToken);
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionDropTests.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionDropTests.cs
@@ -1,0 +1,20 @@
+using Eventuous.Postgresql;
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Subscriptions.Base;
+using Testcontainers.PostgreSql;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class SubscriptionDrop()
+    : SubscriptionDropBase<PostgreSqlContainer, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, PostgresCheckpointStore>(
+        new SubscriptionFixture<PostgresStore, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestEventHandler>(
+            _ => { },
+            false
+        )
+    ) {
+    [Test]
+    public async Task Postgres_ShouldResubscribeAfterConnectionDrop(CancellationToken cancellationToken) {
+        await ShouldResubscribeAfterConnectionDrop(cancellationToken);
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionMeasureTests.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionMeasureTests.cs
@@ -1,0 +1,20 @@
+using Eventuous.Postgresql;
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Subscriptions.Base;
+using Testcontainers.PostgreSql;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class SubscriptionMeasure()
+    : SubscriptionMeasureBase<PostgreSqlContainer, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, PostgresCheckpointStore>(
+        new SubscriptionFixture<PostgresStore, PostgresAllStreamSubscription, PostgresAllStreamSubscriptionOptions, TestEventHandler>(
+            _ => { },
+            false
+        )
+    ) {
+    [Test]
+    public async Task Postgres_ShouldMeasureEndOfStream(CancellationToken cancellationToken) {
+        await ShouldMeasureEndOfStream(cancellationToken);
+    }
+}

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
@@ -341,16 +341,20 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
             cmd.CommandType = CommandType.Text;
 
             cmd.CommandText = Kind switch {
-                SubscriptionKind.All    => GetEndOfStream,
-                SubscriptionKind.Stream => GetEndOfAll
+                SubscriptionKind.All    => GetEndOfAll,
+                SubscriptionKind.Stream => GetEndOfStream
             };
             await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).NoContext();
 
-            var position = await reader.ReadAsync(cancellationToken).NoContext() ? reader.GetInt64(0) : 0;
+            // MAX(...) returns NULL on an empty table, and providers may return the position column as either
+            // Int32 or Int64, so guard against DBNull and convert rather than calling the strict GetInt64.
+            var position = await reader.ReadAsync(cancellationToken).NoContext() && reader[0] is not DBNull
+                ? Convert.ToInt64(reader[0])
+                : 0;
 
             return new(SubscriptionId, (ulong)position, DateTime.UtcNow);
-        } catch (Exception) {
-            Log.WarnLog?.Log("Failed to get end of stream");
+        } catch (Exception e) {
+            Log.WarnLog?.Log(e, "Failed to get end of stream");
 
             return EndOfStream.Invalid;
         }

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/SubscriptionDropTests.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/SubscriptionDropTests.cs
@@ -1,0 +1,19 @@
+using Eventuous.SqlServer.Subscriptions;
+using Eventuous.Tests.Subscriptions.Base;
+using Testcontainers.MsSql;
+
+namespace Eventuous.Tests.SqlServer.Subscriptions;
+
+[NotInParallel]
+public class SubscriptionDrop()
+    : SubscriptionDropBase<MsSqlContainer, SqlServerAllStreamSubscription, SqlServerAllStreamSubscriptionOptions, SqlServerCheckpointStore>(
+        new SubscriptionFixture<SqlServerAllStreamSubscription, SqlServerAllStreamSubscriptionOptions, TestEventHandler>(
+            _ => { },
+            false
+        )
+    ) {
+    [Test]
+    public async Task SqlServer_ShouldResubscribeAfterConnectionDrop(CancellationToken cancellationToken) {
+        await ShouldResubscribeAfterConnectionDrop(cancellationToken);
+    }
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/SubscriptionMeasureTests.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/SubscriptionMeasureTests.cs
@@ -1,0 +1,19 @@
+using Eventuous.SqlServer.Subscriptions;
+using Eventuous.Tests.Subscriptions.Base;
+using Testcontainers.MsSql;
+
+namespace Eventuous.Tests.SqlServer.Subscriptions;
+
+[NotInParallel]
+public class SubscriptionMeasure()
+    : SubscriptionMeasureBase<MsSqlContainer, SqlServerAllStreamSubscription, SqlServerAllStreamSubscriptionOptions, SqlServerCheckpointStore>(
+        new SubscriptionFixture<SqlServerAllStreamSubscription, SqlServerAllStreamSubscriptionOptions, TestEventHandler>(
+            _ => { },
+            false
+        )
+    ) {
+    [Test]
+    public async Task SqlServer_ShouldMeasureEndOfStream(CancellationToken cancellationToken) {
+        await ShouldMeasureEndOfStream(cancellationToken);
+    }
+}


### PR DESCRIPTION
Adds subscription test coverage requested in #308 and fixes the relational end-of-stream measure bug reported in #548.

## #308 — drop/resubscribe + health

Adds an infra-agnostic base test, `SubscriptionDropBase`, that verifies a subscription drops and resubscribes when the underlying infrastructure connection is lost and restored, and that the health check transitions accordingly. Follows the existing `HandlerFailureBase` convention (one base + a thin per-store subclass).

Flow: produce/consume events (assert **Healthy**) → `docker pause` the container to drop the connection → assert subscription dropped and **Unhealthy** → `docker unpause` → assert resubscribe and **Healthy** → produce more events and assert they are processed.

| Store | Test |
|-------|------|
| SQL Server | `SqlServer_ShouldResubscribeAfterConnectionDrop` |
| PostgreSQL | `Postgres_ShouldResubscribeAfterConnectionDrop` |
| KurrentDB (ESDB) | `Esdb_ShouldResubscribeAfterConnectionDrop` (`[Retry(3)]`) |

SQLite is excluded — its fixture isn't container-backed, so there's no transport to drop.

`SubscriptionFixtureBase` now wires the subscribed/dropped callbacks to a `SubscriptionHealthCheck` (mirroring `SubscriptionHostedService`) and exposes `IsDropped`. Backward-compatible — existing handler-failure tests still pass.

Note: the health check only exposes **Healthy/Unhealthy** (no `Degraded`), so the test asserts `Unhealthy` on drop and `Healthy` on recovery.

## #548 — `GetSubscriptionEndOfStream` fix

`SqlSubscriptionBase.GetSubscriptionEndOfStream` had three defects that made the gap/lag diagnostics log `"Failed to get end of stream"` repeatedly:

- **Swapped switch arms** — an `All` subscription queried `MAX(stream_position)` and a `Stream` subscription queried `MAX(global_position)`.
- **`GetInt64(0)`** threw `InvalidCastException` when the provider returned the position column as `Int32`.
- **No `DBNull` guard** — `MAX(...)` over an empty table threw.

Fixed by querying the correct column per kind, guarding against `DBNull`, and using `Convert.ToInt64` (accepts either integer width). The catch block now logs the actual exception instead of swallowing it.

Added `SubscriptionMeasureBase` + SQL Server/PostgreSQL subclasses asserting the measure returns position `0` on an empty store and the global end position after events are appended.

## Verification

Ran locally (net10.0) against real containers — all passing:

- Drop tests: SQL Server (~1m47s), PostgreSQL (~1m29s), KurrentDB (~1m16s) ✅
- Measure tests: SQL Server, PostgreSQL ✅ — and confirmed they **fail** against the unfixed code
- Existing `HandlerFailureResubscribe` (SQL Server + PostgreSQL) ✅ — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
