### PR TITLE
fix: true streaming reads in KurrentDB store and paged read-to-end API

### DIFF
--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
@@ -11,6 +11,8 @@ public interface IEventReader {
     /// events before yielding, so memory usage can grow with <paramref name="count"/>. To read a whole stream,
     /// use <see cref="StoreFunctions.ReadStreamToEnd"/>, which reads in pages, instead of passing
     /// <see cref="int.MaxValue"/> as the count.
+    /// Implementations must yield exactly <paramref name="count"/> events unless the end of the stream is reached,
+    /// and must return an empty sequence, not throw, when reading past the end of an existing stream.
     /// </summary>
     /// <param name="stream">Stream name</param>
     /// <param name="start">Where to start reading events</param>

--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
@@ -7,6 +7,10 @@ public interface IEventReader {
     /// <summary>
     /// Read a fixed number of events from an existing stream as an async enumerable.
     /// Throws <see cref="StreamNotFound"/> if the stream does not exist.
+    /// Implementations either stream events as they arrive from the store, or buffer up to <paramref name="count"/>
+    /// events before yielding, so memory usage can grow with <paramref name="count"/>. To read a whole stream,
+    /// use <see cref="StoreFunctions.ReadStreamToEnd"/>, which reads in pages, instead of passing
+    /// <see cref="int.MaxValue"/> as the count.
     /// </summary>
     /// <param name="stream">Stream name</param>
     /// <param name="start">Where to start reading events</param>
@@ -18,6 +22,8 @@ public interface IEventReader {
     /// <summary>
     /// Read a number of events from a given stream, backwards (from the stream end).
     /// Throws <see cref="StreamNotFound"/> if the stream does not exist.
+    /// Implementations either stream events as they arrive from the store, or buffer up to <paramref name="count"/>
+    /// events before yielding, so memory usage can grow with <paramref name="count"/>.
     /// </summary>
     /// <param name="stream">Stream name</param>
     /// <param name="start">Where to start reading events</param>

--- a/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/IEventReader.cs
@@ -7,10 +7,10 @@ public interface IEventReader {
     /// <summary>
     /// Read a fixed number of events from an existing stream as an async enumerable.
     /// Throws <see cref="StreamNotFound"/> if the stream does not exist.
-    /// Implementations either stream events as they arrive from the store, or buffer up to <paramref name="count"/>
-    /// events before yielding, so memory usage can grow with <paramref name="count"/>. To read a whole stream,
-    /// use <see cref="StoreFunctions.ReadStreamToEnd"/>, which reads in pages, instead of passing
-    /// <see cref="int.MaxValue"/> as the count.
+    /// Implementations either stream events as they arrive from the store, or buffer events in an amount
+    /// proportional to <paramref name="count"/> before yielding, so memory usage can grow with
+    /// <paramref name="count"/>. To read a whole stream, use <see cref="StoreFunctions.ReadStreamToEnd"/>,
+    /// which reads in pages, instead of passing <see cref="int.MaxValue"/> as the count.
     /// Implementations must yield exactly <paramref name="count"/> events unless the end of the stream is reached,
     /// and must return an empty sequence, not throw, when reading past the end of an existing stream.
     /// </summary>
@@ -24,8 +24,9 @@ public interface IEventReader {
     /// <summary>
     /// Read a number of events from a given stream, backwards (from the stream end).
     /// Throws <see cref="StreamNotFound"/> if the stream does not exist.
-    /// Implementations either stream events as they arrive from the store, or buffer up to <paramref name="count"/>
-    /// events before yielding, so memory usage can grow with <paramref name="count"/>.
+    /// Implementations either stream events as they arrive from the store, or buffer events in an amount
+    /// proportional to <paramref name="count"/> before yielding, so memory usage can grow with
+    /// <paramref name="count"/>.
     /// </summary>
     /// <param name="stream">Stream name</param>
     /// <param name="start">Where to start reading events</param>

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -164,43 +164,16 @@ public static class StoreFunctions {
         /// instead of throwing <see cref="StreamNotFound"/>. Default is true.</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An async enumerable of events retrieved from the stream</returns>
-        public async IAsyncEnumerable<StreamEvent> ReadStreamToEnd(
-                StreamName                                 streamName,
-                StreamReadPosition                         start,
-                int                                        pageSize          = 500,
-                bool                                       failIfNotFound    = true,
-                [EnumeratorCancellation] CancellationToken cancellationToken = default
+        public IAsyncEnumerable<StreamEvent> ReadStreamToEnd(
+                StreamName        streamName,
+                StreamReadPosition start,
+                int               pageSize          = 500,
+                bool              failIfNotFound    = true,
+                CancellationToken cancellationToken = default
             ) {
-            var position = start;
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
 
-            while (true) {
-                var  yielded      = 0;
-                long lastRevision = 0;
-
-                await using var enumerator = eventReader.ReadEvents(streamName, position, pageSize, cancellationToken).GetAsyncEnumerator(cancellationToken);
-
-                while (true) {
-                    bool moved;
-
-                    try {
-                        moved = await enumerator.MoveNextAsync().NoContext();
-                    } catch (StreamNotFound) when (!failIfNotFound) {
-                        yield break;
-                    }
-
-                    if (!moved) break;
-
-                    var evt = enumerator.Current;
-                    yielded++;
-                    lastRevision = evt.Revision;
-
-                    yield return evt;
-                }
-
-                if (yielded < pageSize) yield break;
-
-                position = new(lastRevision + 1);
-            }
+            return ReadToEnd(eventReader, streamName, start, pageSize, failIfNotFound, cancellationToken);
         }
 
         /// <summary>
@@ -225,6 +198,48 @@ public static class StoreFunctions {
             }
 
             return [.. streamEvents];
+        }
+    }
+
+    // Relies on readers yielding exactly `count` events unless the stream end is reached:
+    // a page shorter than pageSize means there is nothing left to read
+    static async IAsyncEnumerable<StreamEvent> ReadToEnd(
+            IEventReader                               eventReader,
+            StreamName                                 streamName,
+            StreamReadPosition                         start,
+            int                                        pageSize,
+            bool                                       failIfNotFound,
+            [EnumeratorCancellation] CancellationToken cancellationToken
+        ) {
+        var position = start;
+
+        while (true) {
+            var  yielded      = 0;
+            long lastRevision = 0;
+
+            await using var enumerator = eventReader.ReadEvents(streamName, position, pageSize, cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+            while (true) {
+                bool moved;
+
+                try {
+                    moved = await enumerator.MoveNextAsync().NoContext();
+                } catch (StreamNotFound) when (!failIfNotFound) {
+                    yield break;
+                }
+
+                if (!moved) break;
+
+                var evt = enumerator.Current;
+                yielded++;
+                lastRevision = evt.Revision;
+
+                yield return evt;
+            }
+
+            if (yielded < pageSize) yield break;
+
+            position = new(lastRevision + 1);
         }
     }
 }

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -158,8 +158,9 @@ public static class StoreFunctions {
         /// </summary>
         /// <param name="streamName">Name of the stream to read from</param>
         /// <param name="start">Stream position to start reading from</param>
-        /// <param name="pageSize">Number of events to read per page. It caps the amount of events a buffering
-        /// implementation of <see cref="IEventReader"/> holds in memory at a time.</param>
+        /// <param name="pageSize">Number of events to read per page. It bounds the memory a buffering
+        /// implementation of <see cref="IEventReader"/> uses: such implementations hold at most a small
+        /// multiple of a page in memory at a time (e.g. a tiered reader combining two stores).</param>
         /// <param name="failIfNotFound">Set to false to complete without yielding anything when the stream isn't found,
         /// instead of throwing <see cref="StreamNotFound"/>. Default is true.</param>
         /// <param name="cancellationToken">Cancellation token</param>

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -240,6 +240,9 @@ public static class StoreFunctions {
 
             if (yielded < pageSize) yield break;
 
+            // The maximum revision is the end of the representable position space
+            if (lastRevision == long.MaxValue) yield break;
+
             position = new(lastRevision + 1);
         }
     }

--- a/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/StoreFunctions.cs
@@ -1,6 +1,8 @@
 // Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using System.Runtime.CompilerServices;
+
 namespace Eventuous;
 
 public static class StoreFunctions {
@@ -149,6 +151,59 @@ public static class StoreFunctions {
         }
 
         /// <summary>
+        /// Reads a stream from the given position to the end, as an async enumerable.
+        /// Events are read in pages of <paramref name="pageSize"/> and yielded as they arrive, so the whole stream
+        /// is never buffered in memory. Use this instead of calling <see cref="IEventReader.ReadEvents"/>
+        /// with <see cref="int.MaxValue"/> as the count.
+        /// </summary>
+        /// <param name="streamName">Name of the stream to read from</param>
+        /// <param name="start">Stream position to start reading from</param>
+        /// <param name="pageSize">Number of events to read per page. It caps the amount of events a buffering
+        /// implementation of <see cref="IEventReader"/> holds in memory at a time.</param>
+        /// <param name="failIfNotFound">Set to false to complete without yielding anything when the stream isn't found,
+        /// instead of throwing <see cref="StreamNotFound"/>. Default is true.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An async enumerable of events retrieved from the stream</returns>
+        public async IAsyncEnumerable<StreamEvent> ReadStreamToEnd(
+                StreamName                                 streamName,
+                StreamReadPosition                         start,
+                int                                        pageSize          = 500,
+                bool                                       failIfNotFound    = true,
+                [EnumeratorCancellation] CancellationToken cancellationToken = default
+            ) {
+            var position = start;
+
+            while (true) {
+                var  yielded      = 0;
+                long lastRevision = 0;
+
+                await using var enumerator = eventReader.ReadEvents(streamName, position, pageSize, cancellationToken).GetAsyncEnumerator(cancellationToken);
+
+                while (true) {
+                    bool moved;
+
+                    try {
+                        moved = await enumerator.MoveNextAsync().NoContext();
+                    } catch (StreamNotFound) when (!failIfNotFound) {
+                        yield break;
+                    }
+
+                    if (!moved) break;
+
+                    var evt = enumerator.Current;
+                    yielded++;
+                    lastRevision = evt.Revision;
+
+                    yield return evt;
+                }
+
+                if (yielded < pageSize) yield break;
+
+                position = new(lastRevision + 1);
+            }
+        }
+
+        /// <summary>
         /// Reads a stream from the event store to a collection of <seealso cref="StreamEvent"/>
         /// </summary>
         /// <param name="streamName">Name of the stream to read from</param>
@@ -163,23 +218,10 @@ public static class StoreFunctions {
                 bool               failIfNotFound    = true,
                 CancellationToken  cancellationToken = default
             ) {
-            const int pageSize = 500;
-
             var streamEvents = new List<StreamEvent>();
 
-            var position = start;
-
-            try {
-                while (true) {
-                    var events = await eventReader.ReadEvents(streamName, position, pageSize, failIfNotFound, cancellationToken).NoContext();
-                    streamEvents.AddRange(events);
-
-                    if (events.Length < pageSize) break;
-
-                    position = new(position.Value + events.Length);
-                }
-            } catch (StreamNotFound) when (!failIfNotFound) {
-                return [];
+            await foreach (var evt in eventReader.ReadStreamToEnd(streamName, start, failIfNotFound: failIfNotFound, cancellationToken: cancellationToken).NoContext(cancellationToken)) {
+                streamEvents.Add(evt);
             }
 
             return [.. streamEvents];

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -20,7 +20,10 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
 
         switch (hotEvents.Length) {
             case > 0 when hotEvents[0].Revision > start.Value: {
-                (var events, archiveNotFound) = await LoadStreamEvents(archiveReader, streamName, start, (int)hotEvents[0].Revision, cancellationToken).NoContext();
+                // Fill the gap before the first hot event from the archive, bounded by the requested count
+                var gapCount = (int)Math.Min(count, hotEvents[0].Revision - start.Value);
+
+                (var events, archiveNotFound) = await LoadStreamEvents(archiveReader, streamName, start, gapCount, cancellationToken).NoContext();
                 archivedEvents                = events.Select(x => x with { FromArchive = true });
 
                 break;
@@ -32,7 +35,7 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
                 archivedEvents = []; break;
         }
 
-        var combined = archivedEvents.Concat(hotEvents).Distinct(Comparer);
+        var combined = archivedEvents.Concat(hotEvents).Distinct(Comparer).Take(count);
         var any      = false;
 
         foreach (var evt in combined) {
@@ -53,7 +56,8 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
         var                      archiveNotFound = false;
 
         switch (hotEvents.Length) {
-            case > 0 when hotEvents.Length < count: {
+            // When the hot store read reached revision 0, no events can precede it
+            case > 0 when hotEvents.Length < count && hotEvents[^1].Revision > 0: {
                 // Hot store returned fewer events than requested, fill the gap from archive
                 var lastHotRevision = hotEvents[^1].Revision;
 

--- a/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
+++ b/src/Core/src/Eventuous.Persistence/EventStore/TieredEventReader.cs
@@ -13,14 +13,24 @@ namespace Eventuous;
 /// <param name="archiveReader">Event reader pointing to archive store</param>
 public class TieredEventReader(IEventReader hotReader, IEventReader archiveReader) : IEventReader {
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName streamName, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
-        var hotEvents = await LoadStreamEvents(hotReader, streamName, start, count, cancellationToken).NoContext();
+        var (hotEvents, hotNotFound) = await LoadStreamEvents(hotReader, streamName, start, count, cancellationToken).NoContext();
 
-        var archivedEvents = hotEvents.Length switch {
-            > 0 when hotEvents[0].Revision > start.Value
-                => (await LoadStreamEvents(archiveReader, streamName, start, (int)hotEvents[0].Revision, cancellationToken).NoContext()).Select(x => x with { FromArchive = true }),
-            0 => (await LoadStreamEvents(archiveReader, streamName, start, count, cancellationToken).NoContext()).Select(x => x with { FromArchive = true }),
-            _ => []
-        };
+        IEnumerable<StreamEvent> archivedEvents;
+        var                      archiveNotFound = false;
+
+        switch (hotEvents.Length) {
+            case > 0 when hotEvents[0].Revision > start.Value: {
+                (var events, archiveNotFound) = await LoadStreamEvents(archiveReader, streamName, start, (int)hotEvents[0].Revision, cancellationToken).NoContext();
+                archivedEvents                = events.Select(x => x with { FromArchive = true });
+
+                break;
+            }
+            case 0:
+                (var archived, archiveNotFound) = await LoadStreamEvents(archiveReader, streamName, start, count, cancellationToken).NoContext();
+                archivedEvents                  = archived.Select(x => x with { FromArchive = true }); break;
+            default:
+                archivedEvents = []; break;
+        }
 
         var combined = archivedEvents.Concat(hotEvents).Distinct(Comparer);
         var any      = false;
@@ -31,28 +41,31 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
             yield return evt;
         }
 
-        if (!any) throw new StreamNotFound(streamName);
+        // No events with both tiers reporting a missing stream means the stream doesn't exist;
+        // otherwise an empty result can mean the read window is past the stream end
+        if (!any && hotNotFound && archiveNotFound) throw new StreamNotFound(streamName);
     }
 
     public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName streamName, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
-        var hotEvents = await LoadStreamEvents(hotReader, streamName, start, count, cancellationToken, backwards: true).NoContext();
+        var (hotEvents, hotNotFound) = await LoadStreamEvents(hotReader, streamName, start, count, cancellationToken, backwards: true).NoContext();
 
         IEnumerable<StreamEvent> archivedEvents;
+        var                      archiveNotFound = false;
 
         switch (hotEvents.Length) {
             case > 0 when hotEvents.Length < count: {
                 // Hot store returned fewer events than requested, fill the gap from archive
                 var lastHotRevision = hotEvents[^1].Revision;
 
-                archivedEvents = (await LoadStreamEvents(archiveReader, streamName, new(lastHotRevision - 1), count - hotEvents.Length, cancellationToken, backwards: true).NoContext())
-                    .Select(x => x with { FromArchive = true });
+                (var events, archiveNotFound) = await LoadStreamEvents(archiveReader, streamName, new(lastHotRevision - 1), count - hotEvents.Length, cancellationToken, backwards: true).NoContext();
+                archivedEvents                = events.Select(x => x with { FromArchive = true });
 
                 break;
             }
             case 0:
                 // Hot store has no events, try archive for the full range
-                archivedEvents = (await LoadStreamEvents(archiveReader, streamName, start, count, cancellationToken, backwards: true).NoContext())
-                    .Select(x => x with { FromArchive = true }); break;
+                (var archived, archiveNotFound) = await LoadStreamEvents(archiveReader, streamName, start, count, cancellationToken, backwards: true).NoContext();
+                archivedEvents                  = archived.Select(x => x with { FromArchive = true }); break;
             default:
                 archivedEvents = []; break;
         }
@@ -66,10 +79,12 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
             yield return evt;
         }
 
-        if (!any) throw new StreamNotFound(streamName);
+        // No events with both tiers reporting a missing stream means the stream doesn't exist;
+        // otherwise an empty result can mean the read window is past the stream end
+        if (!any && hotNotFound && archiveNotFound) throw new StreamNotFound(streamName);
     }
 
-    static async Task<StreamEvent[]> LoadStreamEvents(
+    static async Task<(StreamEvent[] Events, bool NotFound)> LoadStreamEvents(
             IEventReader       reader,
             StreamName         streamName,
             StreamReadPosition startPosition,
@@ -78,11 +93,13 @@ public class TieredEventReader(IEventReader hotReader, IEventReader archiveReade
             bool               backwards = false
         ) {
         try {
-            return backwards
+            var events = backwards
                 ? await reader.ReadEventsBackwards(streamName, startPosition, localCount, true, cancellationToken).NoContext()
                 : await reader.ReadEvents(streamName, startPosition, localCount, true, cancellationToken).NoContext();
+
+            return (events, false);
         } catch (StreamNotFound) {
-            return [];
+            return ([], true);
         }
     }
 

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Read.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Read.cs
@@ -148,6 +148,102 @@ public abstract class StoreReadTests<T> where T : StoreFixtureBase {
 
     [Test]
     [Category("Store")]
+    public async Task ShouldThrowWhenReadingMissingStream(CancellationToken cancellationToken) {
+        var streamName = Helpers.GetStreamName();
+
+        await Assert.ThrowsAsync<StreamNotFound>(() => _fixture.EventStore.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldThrowWhenReadingMissingStreamBackwards(CancellationToken cancellationToken) {
+        var streamName = Helpers.GetStreamName();
+
+        await Assert.ThrowsAsync<StreamNotFound>(() => _fixture.EventStore.ReadEventsBackwards(streamName, StreamReadPosition.End, 10, true, cancellationToken));
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReadStreamToEnd(CancellationToken cancellationToken) {
+        object[] events     = [.. _fixture.CreateEvents(25)];
+        var      streamName = Helpers.GetStreamName();
+        await _fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream);
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in _fixture.EventStore.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 10, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        IEnumerable<object> actual = result.Select(x => x.Payload)!;
+        await Assert.That(actual).IsEquivalentTo(events);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReadStreamToEndWithExactPageMultiple(CancellationToken cancellationToken) {
+        object[] events     = [.. _fixture.CreateEvents(20)];
+        var      streamName = Helpers.GetStreamName();
+        await _fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream);
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in _fixture.EventStore.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 10, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        IEnumerable<object> actual = result.Select(x => x.Payload)!;
+        await Assert.That(actual).IsEquivalentTo(events);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReadStreamToEndFromPosition(CancellationToken cancellationToken) {
+        object[] events     = [.. _fixture.CreateEvents(25)];
+        var      streamName = Helpers.GetStreamName();
+        await _fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream);
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in _fixture.EventStore.ReadStreamToEnd(streamName, new(10), pageSize: 10, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        var expected = events.Skip(10);
+        var actual   = result.Select(x => x.Payload!);
+        await Assert.That(actual).IsEquivalentTo(expected);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldThrowWhenReadingMissingStreamToEnd(CancellationToken cancellationToken) {
+        var streamName = Helpers.GetStreamName();
+
+        await Assert.ThrowsAsync<StreamNotFound>(ReadFunc);
+
+        return;
+
+        async Task ReadFunc() {
+            await foreach (var _ in _fixture.EventStore.ReadStreamToEnd(streamName, StreamReadPosition.Start, cancellationToken: cancellationToken)) { }
+        }
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReturnNothingWhenReadingMissingStreamToEnd(CancellationToken cancellationToken) {
+        var streamName = Helpers.GetStreamName();
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in _fixture.EventStore.ReadStreamToEnd(streamName, StreamReadPosition.Start, failIfNotFound: false, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    [Category("Store")]
     public async Task ShouldThrowWhenReadingBackwardsFromNegativePosition(CancellationToken cancellationToken) {
         object[] events     = [.. _fixture.CreateEvents(10)];
         var      streamName = Helpers.GetStreamName();

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Read.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Read.cs
@@ -216,6 +216,21 @@ public abstract class StoreReadTests<T> where T : StoreFixtureBase {
 
     [Test]
     [Category("Store")]
+    public async Task ShouldRejectInvalidPageSizeReadingToEnd(CancellationToken cancellationToken) {
+        var streamName = Helpers.GetStreamName();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Read(0));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Read(-1));
+
+        return;
+
+        async Task Read(int pageSize) {
+            await foreach (var _ in _fixture.EventStore.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: pageSize, cancellationToken: cancellationToken)) { }
+        }
+    }
+
+    [Test]
+    [Category("Store")]
     public async Task ShouldThrowWhenReadingMissingStreamToEnd(CancellationToken cancellationToken) {
         var streamName = Helpers.GetStreamName();
 

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
@@ -28,6 +28,44 @@ public abstract class TieredStoreTestsBase<TContainer> where TContainer : Docker
         await Assert.That(loaded.Skip(50).Select(x => x.FromArchive)).DoesNotContain(true);
     }
 
+    protected async Task Should_return_empty_reading_past_end() {
+        const int count = 10;
+
+        var (tieredReader, stream, _) = await SeedTieredStream(count);
+
+        var loaded = await tieredReader.ReadEvents(stream, new(count), 5, true, CancellationToken.None);
+
+        await Assert.That(loaded).IsEmpty();
+    }
+
+    protected async Task Should_read_stream_to_end_with_exact_page_multiple() {
+        const int count = 100;
+
+        var (tieredReader, stream, testEvents) = await SeedTieredStream(count);
+
+        var loaded = new List<StreamEvent>();
+
+        // 100 events with page size 50 forces a final read past the stream end
+        await foreach (var evt in tieredReader.ReadStreamToEnd(stream, StreamReadPosition.Start, pageSize: 50)) {
+            loaded.Add(evt);
+        }
+
+        var actual = loaded.Select(x => (TestEventForTiers)x.Payload!);
+        await Assert.That(actual).IsEquivalentTo(testEvents);
+    }
+
+    async Task<(TieredEventReader Reader, StreamName Stream, TestEventForTiers[] Events)> SeedTieredStream(int count) {
+        var store      = _storeFixture.EventStore;
+        var archive    = new ArchiveStore(_storeFixture.EventStore);
+        var testEvents = TestEventForTiers.CreateMany(count).ToArray();
+        var stream     = new StreamName($"Test-{Guid.NewGuid():N}");
+
+        await store.Store(stream, ExpectedStreamVersion.NoStream, testEvents);
+        await archive.Store(stream, ExpectedStreamVersion.NoStream, testEvents);
+
+        return (new(store, archive), stream, testEvents);
+    }
+
     readonly StoreFixtureBase<TContainer> _storeFixture;
 
     protected TieredStoreTestsBase(StoreFixtureBase<TContainer> storeFixture) {

--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/TieredStoreTests.cs
@@ -9,23 +9,35 @@ public abstract class TieredStoreTestsBase<TContainer> where TContainer : Docker
     protected async Task Should_load_hot_and_archive() {
         const int count = 100;
 
-        var store      = _storeFixture.EventStore;
-        var archive    = new ArchiveStore(_storeFixture.EventStore);
-        var testEvents = TestEventForTiers.CreateMany(count).ToArray();
-        var stream     = new StreamName($"Test-{Guid.NewGuid():N}");
+        var (combined, stream, testEvents) = await SeedTieredStream(count, truncateHotAt: 50);
 
-        await store.Store(stream, ExpectedStreamVersion.NoStream, testEvents);
-        await archive.Store(stream, ExpectedStreamVersion.NoStream, testEvents);
-
-        await store.TruncateStream(stream, new(50), ExpectedStreamVersion.Any);
-        var combined = new TieredEventReader(store, archive);
-        var loaded   = (await combined.ReadStream(stream, StreamReadPosition.Start)).ToArray();
+        var loaded = (await combined.ReadStream(stream, StreamReadPosition.Start)).ToArray();
 
         var actual = loaded.Select(x => (TestEventForTiers)x.Payload!);
         await Assert.That(actual).IsEquivalentTo(testEvents);
 
         await Assert.That(loaded.Take(50).Select(x => x.FromArchive)).DoesNotContain(false);
         await Assert.That(loaded.Skip(50).Select(x => x.FromArchive)).DoesNotContain(true);
+    }
+
+    protected async Task Should_read_bounded_count_across_tier_boundary() {
+        const int count = 100;
+
+        var (combined, stream, testEvents) = await SeedTieredStream(count, truncateHotAt: 50);
+
+        // The first 50 events only exist in the archive, the hot store starts at revision 50
+        var firstPage = await combined.ReadEvents(stream, StreamReadPosition.Start, 50, true, CancellationToken.None);
+
+        await Assert.That(firstPage.Length).IsEqualTo(50);
+        await Assert.That(firstPage.Select(x => (TestEventForTiers)x.Payload!)).IsEquivalentTo(testEvents.Take(50));
+
+        var loaded = new List<StreamEvent>();
+
+        await foreach (var evt in combined.ReadStreamToEnd(stream, StreamReadPosition.Start, pageSize: 50)) {
+            loaded.Add(evt);
+        }
+
+        await Assert.That(loaded.Select(x => (TestEventForTiers)x.Payload!)).IsEquivalentTo(testEvents);
     }
 
     protected async Task Should_return_empty_reading_past_end() {
@@ -54,7 +66,18 @@ public abstract class TieredStoreTestsBase<TContainer> where TContainer : Docker
         await Assert.That(actual).IsEquivalentTo(testEvents);
     }
 
-    async Task<(TieredEventReader Reader, StreamName Stream, TestEventForTiers[] Events)> SeedTieredStream(int count) {
+    protected async Task Should_read_backwards_more_than_available() {
+        const int count = 10;
+
+        var (combined, stream, testEvents) = await SeedTieredStream(count);
+
+        // Requesting more events than the stream holds reads the hot store down to revision 0
+        var loaded = await combined.ReadEventsBackwards(stream, StreamReadPosition.End, count * 2, true, CancellationToken.None);
+
+        await Assert.That(loaded.Select(x => (TestEventForTiers)x.Payload!).Reverse()).IsEquivalentTo(testEvents);
+    }
+
+    async Task<(TieredEventReader Reader, StreamName Stream, TestEventForTiers[] Events)> SeedTieredStream(int count, long? truncateHotAt = null) {
         var store      = _storeFixture.EventStore;
         var archive    = new ArchiveStore(_storeFixture.EventStore);
         var testEvents = TestEventForTiers.CreateMany(count).ToArray();
@@ -62,6 +85,10 @@ public abstract class TieredStoreTestsBase<TContainer> where TContainer : Docker
 
         await store.Store(stream, ExpectedStreamVersion.NoStream, testEvents);
         await archive.Store(stream, ExpectedStreamVersion.NoStream, testEvents);
+
+        if (truncateHotAt != null) {
+            await store.TruncateStream(stream, new(truncateHotAt.Value), ExpectedStreamVersion.Any);
+        }
 
         return (new(store, archive), stream, testEvents);
     }

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -216,48 +216,63 @@ public partial class KurrentDBEventStore : IEventStore {
     }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        var read = _client.ReadStreamAsync(Direction.Forwards, stream, start.AsStreamPosition(), count, cancellationToken: cancellationToken);
-
-        var events = await TryExecute(
-            async () => {
-                var resolvedEvents = await read.ToArrayAsync(cancellationToken).NoContext();
-
-                return ToStreamEvents(resolvedEvents);
-            },
+    public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken = default)
+        => EnumerateStream(
+            () => _client.ReadStreamAsync(Direction.Forwards, stream, start.AsStreamPosition(), count, cancellationToken: cancellationToken),
             stream,
-            true,
             () => new("Unable to read {Count} starting at {Start} events from {Stream}", count, start, stream),
-            (s, ex) => new ReadFromStreamException(s, ex)
+            cancellationToken
         );
-
-        foreach (var evt in events) yield return evt;
-    }
 
     /// <inheritdoc/>
-    public async IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        var read = _client.ReadStreamAsync(
-            Direction.Backwards,
+    public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken = default)
+        => EnumerateStream(
+            () => _client.ReadStreamAsync(Direction.Backwards, stream, start.AsStreamPosition(), count, resolveLinkTos: true, cancellationToken: cancellationToken),
             stream,
-            start.AsStreamPosition(),
-            count,
-            resolveLinkTos: true,
-            cancellationToken: cancellationToken
-        );
-
-        var events = await TryExecute(
-            async () => {
-                var resolvedEvents = await read.ToArrayAsync(cancellationToken).NoContext();
-
-                return ToStreamEvents(resolvedEvents);
-            },
-            stream,
-            true,
             () => new("Unable to read {Count} events backwards from {Stream}", count, stream),
-            (s, ex) => new ReadFromStreamException(s, ex)
+            cancellationToken
         );
 
-        foreach (var evt in events) yield return evt;
+    // Events are yielded as they arrive from the server, so a read holds at most one
+    // deserialized event at a time, regardless of the requested count.
+    // The exception mapping wraps each advance of the source enumerator instead of the whole
+    // loop because iterators can't yield from inside a try block with a catch clause.
+    async IAsyncEnumerable<StreamEvent> EnumerateStream(
+            Func<IAsyncEnumerable<ResolvedEvent>>      read,
+            string                                     stream,
+            Func<ErrorInfo>                            getError,
+            [EnumeratorCancellation] CancellationToken cancellationToken
+        ) {
+        await using var enumerator = read().GetAsyncEnumerator(cancellationToken);
+
+        while (true) {
+            var          moved       = false;
+            StreamEvent? streamEvent = null;
+
+            try {
+                moved = await enumerator.MoveNextAsync().NoContext();
+
+                if (moved) streamEvent = ToStreamEvent(enumerator.Current);
+            } catch (StreamNotFoundException) {
+                LogStreamStreamNotFound(stream);
+
+                throw new StreamNotFound(stream);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                var (message, args) = getError();
+                // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+#pragma warning disable CA2254
+                _logger.LogWarning(ex, message, args);
+#pragma warning restore CA2254
+
+                throw new ReadFromStreamException(stream, ex);
+            }
+
+            if (!moved) yield break;
+
+            if (streamEvent != null) yield return streamEvent.Value;
+        }
     }
 
     /// <inheritdoc/>
@@ -361,14 +376,6 @@ public partial class KurrentDBEventStore : IEventStore {
                 resolvedEvent.Event.Created
             );
     }
-
-    StreamEvent[] ToStreamEvents(ResolvedEvent[] resolvedEvents)
-        => [
-            .. resolvedEvents
-                .Select(ToStreamEvent)
-                .Where(x => x != null)
-                .Select(x => x!.Value)
-        ];
 
     record ErrorInfo(string Message, params object[] Args);
 

--- a/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
+++ b/src/KurrentDB/src/Eventuous.KurrentDB/KurrentDBEventStore.cs
@@ -218,8 +218,10 @@ public partial class KurrentDBEventStore : IEventStore {
     /// <inheritdoc/>
     public IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken = default)
         => EnumerateStream(
-            () => _client.ReadStreamAsync(Direction.Forwards, stream, start.AsStreamPosition(), count, cancellationToken: cancellationToken),
+            (from, remaining) => _client.ReadStreamAsync(Direction.Forwards, stream, from ?? start.AsStreamPosition(), remaining, cancellationToken: cancellationToken),
+            forwards: true,
             stream,
+            count,
             () => new("Unable to read {Count} starting at {Start} events from {Stream}", count, start, stream),
             cancellationToken
         );
@@ -227,51 +229,86 @@ public partial class KurrentDBEventStore : IEventStore {
     /// <inheritdoc/>
     public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken = default)
         => EnumerateStream(
-            () => _client.ReadStreamAsync(Direction.Backwards, stream, start.AsStreamPosition(), count, resolveLinkTos: true, cancellationToken: cancellationToken),
+            (from, remaining) => _client.ReadStreamAsync(Direction.Backwards, stream, from ?? start.AsStreamPosition(), remaining, resolveLinkTos: true, cancellationToken: cancellationToken),
+            forwards: false,
             stream,
+            count,
             () => new("Unable to read {Count} events backwards from {Stream}", count, stream),
             cancellationToken
         );
 
     // Events are yielded as they arrive from the server, so a read holds at most one
     // deserialized event at a time, regardless of the requested count.
+    // Non-deserializable system events are skipped and compensated for with follow-up
+    // reads, so the enumeration delivers `count` events unless the stream end is reached —
+    // paged readers rely on a short read meaning the end of the stream.
     // The exception mapping wraps each advance of the source enumerator instead of the whole
     // loop because iterators can't yield from inside a try block with a catch clause.
     async IAsyncEnumerable<StreamEvent> EnumerateStream(
-            Func<IAsyncEnumerable<ResolvedEvent>>      read,
-            string                                     stream,
-            Func<ErrorInfo>                            getError,
-            [EnumeratorCancellation] CancellationToken cancellationToken
+            Func<StreamPosition?, int, IAsyncEnumerable<ResolvedEvent>> read,
+            bool                                                        forwards,
+            string                                                      stream,
+            int                                                         count,
+            Func<ErrorInfo>                                             getError,
+            [EnumeratorCancellation] CancellationToken                  cancellationToken
         ) {
-        await using var enumerator = read().GetAsyncEnumerator(cancellationToken);
+        var             remaining = count;
+        StreamPosition? from      = null;
 
-        while (true) {
-            var          moved       = false;
-            StreamEvent? streamEvent = null;
+        while (remaining > 0) {
+            var  requested = remaining;
+            var  received  = 0;
+            long lastRaw   = 0;
 
-            try {
-                moved = await enumerator.MoveNextAsync().NoContext();
+            await using var enumerator = read(from, requested).GetAsyncEnumerator(cancellationToken);
 
-                if (moved) streamEvent = ToStreamEvent(enumerator.Current);
-            } catch (StreamNotFoundException) {
-                LogStreamStreamNotFound(stream);
+            while (true) {
+                var          moved       = false;
+                StreamEvent? streamEvent = null;
 
-                throw new StreamNotFound(stream);
-            } catch (OperationCanceledException) {
-                throw;
-            } catch (Exception ex) {
-                var (message, args) = getError();
-                // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+                try {
+                    moved = await enumerator.MoveNextAsync().NoContext();
+
+                    if (moved) {
+                        received++;
+                        lastRaw     = enumerator.Current.OriginalEventNumber.ToInt64();
+                        streamEvent = ToStreamEvent(enumerator.Current);
+                    }
+                } catch (StreamNotFoundException) {
+                    LogStreamStreamNotFound(stream);
+
+                    throw new StreamNotFound(stream);
+                } catch (OperationCanceledException) {
+                    throw;
+                } catch (Exception ex) {
+                    var (message, args) = getError();
+                    // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
 #pragma warning disable CA2254
-                _logger.LogWarning(ex, message, args);
+                    _logger.LogWarning(ex, message, args);
 #pragma warning restore CA2254
 
-                throw new ReadFromStreamException(stream, ex);
+                    throw new ReadFromStreamException(stream, ex);
+                }
+
+                if (!moved) break;
+
+                if (streamEvent != null) {
+                    remaining--;
+
+                    yield return streamEvent.Value;
+                }
             }
 
-            if (!moved) yield break;
+            // Fewer events received than requested means the stream end was reached
+            if (received < requested) yield break;
 
-            if (streamEvent != null) yield return streamEvent.Value;
+            // Nothing was skipped and the requested count is delivered
+            if (remaining == 0) yield break;
+
+            // Reading backwards can't continue past the first stream event
+            if (!forwards && lastRaw == 0) yield break;
+
+            from = StreamPosition.FromInt64(forwards ? lastRaw + 1 : lastRaw - 1);
         }
     }
 

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/StreamingReadTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/StreamingReadTests.cs
@@ -1,6 +1,7 @@
 using Eventuous.KurrentDB;
 using Eventuous.Sut.Domain;
 using Eventuous.Tests.Persistence.Base.Fixtures;
+using KurrentDB.Client;
 
 namespace Eventuous.Tests.KurrentDB.Store;
 
@@ -53,6 +54,73 @@ public class StreamingReadTests {
 
         await Assert.That(deserializedAtFirstYield).IsEqualTo(1);
         await Assert.That(serializer.DeserializedCount).IsEqualTo(EventCount);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReadRequestedCountWhenSystemEventsAreSkipped(CancellationToken cancellationToken) {
+        var (streamName, events) = await SeedStreamWithSystemEvent(cancellationToken);
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in _fixture.EventStore.ReadEvents(streamName, StreamReadPosition.Start, events.Length, cancellationToken)) {
+            result.Add(evt);
+        }
+
+        IEnumerable<object> actual = result.Select(x => x.Payload)!;
+        await Assert.That(actual).IsEquivalentTo(events);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReadRequestedCountBackwardsWhenSystemEventsAreSkipped(CancellationToken cancellationToken) {
+        var (streamName, events) = await SeedStreamWithSystemEvent(cancellationToken);
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in _fixture.EventStore.ReadEventsBackwards(streamName, StreamReadPosition.End, events.Length, cancellationToken)) {
+            result.Add(evt);
+        }
+
+        IEnumerable<object> actual = result.Select(x => x.Payload).Reverse()!;
+        await Assert.That(actual).IsEquivalentTo(events);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldReadStreamToEndWhenSystemEventsAreSkipped(CancellationToken cancellationToken) {
+        var (streamName, events) = await SeedStreamWithSystemEvent(cancellationToken);
+
+        var result = new List<StreamEvent>();
+
+        // The system event lands inside the first page, which then yields fewer events than the page size
+        await foreach (var evt in _fixture.EventStore.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 6, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        IEnumerable<object> actual = result.Select(x => x.Payload)!;
+        await Assert.That(actual).IsEquivalentTo(events);
+    }
+
+    // Seeds a stream of 12 events where revision 5 is a non-deserializable $-typed event,
+    // which the store skips when reading. Returns the 11 deserializable events.
+    async Task<(StreamName Stream, object[] Events)> SeedStreamWithSystemEvent(CancellationToken cancellationToken) {
+        var      streamName = Helpers.GetStreamName();
+        object[] first      = [.. _fixture.CreateEvents(5)];
+        object[] rest       = [.. _fixture.CreateEvents(6)];
+
+        await _fixture.AppendEvents(streamName, first, ExpectedStreamVersion.NoStream);
+
+        await _fixture.Client.AppendToStreamAsync(
+            streamName.ToString(),
+            StreamState.Any,
+            [new EventData(Uuid.NewUuid(), "$test-skipped", "{}"u8.ToArray())],
+            cancellationToken: cancellationToken
+        );
+
+        await _fixture.AppendEvents(streamName, rest, ExpectedStreamVersion.Any);
+
+        return (streamName, [.. first, .. rest]);
     }
 
     class CountingSerializer(IEventSerializer inner) : IEventSerializer {

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/StreamingReadTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/StreamingReadTests.cs
@@ -1,0 +1,71 @@
+using Eventuous.KurrentDB;
+using Eventuous.Sut.Domain;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+
+namespace Eventuous.Tests.KurrentDB.Store;
+
+[ClassDataSource<StoreFixture>]
+public class StreamingReadTests {
+    readonly StoreFixture _fixture;
+
+    public StreamingReadTests(StoreFixture fixture) {
+        fixture.TypeMapper.RegisterKnownEventTypes(typeof(BookingEvents.BookingImported).Assembly);
+        _fixture = fixture;
+    }
+
+    const int EventCount = 100;
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldStreamEventsForwardsWithoutBufferingWholeRead(CancellationToken cancellationToken) {
+        var serializer = new CountingSerializer(_fixture.Serializer);
+        var store      = new KurrentDBEventStore(_fixture.Client, serializer);
+
+        object[] events     = [.. _fixture.CreateEvents(EventCount)];
+        var      streamName = Helpers.GetStreamName();
+        await _fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream);
+
+        var deserializedAtFirstYield = 0;
+
+        await foreach (var _ in store.ReadEvents(streamName, StreamReadPosition.Start, EventCount, cancellationToken)) {
+            if (deserializedAtFirstYield == 0) deserializedAtFirstYield = serializer.DeserializedCount;
+        }
+
+        await Assert.That(deserializedAtFirstYield).IsEqualTo(1);
+        await Assert.That(serializer.DeserializedCount).IsEqualTo(EventCount);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldStreamEventsBackwardsWithoutBufferingWholeRead(CancellationToken cancellationToken) {
+        var serializer = new CountingSerializer(_fixture.Serializer);
+        var store      = new KurrentDBEventStore(_fixture.Client, serializer);
+
+        object[] events     = [.. _fixture.CreateEvents(EventCount)];
+        var      streamName = Helpers.GetStreamName();
+        await _fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream);
+
+        var deserializedAtFirstYield = 0;
+
+        await foreach (var _ in store.ReadEventsBackwards(streamName, new(EventCount - 1), EventCount, cancellationToken)) {
+            if (deserializedAtFirstYield == 0) deserializedAtFirstYield = serializer.DeserializedCount;
+        }
+
+        await Assert.That(deserializedAtFirstYield).IsEqualTo(1);
+        await Assert.That(serializer.DeserializedCount).IsEqualTo(EventCount);
+    }
+
+    class CountingSerializer(IEventSerializer inner) : IEventSerializer {
+        int _deserializedCount;
+
+        public int DeserializedCount => _deserializedCount;
+
+        public DeserializationResult DeserializeEvent(ReadOnlySpan<byte> data, string eventType, string contentType) {
+            Interlocked.Increment(ref _deserializedCount);
+
+            return inner.DeserializeEvent(data, eventType, contentType);
+        }
+
+        public SerializationResult SerializeEvent(object evt) => inner.SerializeEvent(evt);
+    }
+}

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/TieredStoreTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/TieredStoreTests.cs
@@ -9,4 +9,14 @@ public class TieredStoreTests(StoreFixture storeFixture) : TieredStoreTestsBase<
     public async Task Esdb_should_load_hot_and_archive() {
         await Should_load_hot_and_archive();
     }
+
+    [Test]
+    public async Task Esdb_should_return_empty_reading_past_end() {
+        await Should_return_empty_reading_past_end();
+    }
+
+    [Test]
+    public async Task Esdb_should_read_stream_to_end_with_exact_page_multiple() {
+        await Should_read_stream_to_end_with_exact_page_multiple();
+    }
 }

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/TieredStoreTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Store/TieredStoreTests.cs
@@ -19,4 +19,14 @@ public class TieredStoreTests(StoreFixture storeFixture) : TieredStoreTestsBase<
     public async Task Esdb_should_read_stream_to_end_with_exact_page_multiple() {
         await Should_read_stream_to_end_with_exact_page_multiple();
     }
+
+    [Test]
+    public async Task Esdb_should_read_bounded_count_across_tier_boundary() {
+        await Should_read_bounded_count_across_tier_boundary();
+    }
+
+    [Test]
+    public async Task Esdb_should_read_backwards_more_than_available() {
+        await Should_read_backwards_more_than_available();
+    }
 }

--- a/src/Postgres/src/Eventuous.Postgresql/PostgresStore.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/PostgresStore.cs
@@ -56,7 +56,8 @@ public class PostgresStore : SqlEventStoreBase<NpgsqlConnection, NpgsqlTransacti
     protected override DbCommand GetReadBackwardsCommand(NpgsqlConnection connection, StreamName stream, StreamReadPosition start, int count)
         => connection.GetCommand(Schema.ReadStreamBackwards)
             .Add("_stream_name", NpgsqlDbType.Varchar, stream.ToString())
-            .Add("_from_position", NpgsqlDbType.Integer, start.Value)
+            // Stream positions are 32-bit, so StreamReadPosition.End gets clamped, and the function trims it to the stream head
+            .Add("_from_position", NpgsqlDbType.Integer, (int)Math.Min(start.Value, int.MaxValue))
             .Add("_count", NpgsqlDbType.Integer, count);
 
     protected override bool IsStreamNotFound(Exception exception)

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -36,30 +36,31 @@ public class RedisStore : IEventReader, IEventWriter {
 
     const string ContentType = "application/json";
 
+    /// <summary>
+    /// Reads events from a stream. Positions are inclusive of the start position.
+    /// Streams containing entries written by pre-0.16 versions with auto-generated IDs whose
+    /// sequence number exceeds 9 are not readable from a non-zero position: positions for such
+    /// entries don't round-trip through the position encoding, so resumed reads are rejected with
+    /// <see cref="NotSupportedException"/> instead of risking silently skipped events. Read such
+    /// streams from the start, which fails loudly on the first unrepresentable entry, and migrate them.
+    /// </summary>
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
         StreamEvent[] events;
 
         try {
-            // Entries written by older versions with auto-generated IDs can sort below the decoded
-            // start position while falling inside the requested range: position m*10+s decodes to
-            // ID m-s, but a legacy entry (m-1)-(s+10) encodes to the same position or higher.
-            // Fail loudly when such entries exist instead of silently skipping them.
-            // This check is complete for every position this store version can produce: revisions
-            // are only emitted for entries with sequence numbers 0-9, so the ID gap between a
-            // revision and the next position is exactly the range probed here, and older entries
-            // are materialized (and rejected) by the pages that precede the position. Positions
-            // minted by pre-fix versions from unrepresentable entries are inherently ambiguous —
-            // the encoding maps e.g. both legacy 12345-20 and valid 12347-0 to 123470 — and can't
-            // be detected without breaking reads of valid data; reading such streams from the
-            // start rejects the first unrepresentable entry.
+            // A resumed position is only unambiguous when every entry ID in the stream round-trips
+            // through the position encoding (sequence numbers 0-9). Entries the encoding can't
+            // represent can hide below the decoded start position while falling inside the
+            // requested range, so reads from a non-zero position are conservatively rejected for
+            // streams holding any such entry. The verdict is computed server-side and cached;
+            // entries written by the current store version always carry sequence 0.
             if (start.Value >= 10) {
-                var previousMs = start.Value / 10 - 1;
-                var hidden     = await _getDatabase().StreamRangeAsync(stream.ToString(), $"{previousMs}-{start.Value % 10 + 10}", $"{previousMs}", count: 1).NoContext();
+                var unclean = (string?)await _getDatabase().ExecuteAsync("FCALL", "check_stream_clean", 1, stream.ToString()).NoContext();
 
-                if (hidden is { Length: > 0 }) {
+                if (!string.IsNullOrEmpty(unclean)) {
                     throw new NotSupportedException(
-                        $"Redis stream entry ID {hidden[0].Id} can't be reached from position {start.Value}: the position encoding only supports ID sequence numbers 0-9. " +
-                        "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store."
+                        $"Stream {stream} can't be read from position {start.Value}: it contains entry ID {unclean}, which the position encoding can't represent (only ID sequence numbers 0-9 are supported). " +
+                        "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store. Read the stream from the start and migrate it."
                     );
                 }
             }

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -44,6 +44,14 @@ public class RedisStore : IEventReader, IEventWriter {
             // start position while falling inside the requested range: position m*10+s decodes to
             // ID m-s, but a legacy entry (m-1)-(s+10) encodes to the same position or higher.
             // Fail loudly when such entries exist instead of silently skipping them.
+            // This check is complete for every position this store version can produce: revisions
+            // are only emitted for entries with sequence numbers 0-9, so the ID gap between a
+            // revision and the next position is exactly the range probed here, and older entries
+            // are materialized (and rejected) by the pages that precede the position. Positions
+            // minted by pre-fix versions from unrepresentable entries are inherently ambiguous —
+            // the encoding maps e.g. both legacy 12345-20 and valid 12347-0 to 123470 — and can't
+            // be detected without breaking reads of valid data; reading such streams from the
+            // start rejects the first unrepresentable entry.
             if (start.Value >= 10) {
                 var previousMs = start.Value / 10 - 1;
                 var hidden     = await _getDatabase().StreamRangeAsync(stream.ToString(), $"{previousMs}-{start.Value % 10 + 10}", $"{previousMs}", count: 1).NoContext();

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -43,10 +43,15 @@ public class RedisStore : IEventReader, IEventWriter {
             var result = await _getDatabase().StreamReadAsync(stream.ToString(), start.Value.ToRedisValue(), count).NoContext();
 
             if (result == null! || result.Length == 0) {
-                throw new StreamNotFound(stream);
-            }
+                // An empty result can also mean the read window is past the stream end
+                if (!await _getDatabase().KeyExistsAsync(stream.ToString()).NoContext()) {
+                    throw new StreamNotFound(stream);
+                }
 
-            events = [.. result.Select(x => ToStreamEvent(x, _serializer, _metaSerializer))];
+                events = [];
+            } else {
+                events = [.. result.Select(x => ToStreamEvent(x, _serializer, _metaSerializer))];
+            }
         } catch (InvalidOperationException e) when (e.Message.Contains("Reading is not allowed after reader was completed") ||
                                                     cancellationToken.IsCancellationRequested) {
             throw new OperationCanceledException("Redis read operation terminated", e, cancellationToken);

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -46,32 +47,25 @@ public class RedisStore : IEventReader, IEventWriter {
     /// </summary>
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
         StreamEvent[] events;
+        var           database = _getDatabase();
 
         try {
             // A resumed position is only unambiguous when every entry ID in the stream round-trips
             // through the position encoding (sequence numbers 0-9). Entries the encoding can't
             // represent can hide below the decoded start position while falling inside the
             // requested range, so reads from a non-zero position are conservatively rejected for
-            // streams holding any such entry. The verdict is computed server-side and cached;
-            // entries written by the current store version always carry sequence 0.
+            // streams holding any such entry.
             if (start.Value >= 10) {
-                var unclean = (string?)await _getDatabase().ExecuteAsync("FCALL", "check_stream_clean", 1, stream.ToString()).NoContext();
-
-                if (!string.IsNullOrEmpty(unclean)) {
-                    throw new NotSupportedException(
-                        $"Stream {stream} can't be read from position {start.Value}: it contains entry ID {unclean}, which the position encoding can't represent (only ID sequence numbers 0-9 are supported). " +
-                        "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store. Read the stream from the start and migrate it."
-                    );
-                }
+                await EnsureStreamPositionsRoundTrip(database, stream, cancellationToken).NoContext();
             }
 
             // Range read is inclusive of the start position, matching the IEventReader contract
             // and the paged read extensions, which advance pages from the last revision + 1
-            var result = await _getDatabase().StreamRangeAsync(stream.ToString(), start.Value.ToRedisValue(), count: count).NoContext();
+            var result = await database.StreamRangeAsync(stream.ToString(), start.Value.ToRedisValue(), count: count).NoContext();
 
             if (result == null! || result.Length == 0) {
                 // An empty result can also mean the read window is past the stream end
-                if (!await _getDatabase().KeyExistsAsync(stream.ToString()).NoContext()) {
+                if (!await database.KeyExistsAsync(stream.ToString()).NoContext()) {
                     throw new StreamNotFound(stream);
                 }
 
@@ -89,6 +83,65 @@ public class RedisStore : IEventReader, IEventWriter {
 
     public IAsyncEnumerable<StreamEvent> ReadEventsBackwards(StreamName stream, StreamReadPosition start, int count, CancellationToken cancellationToken)
         => throw new NotImplementedException();
+
+    const int ValidationPageSize = 1000;
+
+    readonly ConcurrentDictionary<string, (RedisValue First, RedisValue Last)> _validatedStreams = new();
+
+    // Validates that every entry ID in the stream round-trips through the position encoding.
+    // The verdict is cached per stream, anchored on the first entry ID: Redis only accepts
+    // appends with increasing entry IDs, so a validated range can't gain new entries, and a
+    // changed first entry means the stream was recreated. Only entries appended after the last
+    // validated one are scanned on subsequent reads, one bounded page at a time.
+    async ValueTask EnsureStreamPositionsRoundTrip(IDatabase database, string stream, CancellationToken cancellationToken) {
+        var head = await database.StreamRangeAsync(stream, "-", "+", count: 1).NoContext();
+
+        // A missing stream holds nothing to validate, and no verdict is recorded for the name
+        if (head.Length == 0) return;
+
+        var first = head[0].Id;
+
+        RedisValue from;
+        RedisValue last;
+
+        if (_validatedStreams.TryGetValue(stream, out var validated) && validated.First == first) {
+            from = $"({validated.Last}";
+            last = validated.Last;
+        } else {
+            from = "-";
+            last = first;
+        }
+
+        while (true) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var batch = await database.StreamRangeAsync(stream, from, "+", count: ValidationPageSize).NoContext();
+
+            if (batch.Length == 0) break;
+
+            foreach (var entry in batch) {
+                if (EntrySequence(entry.Id) > 9) {
+                    throw new NotSupportedException(
+                        $"Stream {stream} can't be read from a non-zero position: it contains entry ID {entry.Id}, which the position encoding can't represent (only ID sequence numbers 0-9 are supported). " +
+                        "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store. Read the stream from the start and migrate it."
+                    );
+                }
+            }
+
+            last = batch[^1].Id;
+            from = $"({last}";
+
+            if (batch.Length < ValidationPageSize) break;
+        }
+
+        _validatedStreams[stream] = (first, last);
+    }
+
+    static long EntrySequence(RedisValue id) {
+        var value = Ensure.NotNull<string>(id);
+
+        return long.Parse(value.AsSpan(value.IndexOf('-') + 1));
+    }
 
     public async Task<AppendEventsResult> AppendEvents(
             StreamName                          stream,

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -40,6 +40,22 @@ public class RedisStore : IEventReader, IEventWriter {
         StreamEvent[] events;
 
         try {
+            // Entries written by older versions with auto-generated IDs can sort below the decoded
+            // start position while falling inside the requested range: position m*10+s decodes to
+            // ID m-s, but a legacy entry (m-1)-(s+10) encodes to the same position or higher.
+            // Fail loudly when such entries exist instead of silently skipping them.
+            if (start.Value >= 10) {
+                var previousMs = start.Value / 10 - 1;
+                var hidden     = await _getDatabase().StreamRangeAsync(stream.ToString(), $"{previousMs}-{start.Value % 10 + 10}", $"{previousMs}", count: 1).NoContext();
+
+                if (hidden is { Length: > 0 }) {
+                    throw new NotSupportedException(
+                        $"Redis stream entry ID {hidden[0].Id} can't be reached from position {start.Value}: the position encoding only supports ID sequence numbers 0-9. " +
+                        "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store."
+                    );
+                }
+            }
+
             // Range read is inclusive of the start position, matching the IEventReader contract
             // and the paged read extensions, which advance pages from the last revision + 1
             var result = await _getDatabase().StreamRangeAsync(stream.ToString(), start.Value.ToRedisValue(), count: count).NoContext();

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -46,6 +46,10 @@ public class RedisStore : IEventReader, IEventWriter {
     /// To support that rejection, every read from a non-zero position validates the stream prefix
     /// below the position in bounded batches, so resumed reads cost extra roundtrips proportional
     /// to the prefix length.
+    /// Pre-0.16 writers must be quiesced before resumed reads are used: an old writer racing the
+    /// gap between validation and the data read can append an unrepresentable entry below the
+    /// requested position, which that read won't see. Such a stream is rejected by the next
+    /// resumed read, but the racing read itself can't detect it.
     /// </summary>
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
         StreamEvent[] events;
@@ -96,6 +100,9 @@ public class RedisStore : IEventReader, IEventWriter {
     // materializes them, and converting an unrepresentable ID to a revision fails loudly.
     // A key replaced concurrently with an in-flight read can still change underneath the scan,
     // which no non-atomic paged read can detect; that also holds for the data reads themselves.
+    // Likewise, a pre-fix writer appending an unrepresentable entry between this scan and the
+    // data read escapes the racing read (the next resumed read rejects the stream) — old writers
+    // must be quiesced before resumed reads are used, as documented on ReadEvents.
     async ValueTask EnsureStreamPositionsRoundTrip(IDatabase database, string stream, StreamReadPosition start, CancellationToken cancellationToken) {
         RedisValue from = "-";
         var        end  = $"({start.Value.ToRedisValue()}";
@@ -122,10 +129,11 @@ public class RedisStore : IEventReader, IEventWriter {
         }
     }
 
-    static long EntrySequence(RedisValue id) {
+    // Redis stream ID sequence components are unsigned 64-bit values
+    static ulong EntrySequence(RedisValue id) {
         var value = Ensure.NotNull<string>(id);
 
-        return long.Parse(value.AsSpan(value.IndexOf('-') + 1));
+        return ulong.Parse(value.AsSpan(value.IndexOf('-') + 1));
     }
 
     public async Task<AppendEventsResult> AppendEvents(

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -46,10 +46,13 @@ public class RedisStore : IEventReader, IEventWriter {
     /// To support that rejection, every read from a non-zero position validates the stream prefix
     /// below the position in bounded batches, so resumed reads cost extra roundtrips proportional
     /// to the prefix length.
-    /// Pre-0.16 writers must be quiesced before resumed reads are used: an old writer racing the
+    /// Resumed reads require exclusive write ownership of the stream by this store version: any
+    /// writer that doesn't use its explicit entry ID scheme — a pre-0.16 store version, or any
+    /// external XADD with auto-generated IDs — must be quiesced first. Such a writer racing the
     /// gap between validation and the data read can append an unrepresentable entry below the
-    /// requested position, which that read won't see. Such a stream is rejected by the next
-    /// resumed read, but the racing read itself can't detect it.
+    /// requested position, which that read won't see. The stream is rejected by the next resumed
+    /// read, but the racing read itself can't detect it. Concurrent writers going through this
+    /// store version are safe.
     /// </summary>
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
         StreamEvent[] events;
@@ -100,9 +103,10 @@ public class RedisStore : IEventReader, IEventWriter {
     // materializes them, and converting an unrepresentable ID to a revision fails loudly.
     // A key replaced concurrently with an in-flight read can still change underneath the scan,
     // which no non-atomic paged read can detect; that also holds for the data reads themselves.
-    // Likewise, a pre-fix writer appending an unrepresentable entry between this scan and the
-    // data read escapes the racing read (the next resumed read rejects the stream) — old writers
-    // must be quiesced before resumed reads are used, as documented on ReadEvents.
+    // Likewise, a writer not using the explicit entry ID scheme (a pre-fix store version or any
+    // external XADD with auto-generated IDs) appending an unrepresentable entry between this scan
+    // and the data read escapes the racing read (the next resumed read rejects the stream) — such
+    // writers must be quiesced before resumed reads are used, as documented on ReadEvents.
     async ValueTask EnsureStreamPositionsRoundTrip(IDatabase database, string stream, StreamReadPosition start, CancellationToken cancellationToken) {
         RedisValue from = "-";
         var        end  = $"({start.Value.ToRedisValue()}";

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
-using System.Collections.Concurrent;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -44,6 +43,9 @@ public class RedisStore : IEventReader, IEventWriter {
     /// entries don't round-trip through the position encoding, so resumed reads are rejected with
     /// <see cref="NotSupportedException"/> instead of risking silently skipped events. Read such
     /// streams from the start, which fails loudly on the first unrepresentable entry, and migrate them.
+    /// To support that rejection, every read from a non-zero position validates the stream prefix
+    /// below the position in bounded batches, so resumed reads cost extra roundtrips proportional
+    /// to the prefix length.
     /// </summary>
     public async IAsyncEnumerable<StreamEvent> ReadEvents(StreamName stream, StreamReadPosition start, int count, [EnumeratorCancellation] CancellationToken cancellationToken) {
         StreamEvent[] events;
@@ -56,7 +58,7 @@ public class RedisStore : IEventReader, IEventWriter {
             // requested range, so reads from a non-zero position are conservatively rejected for
             // streams holding any such entry.
             if (start.Value >= 10) {
-                await EnsureStreamPositionsRoundTrip(database, stream, cancellationToken).NoContext();
+                await EnsureStreamPositionsRoundTrip(database, stream, start, cancellationToken).NoContext();
             }
 
             // Range read is inclusive of the start position, matching the IEventReader contract
@@ -86,36 +88,22 @@ public class RedisStore : IEventReader, IEventWriter {
 
     const int ValidationPageSize = 1000;
 
-    readonly ConcurrentDictionary<string, (RedisValue First, RedisValue Last)> _validatedStreams = new();
-
-    // Validates that every entry ID in the stream round-trips through the position encoding.
-    // The verdict is cached per stream, anchored on the first entry ID: Redis only accepts
-    // appends with increasing entry IDs, so a validated range can't gain new entries, and a
-    // changed first entry means the stream was recreated. Only entries appended after the last
-    // validated one are scanned on subsequent reads, one bounded page at a time.
-    async ValueTask EnsureStreamPositionsRoundTrip(IDatabase database, string stream, CancellationToken cancellationToken) {
-        var head = await database.StreamRangeAsync(stream, "-", "+", count: 1).NoContext();
-
-        // A missing stream holds nothing to validate, and no verdict is recorded for the name
-        if (head.Length == 0) return;
-
-        var first = head[0].Id;
-
-        RedisValue from;
-        RedisValue last;
-
-        if (_validatedStreams.TryGetValue(stream, out var validated) && validated.First == first) {
-            from = $"({validated.Last}";
-            last = validated.Last;
-        } else {
-            from = "-";
-            last = first;
-        }
+    // Validates that every entry ID below the decoded start position round-trips through the
+    // position encoding, scanning the current stream contents in bounded pages on every call.
+    // No verdict is cached: Redis has no immutable per-key generation identity, so a cached
+    // verdict can go stale when a key is deleted, recreated, or restored under the same name.
+    // Entries at or above the decoded position don't need validation here — the read
+    // materializes them, and converting an unrepresentable ID to a revision fails loudly.
+    // A key replaced concurrently with an in-flight read can still change underneath the scan,
+    // which no non-atomic paged read can detect; that also holds for the data reads themselves.
+    async ValueTask EnsureStreamPositionsRoundTrip(IDatabase database, string stream, StreamReadPosition start, CancellationToken cancellationToken) {
+        RedisValue from = "-";
+        var        end  = $"({start.Value.ToRedisValue()}";
 
         while (true) {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var batch = await database.StreamRangeAsync(stream, from, "+", count: ValidationPageSize).NoContext();
+            var batch = await database.StreamRangeAsync(stream, from, end, count: ValidationPageSize).NoContext();
 
             if (batch.Length == 0) break;
 
@@ -128,13 +116,10 @@ public class RedisStore : IEventReader, IEventWriter {
                 }
             }
 
-            last = batch[^1].Id;
-            from = $"({last}";
-
             if (batch.Length < ValidationPageSize) break;
-        }
 
-        _validatedStreams[stream] = (first, last);
+            from = $"({batch[^1].Id}";
+        }
     }
 
     static long EntrySequence(RedisValue id) {

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -139,6 +139,6 @@ public class RedisStore : IEventReader, IEventWriter {
         };
 
         StreamEvent AsStreamEvent(object payload)
-            => new(Guid.Parse(evt[MessageId].ToString()), payload, meta ?? new Metadata(), ContentType, evt.Id.ToLong(), DateTime.Parse(evt[Created]!, CultureInfo.InvariantCulture));
+            => new(Guid.Parse(evt[MessageId].ToString()), payload, meta ?? new Metadata(), ContentType, evt.Id.ToRevision(), DateTime.Parse(evt[Created]!, CultureInfo.InvariantCulture));
     }
 }

--- a/src/Redis/src/Eventuous.Redis/RedisStore.cs
+++ b/src/Redis/src/Eventuous.Redis/RedisStore.cs
@@ -40,7 +40,9 @@ public class RedisStore : IEventReader, IEventWriter {
         StreamEvent[] events;
 
         try {
-            var result = await _getDatabase().StreamReadAsync(stream.ToString(), start.Value.ToRedisValue(), count).NoContext();
+            // Range read is inclusive of the start position, matching the IEventReader contract
+            // and the paged read extensions, which advance pages from the last revision + 1
+            var result = await _getDatabase().StreamRangeAsync(stream.ToString(), start.Value.ToRedisValue(), count: count).NoContext();
 
             if (result == null! || result.Length == 0) {
                 // An empty result can also mean the read window is past the stream end

--- a/src/Redis/src/Eventuous.Redis/Scripts/AppendEvents.lua
+++ b/src/Redis/src/Eventuous.Redis/Scripts/AppendEvents.lua
@@ -12,6 +12,34 @@ local function last_id_ms(key)
   return tonumber(string.sub(id, 1, string.find(id, '-', 1, true) - 1))
 end
 
+-- Returns the ID of the first entry whose sequence number can't be represented by the
+-- client-side position encoding (sequence > 9), or an empty string when the stream is clean.
+-- A clean verdict is cached: entries written by append_events always carry sequence 0, so a
+-- stream verified clean stays clean.
+local function check_stream_clean(keys, args)
+  local key = keys[1]
+  if redis.call('HGET', '_clean_streams', key) == '1' then
+    return ''
+  end
+  local cursor = '-'
+  while true do
+    local entries = redis.call('XRANGE', key, cursor, '+', 'COUNT', 1000)
+    if #entries == 0 then
+      break
+    end
+    for i=1,#entries do
+      local id = entries[i][1]
+      local seq = tonumber(string.sub(id, string.find(id, '-', 1, true) + 1))
+      if seq > 9 then
+        return id
+      end
+    end
+    cursor = '(' .. entries[#entries][1]
+  end
+  redis.call('HSET', '_clean_streams', key, '1')
+  return ''
+end
+
 local function append_events(keys, args)
   local stream_name = keys[1]
   local expected_version = tonumber(keys[2])
@@ -68,3 +96,4 @@ local function append_events(keys, args)
 end
  
 redis.register_function('append_events', append_events)
+redis.register_function('check_stream_clean', check_stream_clean)

--- a/src/Redis/src/Eventuous.Redis/Scripts/AppendEvents.lua
+++ b/src/Redis/src/Eventuous.Redis/Scripts/AppendEvents.lua
@@ -12,34 +12,6 @@ local function last_id_ms(key)
   return tonumber(string.sub(id, 1, string.find(id, '-', 1, true) - 1))
 end
 
--- Returns the ID of the first entry whose sequence number can't be represented by the
--- client-side position encoding (sequence > 9), or an empty string when the stream is clean.
--- A clean verdict is cached: entries written by append_events always carry sequence 0, so a
--- stream verified clean stays clean.
-local function check_stream_clean(keys, args)
-  local key = keys[1]
-  if redis.call('HGET', '_clean_streams', key) == '1' then
-    return ''
-  end
-  local cursor = '-'
-  while true do
-    local entries = redis.call('XRANGE', key, cursor, '+', 'COUNT', 1000)
-    if #entries == 0 then
-      break
-    end
-    for i=1,#entries do
-      local id = entries[i][1]
-      local seq = tonumber(string.sub(id, string.find(id, '-', 1, true) + 1))
-      if seq > 9 then
-        return id
-      end
-    end
-    cursor = '(' .. entries[#entries][1]
-  end
-  redis.call('HSET', '_clean_streams', key, '1')
-  return ''
-end
-
 local function append_events(keys, args)
   local stream_name = keys[1]
   local expected_version = tonumber(keys[2])
@@ -96,4 +68,3 @@ local function append_events(keys, args)
 end
  
 redis.register_function('append_events', append_events)
-redis.register_function('check_stream_clean', check_stream_clean)

--- a/src/Redis/src/Eventuous.Redis/Scripts/AppendEvents.lua
+++ b/src/Redis/src/Eventuous.Redis/Scripts/AppendEvents.lua
@@ -1,5 +1,17 @@
 #!lua name=append_events
 
+-- Entry IDs are assigned explicitly as '<milliseconds>-0' with the millisecond part bumped past
+-- the last entry when needed. Auto-generated IDs ('*') bump the sequence part instead, and the
+-- client-side position encoding can only represent sequence numbers 0-9.
+local function last_id_ms(key)
+  local entries = redis.call('XREVRANGE', key, '+', '-', 'COUNT', 1)
+  if #entries == 0 then
+    return 0
+  end
+  local id = entries[1][1]
+  return tonumber(string.sub(id, 1, string.find(id, '-', 1, true) - 1))
+end
+
 local function append_events(keys, args)
   local stream_name = keys[1]
   local expected_version = tonumber(keys[2])
@@ -22,20 +34,29 @@ local function append_events(keys, args)
   local global_position
   local items_inserted = 0
 
+  local time = redis.call('TIME')
+  local now_ms = tonumber(time[1]) * 1000 + math.floor(tonumber(time[2]) / 1000)
+  local stream_ms = last_id_ms(stream_name)
+  local all_ms = last_id_ms('_all')
+
   for i=1, table.getn(args), 4 do
 
+      stream_ms = math.max(now_ms, stream_ms + 1)
+
       local stream_position = redis.call(
-        'XADD', stream_name, '*', 
+        'XADD', stream_name, string.format('%.0f', stream_ms) .. '-0',
         'message_id', args[i],
-        'message_type', args[i+1], 
-        'json_data', args[i+2], 
+        'message_type', args[i+1],
+        'json_data', args[i+2],
         'json_metadata', args[i+3],
         'created', created
       )
 
+      all_ms = math.max(now_ms, all_ms + 1)
+
       global_position = redis.call(
-        'XADD', '_all', '*', 
-        'stream', stream_name, 
+        'XADD', '_all', string.format('%.0f', all_ms) .. '-0',
+        'stream', stream_name,
         'position', stream_position
       )
 

--- a/src/Redis/src/Eventuous.Redis/Tools/Conversions.cs
+++ b/src/Redis/src/Eventuous.Redis/Tools/Conversions.cs
@@ -9,16 +9,24 @@ static class Conversions {
         return long.Parse(first) * 10 + long.Parse(second);
     }
 
+    // Redis stream ID components are unsigned 64-bit values, so both parts are parsed as ulong
+    // and range-checked before conversion to the signed position
     public static long ToRevision(this RedisValue value) {
         var (first, second) = new Split(Ensure.NotNull<string>(value).AsSpan());
-        var sequence = long.Parse(second);
+        var sequence = ulong.Parse(second);
 
-        return sequence <= 9
-            ? long.Parse(first) * 10 + sequence
-            : throw new NotSupportedException(
+        if (sequence > 9) {
+            throw new NotSupportedException(
                 $"Redis stream entry ID {value} can't be represented as a stream position: the position encoding only supports ID sequence numbers 0-9. " +
                 "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store."
             );
+        }
+
+        var milliseconds = ulong.Parse(first);
+
+        return milliseconds <= long.MaxValue / 10
+            ? (long)milliseconds * 10 + (long)sequence
+            : throw new NotSupportedException($"Redis stream entry ID {value} can't be represented as a stream position: the millisecond part is too large.");
     }
 
     public static ulong ToULong(this ReadOnlySpan<char> valueString) {

--- a/src/Redis/src/Eventuous.Redis/Tools/Conversions.cs
+++ b/src/Redis/src/Eventuous.Redis/Tools/Conversions.cs
@@ -24,9 +24,12 @@ static class Conversions {
 
         var milliseconds = ulong.Parse(first);
 
-        return milliseconds <= long.MaxValue / 10
+        const ulong maxMilliseconds = long.MaxValue / 10;
+
+        // At the quotient boundary only sequences up to long.MaxValue % 10 still fit
+        return milliseconds < maxMilliseconds || (milliseconds == maxMilliseconds && sequence <= long.MaxValue % 10)
             ? (long)milliseconds * 10 + (long)sequence
-            : throw new NotSupportedException($"Redis stream entry ID {value} can't be represented as a stream position: the millisecond part is too large.");
+            : throw new NotSupportedException($"Redis stream entry ID {value} can't be represented as a stream position: the encoded value exceeds the position range.");
     }
 
     public static ulong ToULong(this ReadOnlySpan<char> valueString) {

--- a/src/Redis/src/Eventuous.Redis/Tools/Conversions.cs
+++ b/src/Redis/src/Eventuous.Redis/Tools/Conversions.cs
@@ -9,6 +9,18 @@ static class Conversions {
         return long.Parse(first) * 10 + long.Parse(second);
     }
 
+    public static long ToRevision(this RedisValue value) {
+        var (first, second) = new Split(Ensure.NotNull<string>(value).AsSpan());
+        var sequence = long.Parse(second);
+
+        return sequence <= 9
+            ? long.Parse(first) * 10 + sequence
+            : throw new NotSupportedException(
+                $"Redis stream entry ID {value} can't be represented as a stream position: the position encoding only supports ID sequence numbers 0-9. " +
+                "Entries with higher sequence numbers were written with auto-generated IDs by an older version of the store."
+            );
+    }
+
     public static ulong ToULong(this ReadOnlySpan<char> valueString) {
         var (first, second) = new Split(valueString);
         return ulong.Parse(first) * 10 + ulong.Parse(second);

--- a/src/Redis/test/Eventuous.Tests.Redis/Fixtures/IntegrationFixture.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Fixtures/IntegrationFixture.cs
@@ -37,7 +37,9 @@ public sealed class IntegrationFixture : IAsyncInitializer, IAsyncDisposable {
         IDatabase GetDb() {
             // FLUSHDB in test teardown is an admin command; StackExchange.Redis 3.x enforces the
             // admin gate for raw commands issued through Execute as well.
-            var muxer = ConnectionMultiplexer.Connect($"{connString},allowAdmin=true");
+            // abortConnect=false keeps the multiplexer retrying when the first connection attempt
+            // races the freshly started container.
+            var muxer = ConnectionMultiplexer.Connect($"{connString},allowAdmin=true,abortConnect=false");
 
             return muxer.GetDatabase();
         }

--- a/src/Redis/test/Eventuous.Tests.Redis/Fixtures/IntegrationFixture.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Fixtures/IntegrationFixture.cs
@@ -37,9 +37,7 @@ public sealed class IntegrationFixture : IAsyncInitializer, IAsyncDisposable {
         IDatabase GetDb() {
             // FLUSHDB in test teardown is an admin command; StackExchange.Redis 3.x enforces the
             // admin gate for raw commands issued through Execute as well.
-            // abortConnect=false keeps the multiplexer retrying when the first connection attempt
-            // races the freshly started container.
-            var muxer = ConnectionMultiplexer.Connect($"{connString},allowAdmin=true,abortConnect=false");
+            var muxer = ConnectionMultiplexer.Connect($"{connString},allowAdmin=true");
 
             return muxer.GetDatabase();
         }

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Eventuous.Tests.Redis.Fixtures;
 using Shouldly;
+using StackExchange.Redis;
 using static Eventuous.Tests.Redis.Store.Helpers;
 
 namespace Eventuous.Tests.Redis.Store;
@@ -74,7 +75,7 @@ public class ReadEvents(IntegrationFixture fixture) {
 
         // Entries written by older versions can carry auto-generated IDs with sequence numbers
         // the position encoding can't represent; reading them must fail loudly, not garble positions
-        await AddLegacyEntry(streamName, "12345-10");
+        await AddLegacyEntry(fixture.GetDatabase(), streamName, "12345-10");
 
         await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
     }
@@ -84,8 +85,10 @@ public class ReadEvents(IntegrationFixture fixture) {
         var streamName = GetStreamName();
 
         // Legacy auto-generated IDs from a same-millisecond burst
+        var database = fixture.GetDatabase();
+
         for (var sequence = 0; sequence <= 10; sequence++) {
-            await AddLegacyEntry(streamName, $"12345-{sequence}");
+            await AddLegacyEntry(database, streamName, $"12345-{sequence}");
         }
 
         // The first page ends at 12345-9 and the advanced position decodes past 12345-10,
@@ -106,8 +109,10 @@ public class ReadEvents(IntegrationFixture fixture) {
         // A legacy burst with sequence numbers beyond a single decimal carry: positions minted for
         // such entries by older versions are ambiguous, but any read from the start of the stream
         // must reject the first unrepresentable entry it materializes
+        var database = fixture.GetDatabase();
+
         for (var sequence = 0; sequence <= 20; sequence += 5) {
-            await AddLegacyEntry(streamName, $"12345-{sequence}");
+            await AddLegacyEntry(database, streamName, $"12345-{sequence}");
         }
 
         await Assert.ThrowsAsync<NotSupportedException>(ReadFunc);
@@ -123,8 +128,10 @@ public class ReadEvents(IntegrationFixture fixture) {
     public async Task ShouldRejectResumedCursorOnLegacyBurstStream(CancellationToken cancellationToken) {
         var streamName = GetStreamName();
 
+        var database = fixture.GetDatabase();
+
         for (var sequence = 0; sequence <= 20; sequence++) {
-            await AddLegacyEntry(streamName, $"12345-{sequence}");
+            await AddLegacyEntry(database, streamName, $"12345-{sequence}");
         }
 
         // A cursor minted by a pre-fix reader after consuming 12345-19 (revision 123469 + 1):
@@ -132,10 +139,47 @@ public class ReadEvents(IntegrationFixture fixture) {
         await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, new(123470), 10, true, cancellationToken));
     }
 
-    async Task AddLegacyEntry(StreamName streamName, string id) {
+    [Test]
+    public async Task ShouldRejectResumedReadAfterStreamRecreatedWithLegacyEntries(CancellationToken cancellationToken) {
+        var events     = CreateEvents(3).ToArray();
+        var streamName = GetStreamName();
+        await fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream, cancellationToken);
+
+        // A resumed read on the clean stream passes validation
+        var appended = await fixture.EventReader.ReadEvents(streamName, new(10), 10, true, cancellationToken);
+        await Assert.That(appended.Length).IsGreaterThan(0);
+
+        // Recreate the stream under the same name with legacy entries: the earlier verdict must not stick
+        var database = fixture.GetDatabase();
+        await database.KeyDeleteAsync(streamName.ToString());
+
+        for (var sequence = 0; sequence <= 20; sequence++) {
+            await AddLegacyEntry(database, streamName, $"12345-{sequence}");
+        }
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, new(123470), 10, true, cancellationToken));
+    }
+
+    [Test]
+    public async Task ShouldRejectResumedReadAfterMissingStreamGetsLegacyEntries(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+
+        // A resumed read of a missing stream must not establish a verdict for the name
+        await Assert.ThrowsAsync<StreamNotFound>(() => fixture.EventReader.ReadEvents(streamName, new(100), 10, true, cancellationToken));
+
+        var database = fixture.GetDatabase();
+
+        for (var sequence = 0; sequence <= 20; sequence++) {
+            await AddLegacyEntry(database, streamName, $"12345-{sequence}");
+        }
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, new(123470), 10, true, cancellationToken));
+    }
+
+    static async Task AddLegacyEntry(IDatabase database, StreamName streamName, string id) {
         var serialized = EventSerializer.Default.SerializeEvent(CreateEvent());
 
-        await fixture.GetDatabase().StreamAddAsync(
+        await database.StreamAddAsync(
             streamName.ToString(),
             [
                 new("message_id", Guid.NewGuid().ToString()),

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -71,10 +71,37 @@ public class ReadEvents(IntegrationFixture fixture) {
     [Test]
     public async Task ShouldRejectLegacyUnrepresentableEntryId(CancellationToken cancellationToken) {
         var streamName = GetStreamName();
-        var serialized = EventSerializer.Default.SerializeEvent(CreateEvent());
 
         // Entries written by older versions can carry auto-generated IDs with sequence numbers
         // the position encoding can't represent; reading them must fail loudly, not garble positions
+        await AddLegacyEntry(streamName, "12345-10");
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
+    }
+
+    [Test]
+    public async Task ShouldRejectLegacyEntryIdHiddenBehindPageBoundary(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+
+        // Legacy auto-generated IDs from a same-millisecond burst
+        for (var sequence = 0; sequence <= 10; sequence++) {
+            await AddLegacyEntry(streamName, $"12345-{sequence}");
+        }
+
+        // The first page ends at 12345-9 and the advanced position decodes past 12345-10,
+        // which must fail loudly instead of being silently skipped
+        await Assert.ThrowsAsync<NotSupportedException>(ReadFunc);
+
+        return;
+
+        async Task ReadFunc() {
+            await foreach (var _ in fixture.EventReader.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 10, cancellationToken: cancellationToken)) { }
+        }
+    }
+
+    async Task AddLegacyEntry(StreamName streamName, string id) {
+        var serialized = EventSerializer.Default.SerializeEvent(CreateEvent());
+
         await fixture.GetDatabase().StreamAddAsync(
             streamName.ToString(),
             [
@@ -83,10 +110,8 @@ public class ReadEvents(IntegrationFixture fixture) {
                 new("json_data", serialized.Payload),
                 new("created", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture))
             ],
-            "12345-10"
+            id
         );
-
-        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
     }
 
     [Test]

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -161,6 +161,28 @@ public class ReadEvents(IntegrationFixture fixture) {
     }
 
     [Test]
+    public async Task ShouldRejectResumedReadAfterStreamRestoredWithSameFirstEntry(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+        var database   = fixture.GetDatabase();
+
+        // A clean stream with explicit IDs, validated by a resumed read
+        await AddLegacyEntry(database, streamName, "12345-0");
+        await AddLegacyEntry(database, streamName, "12346-0");
+        await AddLegacyEntry(database, streamName, "12347-0");
+
+        var appended = await fixture.EventReader.ReadEvents(streamName, new(123460), 10, true, cancellationToken);
+        await Assert.That(appended.Length).IsGreaterThan(0);
+
+        // Restore the stream with the same first entry but an unrepresentable entry
+        // below the previously validated range: the earlier verdict must not stick
+        await database.KeyDeleteAsync(streamName.ToString());
+        await AddLegacyEntry(database, streamName, "12345-0");
+        await AddLegacyEntry(database, streamName, "12346-10");
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, new(123470), 10, true, cancellationToken));
+    }
+
+    [Test]
     public async Task ShouldRejectResumedReadAfterMissingStreamGetsLegacyEntries(CancellationToken cancellationToken) {
         var streamName = GetStreamName();
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -43,10 +43,29 @@ public class ReadEvents(IntegrationFixture fixture) {
         var events2 = CreateEvents(10).ToArray();
         await fixture.AppendEvents(streamName, events2, ExpectedStreamVersion.Any, cancellationToken);
 
-        var result = await fixture.EventReader.ReadEvents(streamName, new((long)position), 100, true, cancellationToken);
+        // The read position is inclusive, so start from the position right after the first batch
+        var result = await fixture.EventReader.ReadEvents(streamName, new((long)position + 1), 100, true, cancellationToken);
 
         IEnumerable<object> actual = result.Select(x => x.Payload)!;
         await Assert.That(actual).IsEquivalentTo(events2);
+    }
+
+    [Test]
+    public async Task ShouldReadStreamToEndAcrossPages(CancellationToken cancellationToken) {
+        // Keep the batch small so the auto-generated Redis ID sequence numbers stay within
+        // the single digit that the position encoding can represent
+        var events     = CreateEvents(8).ToArray();
+        var streamName = GetStreamName();
+        await fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream, cancellationToken);
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in fixture.EventReader.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 3, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        IEnumerable<object> actual = result.Select(x => x.Payload)!;
+        await Assert.That(actual).IsEquivalentTo(events);
     }
 
     [Test]

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -103,6 +103,18 @@ public class ReadEvents(IntegrationFixture fixture) {
     }
 
     [Test]
+    public async Task ShouldRejectEntryIdWithSequenceAboveLongRange(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+
+        // Redis ID sequence components are unsigned 64-bit; values beyond long range must still
+        // surface as the documented NotSupportedException, both when materialized and when validated
+        await AddLegacyEntry(fixture.GetDatabase(), streamName, "12345-9223372036854775808");
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, new(123470), 10, true, cancellationToken));
+    }
+
+    [Test]
     public async Task ShouldRejectLegacyBurstStreamReadFromStart(CancellationToken cancellationToken) {
         var streamName = GetStreamName();
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Eventuous.Tests.Redis.Fixtures;
 using Shouldly;
 using static Eventuous.Tests.Redis.Store.Helpers;
@@ -52,20 +53,40 @@ public class ReadEvents(IntegrationFixture fixture) {
 
     [Test]
     public async Task ShouldReadStreamToEndAcrossPages(CancellationToken cancellationToken) {
-        // Keep the batch small so the auto-generated Redis ID sequence numbers stay within
-        // the single digit that the position encoding can represent
-        var events     = CreateEvents(8).ToArray();
+        // A single batch this large lands in one millisecond, so all positions must still round-trip
+        var events     = CreateEvents(25).ToArray();
         var streamName = GetStreamName();
         await fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream, cancellationToken);
 
         var result = new List<StreamEvent>();
 
-        await foreach (var evt in fixture.EventReader.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 3, cancellationToken: cancellationToken)) {
+        await foreach (var evt in fixture.EventReader.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 4, cancellationToken: cancellationToken)) {
             result.Add(evt);
         }
 
         IEnumerable<object> actual = result.Select(x => x.Payload)!;
         await Assert.That(actual).IsEquivalentTo(events);
+    }
+
+    [Test]
+    public async Task ShouldRejectLegacyUnrepresentableEntryId(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+        var serialized = EventSerializer.Default.SerializeEvent(CreateEvent());
+
+        // Entries written by older versions can carry auto-generated IDs with sequence numbers
+        // the position encoding can't represent; reading them must fail loudly, not garble positions
+        await fixture.GetDatabase().StreamAddAsync(
+            streamName.ToString(),
+            [
+                new("message_id", Guid.NewGuid().ToString()),
+                new("message_type", serialized.EventType),
+                new("json_data", serialized.Payload),
+                new("created", DateTime.UtcNow.ToString(CultureInfo.InvariantCulture))
+            ],
+            "12345-10"
+        );
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
     }
 
     [Test]

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -99,6 +99,26 @@ public class ReadEvents(IntegrationFixture fixture) {
         }
     }
 
+    [Test]
+    public async Task ShouldRejectLegacyBurstStreamReadFromStart(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+
+        // A legacy burst with sequence numbers beyond a single decimal carry: positions minted for
+        // such entries by older versions are ambiguous, but any read from the start of the stream
+        // must reject the first unrepresentable entry it materializes
+        for (var sequence = 0; sequence <= 20; sequence += 5) {
+            await AddLegacyEntry(streamName, $"12345-{sequence}");
+        }
+
+        await Assert.ThrowsAsync<NotSupportedException>(ReadFunc);
+
+        return;
+
+        async Task ReadFunc() {
+            await foreach (var _ in fixture.EventReader.ReadStreamToEnd(streamName, StreamReadPosition.Start, cancellationToken: cancellationToken)) { }
+        }
+    }
+
     async Task AddLegacyEntry(StreamName streamName, string id) {
         var serialized = EventSerializer.Default.SerializeEvent(CreateEvent());
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -50,6 +50,24 @@ public class ReadEvents(IntegrationFixture fixture) {
     }
 
     [Test]
+    public async Task ShouldReturnEmptyReadingPastEnd(CancellationToken cancellationToken) {
+        var events     = CreateEvents(10).ToArray();
+        var streamName = GetStreamName();
+        var appended   = await fixture.AppendEvents(streamName, events, ExpectedStreamVersion.NoStream, cancellationToken);
+
+        var result = await fixture.EventReader.ReadEvents(streamName, new((long)appended.GlobalPosition + 1000), 10, true, cancellationToken);
+
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task ShouldThrowWhenReadingMissingStream(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+
+        await Assert.ThrowsAsync<StreamNotFound>(() => fixture.EventReader.ReadEvents(streamName, StreamReadPosition.Start, 10, true, cancellationToken));
+    }
+
+    [Test]
     public async Task ShouldReadHead(CancellationToken cancellationToken) {
         // ReSharper disable once CoVariantArrayConversion
         var events     = CreateEvents(20).ToArray();

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -119,6 +119,19 @@ public class ReadEvents(IntegrationFixture fixture) {
         }
     }
 
+    [Test]
+    public async Task ShouldRejectResumedCursorOnLegacyBurstStream(CancellationToken cancellationToken) {
+        var streamName = GetStreamName();
+
+        for (var sequence = 0; sequence <= 20; sequence++) {
+            await AddLegacyEntry(streamName, $"12345-{sequence}");
+        }
+
+        // A cursor minted by a pre-fix reader after consuming 12345-19 (revision 123469 + 1):
+        // resuming from it must be rejected, not silently skip the remaining entries
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(streamName, new(123470), 10, true, cancellationToken));
+    }
+
     async Task AddLegacyEntry(StreamName streamName, string id) {
         var serialized = EventSerializer.Default.SerializeEvent(CreateEvent());
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -131,6 +131,23 @@ public class ReadEvents(IntegrationFixture fixture) {
     }
 
     [Test]
+    public async Task ShouldReadStreamToEndAtMaxRevision(CancellationToken cancellationToken) {
+        // An event at the maximum representable revision filling an exact page must complete
+        // the paged read instead of advancing past the end of the position space
+        var streamName = GetStreamName();
+        await AddLegacyEntry(fixture.GetDatabase(), streamName, "922337203685477580-7");
+
+        var result = new List<StreamEvent>();
+
+        await foreach (var evt in fixture.EventReader.ReadStreamToEnd(streamName, StreamReadPosition.Start, pageSize: 1, cancellationToken: cancellationToken)) {
+            result.Add(evt);
+        }
+
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].Revision).IsEqualTo(long.MaxValue);
+    }
+
+    [Test]
     public async Task ShouldRejectLegacyBurstStreamReadFromStart(CancellationToken cancellationToken) {
         var streamName = GetStreamName();
 

--- a/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
+++ b/src/Redis/test/Eventuous.Tests.Redis/Store/Read.cs
@@ -115,6 +115,22 @@ public class ReadEvents(IntegrationFixture fixture) {
     }
 
     [Test]
+    public async Task ShouldHandleRevisionBoundaryAtLongMax(CancellationToken cancellationToken) {
+        // long.MaxValue / 10 = 922337203685477580, long.MaxValue % 10 = 7: sequence 7 encodes to
+        // exactly long.MaxValue, sequence 8 no longer fits and must be rejected, not wrap negative
+        var fitting = GetStreamName();
+        await AddLegacyEntry(fixture.GetDatabase(), fitting, "922337203685477580-7");
+
+        var result = await fixture.EventReader.ReadEvents(fitting, StreamReadPosition.Start, 10, true, cancellationToken);
+        await Assert.That(result[0].Revision).IsEqualTo(long.MaxValue);
+
+        var overflowing = GetStreamName();
+        await AddLegacyEntry(fixture.GetDatabase(), overflowing, "922337203685477580-8");
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => fixture.EventReader.ReadEvents(overflowing, StreamReadPosition.Start, 10, true, cancellationToken));
+    }
+
+    [Test]
     public async Task ShouldRejectLegacyBurstStreamReadFromStart(CancellationToken cancellationToken) {
         var streamName = GetStreamName();
 

--- a/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/SqlEventStoreBase.cs
@@ -103,6 +103,9 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
 
         var events = await ReadInternal(stream, start, count, cancellationToken).NoContext();
 
+        // A plain query can't tell a missing stream from a read past the stream end
+        if (events.Length == 0 && !await StreamExists(stream, cancellationToken).NoContext()) throw new StreamNotFound(stream);
+
         foreach (var evt in events) yield return evt;
     }
 
@@ -111,6 +114,9 @@ public abstract class SqlEventStoreBase<TConnection, TTransaction>(IEventSeriali
         if (count <= 0) yield break;
 
         var events = await ReadInternalBackwards(stream, start, count, cancellationToken).NoContext();
+
+        // A plain query can't tell a missing stream from a read past the stream end
+        if (events.Length == 0 && !await StreamExists(stream, cancellationToken).NoContext()) throw new StreamNotFound(stream);
 
         foreach (var evt in events) yield return evt;
     }

--- a/src/SqlServer/src/Eventuous.SqlServer/SqlServerStore.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/SqlServerStore.cs
@@ -41,7 +41,8 @@ public class SqlServerStore : SqlEventStoreBase<SqlConnection, SqlTransaction> {
         => connection
             .GetStoredProcCommand(Schema.ReadStreamBackwards)
             .Add("@stream_name", SqlDbType.NVarChar, stream.ToString())
-            .Add("@from_position", SqlDbType.Int, start.Value)
+            // Stream positions are 32-bit, so StreamReadPosition.End gets clamped, and the procedure trims it to the stream head
+            .Add("@from_position", SqlDbType.Int, (int)Math.Min(start.Value, int.MaxValue))
             .Add("@count", SqlDbType.Int, count);
 
     protected override bool IsStreamNotFound(Exception exception) => exception is SqlException e && e.Message.StartsWith("StreamNotFound");


### PR DESCRIPTION
Closes #567

## Summary

- **True streaming reads in `KurrentDBEventStore`**: `ReadEvents` and `ReadEventsBackwards` now yield each event as it arrives from the server instead of materializing the whole requested range into two stream-sized arrays before the first yield. Exception mapping (`StreamNotFound`, `ReadFromStreamException`) and logging are preserved by wrapping each advance of the source enumerator; `OperationCanceledException` now propagates instead of being wrapped.
- **First-class read-to-end**: new `IEventReader.ReadStreamToEnd` extension returns `IAsyncEnumerable<StreamEvent>`, reading in pages (default 500, tunable) and advancing from the last yielded event's revision — bounded memory on every provider, so `count: int.MaxValue` stops being the idiom. `ReadStream` now delegates to it, which also fixes its page advancement for truncated streams.
- **Documented memory semantics** on `IEventReader.ReadEvents`/`ReadEventsBackwards`: implementations either stream or buffer up to `count`, and whole-stream reads should use `ReadStreamToEnd`.

New shared contract tests exposed two pre-existing provider bugs, fixed here:

- **Sqlite** never threw `StreamNotFound` when reading a missing stream (a plain SELECT can't tell a missing stream from a read past the end). `SqlEventStoreBase` now checks `StreamExists` when a read returns no rows.
- **Postgres and SqlServer** crashed reading backwards from `StreamReadPosition.End`: `long.MaxValue` was marshalled into an INT parameter (arithmetic overflow). The parameter is now clamped to the 32-bit position range, which is lossless since both schemas store positions as INT and both procedures already trim the position to the stream head.

## Test plan

- New `StreamingReadTests` (KurrentDB) prove streaming with a counting serializer: exactly 1 event deserialized at first yield, previously the full range
- New shared `StoreReadTests` cases (inherited by KurrentDB, Postgres, SqlServer, Sqlite): read-to-end across page boundaries, exact page multiples, from a position, missing-stream throw/empty behavior, and missing-stream contract for plain reads
- Full affected suites green on net10.0: KurrentDB 68/68, Postgres 44/44, SqlServer 48/48, Sqlite 34/34, core Eventuous.Tests 26/26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-driven hardening (rounds 2–5 of the independent code review)

- `KurrentDBEventStore` reads now deliver the requested count even when non-deserializable `$`-typed events are skipped (follow-up server reads), so a short read reliably means the stream end — the invariant `ReadStreamToEnd` paging relies on, now documented on `IEventReader`
- `ReadStreamToEnd` rejects non-positive page sizes (previously spun forever on relational stores)
- `TieredEventReader`: past-end reads of existing streams return empty instead of throwing; archive gap-fill and combined output are bounded by the requested count; backwards reads no longer crash when the hot tier bottoms out at revision 0
- `RedisStore`: reads are now inclusive (`XRANGE`) matching the position contract; the append function assigns explicit round-trippable entry IDs (`<ms>-0`), fixing silent event loss at page boundaries for same-millisecond bursts

### Redis legacy data caveat

Streams written by earlier versions may contain auto-generated entry IDs with sequence numbers ≥ 10, which the `ms*10+seq` position encoding cannot represent. Reading such an entry, or reading from a position whose gap hides one, now throws `NotSupportedException` naming the entry. Positions minted by pre-fix versions **from** such entries are inherently ambiguous (the encoding maps e.g. both legacy `12345-20` and valid `12347-0` to `123470`) and cannot be detected without breaking valid reads — resume positions for such streams should be re-derived by reading the stream from the start, which fails loudly and identifies the offending entry. A storage-format migration for legacy burst streams is a candidate follow-up issue.
