### PR TITLE
fix(subscriptions): harden the worker dispose failure path

### DIFF
--- a/src/Core/src/Eventuous.Subscriptions/Channels/ChannelWorkerBase.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Channels/ChannelWorkerBase.cs
@@ -31,29 +31,33 @@ abstract class ChannelWorkerBase<T> : IAsyncDisposable {
     /// Idempotent. The commit handler worker is disposed by both the resubscribe and the shutdown
     /// paths, which can run concurrently, so a second call is expected rather than a programming
     /// error. It must not re-enter the shutdown: by then the CTS is disposed, and cancelling it
-    /// again throws <see cref="ObjectDisposedException"/> out of host shutdown. The second caller
-    /// awaits the first call's shutdown, so it can't return before the final checkpoint flush.
+    /// again throws <see cref="ObjectDisposedException"/> out of host shutdown. Every caller awaits
+    /// the same task, so none of them returns before the final checkpoint flush, and a shutdown that
+    /// failed is reported to whoever awaits it instead of being left on a task nobody observes.
     /// </summary>
-    public ValueTask DisposeAsync() => Interlocked.Exchange(ref _disposing, 1) == 0 ? new(StopWorker()) : new(_disposed.Task);
+    public ValueTask DisposeAsync() {
+        if (Interlocked.Exchange(ref _disposing, 1) == 0) _ = StopWorker();
+
+        return new(_disposed.Task);
+    }
 
     async Task StopWorker() {
         try {
-            _stopping = true;
-            await _channel.Stop(_cts, _readerTasks, OnDispose).NoContext();
-#if NET8_0_OR_GREATER
-            await _cts.CancelAsync().NoContext();
-#else
-            _cts.Cancel();
-#endif
-            await Task.WhenAll(_readerTasks).NoThrow();
-            _cts.Dispose();
-            GC.SuppressFinalize(this);
-            _disposed.TrySetResult();
-        } catch (Exception e) {
-            // Don't let a waiter see a clean shutdown that didn't happen.
-            _disposed.TrySetException(e);
+            try {
+                _stopping = true;
+                await _channel.Stop(_cts, _readerTasks, OnDispose).NoContext();
+            }
+            finally {
+                // Release the readers even when the graceful stop above failed: they hold _cts.Token,
+                // and Stop armed a ten-second timer on it, so both outlive the worker unless cancelled
+                // here. Cancelling runs their callbacks, which is why this can't be allowed to throw.
+                await _cts.CancelAsync().NoThrow();
+                await Task.WhenAll(_readerTasks).NoThrow();
+                _cts.Dispose();
+                GC.SuppressFinalize(this);
+            }
 
-            throw;
-        }
+            _disposed.TrySetResult();
+        } catch (Exception e) { _disposed.TrySetException(e); }
     }
 }

--- a/src/Core/src/Eventuous.Subscriptions/Channels/ChannelWorkerBase.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Channels/ChannelWorkerBase.cs
@@ -58,6 +58,10 @@ abstract class ChannelWorkerBase<T> : IAsyncDisposable {
             }
 
             _disposed.TrySetResult();
-        } catch (Exception e) { _disposed.TrySetException(e); }
+        } catch (Exception e) {
+            // Broad on purpose. DisposeAsync hands _disposed.Task to every caller, so completing it is the
+            // only thing that ever releases them; an exception escaping here would strand all of them.
+            _disposed.TrySetException(e);
+        }
     }
 }

--- a/src/Core/src/Eventuous.Subscriptions/EventSubscription.cs
+++ b/src/Core/src/Eventuous.Subscriptions/EventSubscription.cs
@@ -229,6 +229,11 @@ public abstract class EventSubscription<T> : IMessageSubscription, IAsyncDisposa
 
         Task.Run(
             async () => {
+                // Check again: Unsubscribe may have cancelled between the check above and this task
+                // getting scheduled. It doesn't close the race — Resubscribe still disposes the commit
+                // handler before it looks at the token — but it keeps the common case out of it.
+                if (stopping.IsCancellationRequested) return;
+
                 var delay = reason == DropReason.Stopped ? TimeSpan.FromSeconds(10) : TimeSpan.FromSeconds(2);
                 Log.SubscriptionWillResubscribe(delay);
 


### PR DESCRIPTION
Follow-up to #562, which merged before these review findings were addressed. Two bot reviewers flagged the dispose gate; both were right, though one's stated mechanism turned out to be wrong.

## Every caller gets the shared task

The winner awaited `StopWorker()` directly while the `TaskCompletionSource` was faulted separately. A failed shutdown with no second caller therefore left a faulted task nobody observed, which resurfaces through `TaskScheduler.UnobservedTaskException` as exactly the kind of spurious shutdown warning #562 set out to remove. `DisposeAsync` now returns `_disposed.Task` to everyone, so the failure is observed exactly once and there is only ever one task.

## Cleanup moved into a `finally`

A throw from the graceful stop skipped the cancel, the reader drain and `_cts.Dispose()`, leaking the ten-second timer `ChannelExtensions.Stop` arms via `CancelAfter` and leaving the readers holding a live token. That gap predates #562, but the dispose gate makes it permanent, since `_disposing` never resets. Both cleanup awaits suppress, so a throwing cancellation callback can't skip disposal either.

Worth recording that the reviewer's premise — "`channel.Stop` propagates reader-task faults" — is mostly wrong. `Stop` filters to `!r.IsCompleted`, and a faulted task *is* completed, so a reader that has already faulted is silently skipped. I confirmed this empirically: driving the commit worker's processor into a throw and then disposing produces no exception at all. The reachable window is narrower than claimed — a reader faulting *while* `Stop` awaits it, or `CancelAsync` throwing — but it is not empty, and the invariant "dispose always releases the CTS" is worth holding unconditionally.

## Re-check the stopping token inside the resubscribe task

`Unsubscribe` can cancel between the check in `Dropped` and the task being scheduled. This does not close the race — `EventSubscriptionWithCheckpoint.Resubscribe` disposes the commit handler before it looks at the token, which is why the idempotent dispose in #562 is the actual fix — but it keeps the common case out of it.

## Tests

No new tests. The two `ChannelWorkerBase` changes affect an error path whose consequences (a released timer, an unobserved task) have no seam to assert on: reaching the throw needs a reader to fault mid-`Stop`, and observing the fix needs either private fields or `TaskScheduler.UnobservedTaskException` plus forced GC — a global, GC-timed assertion that would itself be the flaky test this work is meant to eliminate. I verified the path with a throwaway probe instead, which is what turned up the `IsCompleted` filtering above. The token re-check is inherently racy and equally untestable; the deterministic pre-check it backs up is already covered by `Drop_after_shutdown_started_does_not_resubscribe`.

## Verification

- `Eventuous.Tests.Subscriptions` 38/38, `Eventuous.Tests` 26/26, `Eventuous.Tests.Application` 21/21 (net10.0)
- `Eventuous.Tests.KurrentDB` 60/60, including the drop/resubscribe test
- `dotnet build Eventuous.slnx` clean across net8.0/net9.0/net10.0; tests ran locally on net10.0 only (net8/net9 runtimes absent on the dev machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)