### PR TITLE
fix(kurrentdb): bump KurrentDB.Client to 1.4.1 to stop unobserved read task exceptions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />
-    <PackageVersion Include="KurrentDB.Client" Version="1.4.0" />
+    <PackageVersion Include="KurrentDB.Client" Version="1.4.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsVer)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsVer)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsVer)" />


### PR DESCRIPTION
## Problem

`KurrentDBEventStore.ReadEvents` and `ReadEventsBackwards` leaked an unobserved task exception whenever a read failed.

`KurrentDBClient.ReadStreamAsync` returns a `ReadStreamResult` that parks the read's failure in **two** places:

```csharp
catch (Exception ex) {
    tcs.TrySetException(ex);            // the public ReadState task — nothing awaits it
    _channel.Writer.TryComplete(ex);    // the message channel — the enumerator observes this
}
```

Both read methods create that result, own it for its whole lifetime, and only call `ToArrayAsync` — so the faulted `ReadState` task is collected unobserved and surfaces on the finalizer thread as a `TaskScheduler.UnobservedTaskException`. (`StreamExists` in the same class already awaits `ReadState`, so it was never affected, and `ReadAllStreamResult` has no `ReadState` at all, so the `$all` paths were never affected either.)

The leak window is precisely *"the read faults before the first response arrives"* — once the first response lands, the pump has already called `tcs.SetResult(ReadState.Ok)` and the later `TrySetException` is a no-op. So this was never only about cancellation: connection failures, auth failures, deadline expiry and an unavailable server all leaked one unobserved exception per read.

## Fix

Bump `KurrentDB.Client` to 1.4.1, which observes the fault at the source ([client #423](https://github.com/kurrent-io/KurrentDB-Client-DotNet/pull/423)):

```csharp
if (tcs.TrySetException(ex))
    _ = tcs.Task.Exception;
```

The same client release fixes two sibling sinks that a consumer cannot reach from the outside at all — `SharingProvider`'s call-invoker boxes, and the batch appender's fire-and-forget send loop (which `AppendToStreamAsync` uses by default).

## Verification

20 reads made to fault before the first response (client pointed at a closed port), counting `TaskScheduler.UnobservedTaskException`:

| | 1.4.0 | 1.4.1 |
|---|---|---|
| unobserved exceptions | **59** | **0** |

On 1.4.0 those 59 came from three distinct sinks: 18× `RpcException(Cancelled)` from `ReadState`, 21× `RpcException(Unavailable)` from `SharingProvider` retry boxes, 20× `ObjectDisposedException` from its disposed-box path.

Solution builds clean on `net8.0`/`net9.0`/`net10.0`.

## Why no Eventuous-side guard as well

It was considered and deliberately left out. The only reliable placement is a continuation attached immediately after `ReadStreamAsync` returns, i.e. before the fault exists, which costs a continuation task allocation on **every** read — every aggregate load — to guard a case the client now handles at the source. The cheap conditional alternative does not work: `_ = read.ReadState.Exception` in a `catch`/`finally` misses the common cancellation case, because `ToArrayAsync(ct)` throws `OperationCanceledException` from the caller's token *before* the pump's catch runs, leaving the task incomplete and `Exception` null.

The version floor also carries weight: the package dependency becomes `KurrentDB.Client >= 1.4.1`, so landing back on 1.4.0 requires an explicit direct downgrade, which NuGet reports as `NU1605`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
