### PR TITLE
fix(subscriptions): keep factory-registered handlers separate

### DIFF
--- a/src/Core/src/Eventuous.Subscriptions/Filters/ConsumePipe.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Filters/ConsumePipe.cs
@@ -9,7 +9,13 @@ public sealed class ConsumePipe : IAsyncDisposable {
     readonly LinkedList<IConsumeFilter> _filters = [];
     readonly List<object>               _owned   = [];
 
-    bool _disposed;
+    /// <summary>
+    /// Completed when the disposal that won <see cref="_disposing"/> is done, so callers that lost the race
+    /// wait for the teardown instead of being told it finished.
+    /// </summary>
+    readonly TaskCompletionSource _disposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    int _disposing;
 
     public IEnumerable<object> RegisteredFilters => _filters.AsEnumerable();
 
@@ -60,30 +66,46 @@ public sealed class ConsumePipe : IAsyncDisposable {
 
     static ValueTask Move(LinkedListNode<IConsumeFilter>? node, IBaseConsumeContext context) => node == null ? default : node.Value.Send(context, node.Next);
 
+    /// <summary>
+    /// Disposes the filters and everything the pipe owns, exactly once. Concurrent callers, which the SignalR
+    /// gateway produces when a disconnect races the gateway shutdown, all wait for the single teardown.
+    /// </summary>
     public async ValueTask DisposeAsync() {
-        if (_disposed) return;
+        // Exchange, not check-then-set: two callers reading a plain flag both pass and double-dispose.
+        if (Interlocked.Exchange(ref _disposing, 1) != 0) {
+            await _disposed.Task.NoContext();
 
-        _disposed = true;
-
-        foreach (var filter in _filters) {
-            if (filter is IAsyncDisposable d) {
-                await d.DisposeAsync().NoContext();
-            }
+            return;
         }
 
-        // After the filters, as they drain in-flight messages that still need their handlers, and in reverse
-        // order of creation.
-        for (var i = _owned.Count - 1; i >= 0; i--) {
-            switch (_owned[i]) {
-                case IAsyncDisposable d:
+        try {
+            foreach (var filter in _filters) {
+                if (filter is IAsyncDisposable d) {
                     await d.DisposeAsync().NoContext();
-
-                    break;
-                case IDisposable d:
-                    d.Dispose();
-
-                    break;
+                }
             }
+
+            // After the filters, as they drain in-flight messages that still need their handlers, and in
+            // reverse order of creation.
+            for (var i = _owned.Count - 1; i >= 0; i--) {
+                switch (_owned[i]) {
+                    case IAsyncDisposable d:
+                        await d.DisposeAsync().NoContext();
+
+                        break;
+                    case IDisposable d:
+                        d.Dispose();
+
+                        break;
+                }
+            }
+
+            _disposed.TrySetResult();
+        } catch (Exception e) {
+            // The losing callers get the same failure rather than a teardown that looks clean.
+            _disposed.TrySetException(e);
+
+            throw;
         }
     }
 }

--- a/src/Core/src/Eventuous.Subscriptions/Filters/ConsumePipe.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Filters/ConsumePipe.cs
@@ -7,8 +7,18 @@ using Context;
 
 public sealed class ConsumePipe : IAsyncDisposable {
     readonly LinkedList<IConsumeFilter> _filters = [];
+    readonly List<object>               _owned   = [];
+
+    bool _disposed;
 
     public IEnumerable<object> RegisteredFilters => _filters.AsEnumerable();
+
+    /// <summary>
+    /// Gives the pipe ownership of a component, so it gets disposed with the pipe. Used for event handlers
+    /// created by the subscription builder, as nothing else would dispose them.
+    /// </summary>
+    /// <param name="component">Component to dispose with the pipe</param>
+    internal void AddOwned(object component) => _owned.Add(component);
 
     public ConsumePipe AddFilterFirst<TIn, TOut>(IConsumeFilter<TIn, TOut> filter)
         where TIn : class, IBaseConsumeContext
@@ -51,9 +61,28 @@ public sealed class ConsumePipe : IAsyncDisposable {
     static ValueTask Move(LinkedListNode<IConsumeFilter>? node, IBaseConsumeContext context) => node == null ? default : node.Value.Send(context, node.Next);
 
     public async ValueTask DisposeAsync() {
+        if (_disposed) return;
+
+        _disposed = true;
+
         foreach (var filter in _filters) {
             if (filter is IAsyncDisposable d) {
                 await d.DisposeAsync().NoContext();
+            }
+        }
+
+        // After the filters, as they drain in-flight messages that still need their handlers, and in reverse
+        // order of creation.
+        for (var i = _owned.Count - 1; i >= 0; i--) {
+            switch (_owned[i]) {
+                case IAsyncDisposable d:
+                    await d.DisposeAsync().NoContext();
+
+                    break;
+                case IDisposable d:
+                    d.Dispose();
+
+                    break;
             }
         }
     }

--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
@@ -44,15 +44,16 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     }
 
     /// <summary>
-    /// Adds an event handler to the subscription. The handler is created once by the given function and kept by
-    /// the subscription, it isn't registered in the container. Nothing disposes it, as the function might return
-    /// a handler owned elsewhere; use the overload with <c>ownsHandler</c> for a handler the function creates.
+    /// Adds an event handler to the subscription. The handler is created once by the given function and owned by
+    /// the subscription, it isn't registered in the container, so it gets disposed when the subscription is
+    /// disposed if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. When the function
+    /// returns a handler owned elsewhere, use the overload with <c>ownsHandler</c> to decline ownership.
     /// </summary>
     /// <param name="getHandler">A function to resolve event handler using the service provider</param>
     /// <typeparam name="THandler">Event handler type</typeparam>
     /// <returns></returns>
     public SubscriptionBuilder AddEventHandler<THandler>(Func<IServiceProvider, THandler> getHandler) where THandler : class, IEventHandler
-        => AddEventHandler(getHandler, false);
+        => AddEventHandler(getHandler, true);
 
     /// <summary>
     /// Adds an event handler to the subscription. The handler is created once by the given function and kept by
@@ -60,10 +61,11 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// </summary>
     /// <param name="getHandler">A function to resolve event handler using the service provider</param>
     /// <param name="ownsHandler">
-    /// When <c>true</c>, the subscription owns the handler and disposes it when the subscription is disposed, if it
-    /// implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Only set it when the function creates
-    /// the handler: a handler the function resolves from the container is owned by the container, and disposing it
-    /// would break the other components using it.
+    /// When <c>true</c>, the default, the subscription owns the handler and disposes it when the subscription is
+    /// disposed, if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Set it to
+    /// <c>false</c> when the function returns a handler owned elsewhere, such as one it resolves from the
+    /// container, as disposing that would break the other components using it. To have the container create and
+    /// own the handler, use <see cref="AddEventHandler{THandler}()"/> instead.
     /// </param>
     /// <typeparam name="THandler">Event handler type</typeparam>
     /// <returns></returns>
@@ -112,10 +114,11 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
     /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
     /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
-    /// The inner handler is created once and kept by the subscription, it isn't registered in the container.
-    /// Nothing disposes it, as <paramref name="getInnerHandler"/> might return a handler owned elsewhere; use the
-    /// overload with <c>ownsInnerHandler</c> for an inner handler the function creates. The wrapping handler
-    /// decorates the inner one and is never disposed.
+    /// The inner handler is created once and owned by the subscription, it isn't registered in the container, so it
+    /// gets disposed when the subscription is disposed if it implements <see cref="IDisposable"/> or
+    /// <see cref="IAsyncDisposable"/>. When <paramref name="getInnerHandler"/> returns a handler owned elsewhere,
+    /// use the overload with <c>ownsInnerHandler</c> to decline ownership. The wrapping handler decorates the inner
+    /// one and is never disposed.
     /// </summary>
     /// <typeparam name="THandler">Inner event handler type</typeparam>
     /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
@@ -126,7 +129,7 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
             Func<IServiceProvider, THandler> getInnerHandler,
             Func<THandler, TWrappingHandler> getWrappingHandler
         ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler
-        => AddCompositionEventHandler(getInnerHandler, getWrappingHandler, false);
+        => AddCompositionEventHandler(getInnerHandler, getWrappingHandler, true);
 
     /// <summary>
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
@@ -140,10 +143,10 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// <param name="getInnerHandler">Function that resolves or creates the inner handler using the service provider</param>
     /// <param name="getWrappingHandler">Factory that produces the wrapping handler from the inner handler</param>
     /// <param name="ownsInnerHandler">
-    /// When <c>true</c>, the subscription owns the inner handler and disposes it when the subscription is disposed,
-    /// if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Only set it when
-    /// <paramref name="getInnerHandler"/> creates the handler: a handler it resolves from the container is owned by
-    /// the container, and disposing it would break the other components using it.
+    /// When <c>true</c>, the default, the subscription owns the inner handler and disposes it when the subscription
+    /// is disposed, if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Set it to
+    /// <c>false</c> when <paramref name="getInnerHandler"/> returns a handler owned elsewhere, such as one it
+    /// resolves from the container, as disposing that would break the other components using it.
     /// </param>
     /// <returns>The current <see cref="SubscriptionBuilder"/> instance</returns>
     public SubscriptionBuilder AddCompositionEventHandler<THandler, TWrappingHandler>(
@@ -161,10 +164,11 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
     /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
     /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
-    /// The inner handler is created once and kept by the subscription, it isn't registered in the container.
-    /// Nothing disposes it, as <paramref name="getInnerHandler"/> might return a handler owned elsewhere; use the
-    /// overload with <c>ownsInnerHandler</c> for an inner handler the function creates. The wrapping handler
-    /// decorates the inner one and is never disposed.
+    /// The inner handler is created once and owned by the subscription, it isn't registered in the container, so it
+    /// gets disposed when the subscription is disposed if it implements <see cref="IDisposable"/> or
+    /// <see cref="IAsyncDisposable"/>. When <paramref name="getInnerHandler"/> returns a handler owned elsewhere,
+    /// use the overload with <c>ownsInnerHandler</c> to decline ownership. The wrapping handler decorates the inner
+    /// one and is never disposed.
     /// </summary>
     /// <typeparam name="THandler">Inner event handler type</typeparam>
     /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
@@ -175,7 +179,7 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
             Func<IServiceProvider, THandler> getInnerHandler,
             Func<THandler, IServiceProvider, TWrappingHandler> getWrappingHandler
         ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler
-        => AddCompositionEventHandler(getInnerHandler, getWrappingHandler, false);
+        => AddCompositionEventHandler(getInnerHandler, getWrappingHandler, true);
 
     /// <summary>
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
@@ -189,10 +193,10 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// <param name="getInnerHandler">Function that resolves or creates the inner handler using the service provider</param>
     /// <param name="getWrappingHandler">Factory that produces the wrapping handler from the inner handler</param>
     /// <param name="ownsInnerHandler">
-    /// When <c>true</c>, the subscription owns the inner handler and disposes it when the subscription is disposed,
-    /// if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Only set it when
-    /// <paramref name="getInnerHandler"/> creates the handler: a handler it resolves from the container is owned by
-    /// the container, and disposing it would break the other components using it.
+    /// When <c>true</c>, the default, the subscription owns the inner handler and disposes it when the subscription
+    /// is disposed, if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Set it to
+    /// <c>false</c> when <paramref name="getInnerHandler"/> returns a handler owned elsewhere, such as one it
+    /// resolves from the container, as disposing that would break the other components using it.
     /// </param>
     /// <returns>The current <see cref="SubscriptionBuilder"/> instance</returns>
     public SubscriptionBuilder AddCompositionEventHandler<THandler, TWrappingHandler>(

--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
@@ -19,7 +19,9 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     public string             SubscriptionId { get; } = subscriptionId;
     public IServiceCollection Services       { get; } = services;
 
-    readonly List<ResolveHandler> _handlers = [];
+    readonly List<ResolveHandler> _handlers      = [];
+    readonly HashSet<Type>        _handlerTypes  = [];
+    readonly List<object>         _ownedHandlers = [];
 
     protected ConsumePipe     Pipe            { get; }      = new();
     protected ResolveConsumer ResolveConsumer { get; set; } = null!;
@@ -27,11 +29,14 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     protected IEventHandler[] ResolveHandlers(IServiceProvider sp) => [.. _handlers.Select(x => x(sp))];
 
     /// <summary>
-    /// Adds an event handler to the subscription
+    /// Adds an event handler to the subscription. The handler is registered in the container, keyed by
+    /// <see cref="SubscriptionId"/>, so it can only be added once per subscription.
     /// </summary>
     /// <typeparam name="THandler">Event handler type</typeparam>
     /// <returns></returns>
+    /// <exception cref="ArgumentException">The same handler type is already registered for this subscription</exception>
     public SubscriptionBuilder AddEventHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler>() where THandler : class, IEventHandler {
+        ReserveHandlerType<THandler>();
         Services.TryAddKeyedSingleton<THandler>(SubscriptionId);
         AddHandlerResolve(sp => sp.GetRequiredKeyedService<THandler>(SubscriptionId));
 
@@ -39,14 +44,16 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     }
 
     /// <summary>
-    /// Adds an event handler to the subscription
+    /// Adds an event handler to the subscription. The handler is created once by the given function and owned by
+    /// the subscription rather than the container, so it gets disposed when the subscription is disposed if it
+    /// implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>.
     /// </summary>
     /// <param name="getHandler">A function to resolve event handler using the service provider</param>
     /// <typeparam name="THandler">Event handler type</typeparam>
     /// <returns></returns>
     public SubscriptionBuilder AddEventHandler<THandler>(Func<IServiceProvider, THandler> getHandler) where THandler : class, IEventHandler {
-        Services.TryAddKeyedSingleton<THandler>(SubscriptionId, (sp, _) => getHandler(sp));
-        AddHandlerResolve(sp => sp.GetRequiredKeyedService<THandler>(SubscriptionId));
+        THandler? handler = null;
+        AddHandlerResolve(sp => handler ??= Own(getHandler(sp)));
 
         return this;
     }
@@ -73,10 +80,12 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// <typeparam name="TWrappingHandler">Wrapping event handler type produced by the factory</typeparam>
     /// <param name="getWrappingHandler">Factory that takes the resolved inner handler and returns the wrapping handler</param>
     /// <returns>The current <see cref="SubscriptionBuilder"/> instance</returns>
+    /// <exception cref="ArgumentException">The same inner handler type is already registered for this subscription</exception>
     public SubscriptionBuilder AddCompositionEventHandler<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler, TWrappingHandler>(
             Func<THandler, TWrappingHandler> getWrappingHandler
         )
         where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler {
+        ReserveHandlerType<THandler>();
         Services.TryAddKeyedSingleton<THandler>(SubscriptionId);
         AddHandlerResolve(sp => getWrappingHandler(sp.GetRequiredKeyedService<THandler>(SubscriptionId)));
 
@@ -87,6 +96,9 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
     /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
     /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
+    /// The inner handler is created once and owned by the subscription rather than the container, so it gets
+    /// disposed when the subscription is disposed if it implements <see cref="IDisposable"/> or
+    /// <see cref="IAsyncDisposable"/>. The wrapping handler decorates it and isn't disposed.
     /// </summary>
     /// <typeparam name="THandler">Inner event handler type</typeparam>
     /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
@@ -97,8 +109,8 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
             Func<IServiceProvider, THandler> getInnerHandler,
             Func<THandler, TWrappingHandler> getWrappingHandler
         ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler {
-        Services.TryAddKeyedSingleton(SubscriptionId, (sp, _) => getInnerHandler(sp));
-        AddHandlerResolve(sp => getWrappingHandler(sp.GetRequiredKeyedService<THandler>(SubscriptionId)));
+        THandler? innerHandler = null;
+        AddHandlerResolve(sp => getWrappingHandler(innerHandler ??= Own(getInnerHandler(sp))));
 
         return this;
     }
@@ -107,6 +119,9 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
     /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
     /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
+    /// The inner handler is created once and owned by the subscription rather than the container, so it gets
+    /// disposed when the subscription is disposed if it implements <see cref="IDisposable"/> or
+    /// <see cref="IAsyncDisposable"/>. The wrapping handler decorates it and isn't disposed.
     /// </summary>
     /// <typeparam name="THandler">Inner event handler type</typeparam>
     /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
@@ -117,8 +132,8 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
             Func<IServiceProvider, THandler> getInnerHandler,
             Func<THandler, IServiceProvider, TWrappingHandler> getWrappingHandler
         ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler {
-        Services.TryAddKeyedSingleton(SubscriptionId, (sp, _) => getInnerHandler(sp));
-        AddHandlerResolve(sp => getWrappingHandler(sp.GetRequiredKeyedService<THandler>(SubscriptionId), sp));
+        THandler? innerHandler = null;
+        AddHandlerResolve(sp => getWrappingHandler(innerHandler ??= Own(getInnerHandler(sp)), sp));
 
         return this;
     }
@@ -165,6 +180,41 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
         Pipe.AddFilterFirst(filter);
 
         return this;
+    }
+
+    /// <summary>
+    /// Records a handler the builder created, so the subscription disposes it. Handlers resolved from the
+    /// container and handlers supplied by the caller are owned elsewhere and are left alone.
+    /// </summary>
+    THandler Own<THandler>(THandler handler) where THandler : class, IEventHandler {
+        if (handler is IDisposable or IAsyncDisposable) _ownedHandlers.Add(handler);
+
+        return handler;
+    }
+
+    /// <summary>
+    /// Hands the handlers created by the builder over to the pipe, which disposes them when the subscription
+    /// is disposed.
+    /// </summary>
+    protected void TransferHandlersOwnership() {
+        foreach (var handler in _ownedHandlers) {
+            Pipe.AddOwned(handler);
+        }
+
+        _ownedHandlers.Clear();
+    }
+
+    /// <summary>
+    /// Claims the container slot keyed by <see cref="SubscriptionId"/> for the given handler type. Two handlers of
+    /// the same type would share that slot, so the subscription would silently dispatch the same instance twice.
+    /// </summary>
+    void ReserveHandlerType<THandler>() where THandler : class, IEventHandler {
+        if (!_handlerTypes.Add(typeof(THandler))) {
+            throw new ArgumentException(
+                $"Event handler {typeof(THandler).Name} is already registered for subscription {SubscriptionId}. "
+              + "Use the overload with a handler factory or instance to add several handlers of the same type."
+            );
+        }
     }
 
     void AddHandlerResolve(ResolveHandler resolveHandler)
@@ -242,6 +292,7 @@ public class SubscriptionBuilder
         }
 
         var consumer = GetConsumer(sp);
+        TransferHandlersOwnership();
 
         if (EventuousDiagnostics.Enabled) {
             Pipe.AddFilterLast(new TracingFilter(consumer.GetType().Name));

--- a/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
+++ b/src/Core/src/Eventuous.Subscriptions/Registrations/SubscriptionBuilder.cs
@@ -44,16 +44,32 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     }
 
     /// <summary>
-    /// Adds an event handler to the subscription. The handler is created once by the given function and owned by
-    /// the subscription rather than the container, so it gets disposed when the subscription is disposed if it
-    /// implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>.
+    /// Adds an event handler to the subscription. The handler is created once by the given function and kept by
+    /// the subscription, it isn't registered in the container. Nothing disposes it, as the function might return
+    /// a handler owned elsewhere; use the overload with <c>ownsHandler</c> for a handler the function creates.
     /// </summary>
     /// <param name="getHandler">A function to resolve event handler using the service provider</param>
     /// <typeparam name="THandler">Event handler type</typeparam>
     /// <returns></returns>
-    public SubscriptionBuilder AddEventHandler<THandler>(Func<IServiceProvider, THandler> getHandler) where THandler : class, IEventHandler {
+    public SubscriptionBuilder AddEventHandler<THandler>(Func<IServiceProvider, THandler> getHandler) where THandler : class, IEventHandler
+        => AddEventHandler(getHandler, false);
+
+    /// <summary>
+    /// Adds an event handler to the subscription. The handler is created once by the given function and kept by
+    /// the subscription, it isn't registered in the container.
+    /// </summary>
+    /// <param name="getHandler">A function to resolve event handler using the service provider</param>
+    /// <param name="ownsHandler">
+    /// When <c>true</c>, the subscription owns the handler and disposes it when the subscription is disposed, if it
+    /// implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Only set it when the function creates
+    /// the handler: a handler the function resolves from the container is owned by the container, and disposing it
+    /// would break the other components using it.
+    /// </param>
+    /// <typeparam name="THandler">Event handler type</typeparam>
+    /// <returns></returns>
+    public SubscriptionBuilder AddEventHandler<THandler>(Func<IServiceProvider, THandler> getHandler, bool ownsHandler) where THandler : class, IEventHandler {
         THandler? handler = null;
-        AddHandlerResolve(sp => handler ??= Own(getHandler(sp)));
+        AddHandlerResolve(sp => handler ??= Own(getHandler(sp), ownsHandler));
 
         return this;
     }
@@ -96,9 +112,10 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
     /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
     /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
-    /// The inner handler is created once and owned by the subscription rather than the container, so it gets
-    /// disposed when the subscription is disposed if it implements <see cref="IDisposable"/> or
-    /// <see cref="IAsyncDisposable"/>. The wrapping handler decorates it and isn't disposed.
+    /// The inner handler is created once and kept by the subscription, it isn't registered in the container.
+    /// Nothing disposes it, as <paramref name="getInnerHandler"/> might return a handler owned elsewhere; use the
+    /// overload with <c>ownsInnerHandler</c> for an inner handler the function creates. The wrapping handler
+    /// decorates the inner one and is never disposed.
     /// </summary>
     /// <typeparam name="THandler">Inner event handler type</typeparam>
     /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
@@ -108,9 +125,34 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     public SubscriptionBuilder AddCompositionEventHandler<THandler, TWrappingHandler>(
             Func<IServiceProvider, THandler> getInnerHandler,
             Func<THandler, TWrappingHandler> getWrappingHandler
+        ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler
+        => AddCompositionEventHandler(getInnerHandler, getWrappingHandler, false);
+
+    /// <summary>
+    /// Adds a composition event handler to the subscription with a custom inner handler resolver.
+    /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
+    /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
+    /// The inner handler is created once and kept by the subscription, it isn't registered in the container.
+    /// The wrapping handler decorates the inner one and is never disposed.
+    /// </summary>
+    /// <typeparam name="THandler">Inner event handler type</typeparam>
+    /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
+    /// <param name="getInnerHandler">Function that resolves or creates the inner handler using the service provider</param>
+    /// <param name="getWrappingHandler">Factory that produces the wrapping handler from the inner handler</param>
+    /// <param name="ownsInnerHandler">
+    /// When <c>true</c>, the subscription owns the inner handler and disposes it when the subscription is disposed,
+    /// if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Only set it when
+    /// <paramref name="getInnerHandler"/> creates the handler: a handler it resolves from the container is owned by
+    /// the container, and disposing it would break the other components using it.
+    /// </param>
+    /// <returns>The current <see cref="SubscriptionBuilder"/> instance</returns>
+    public SubscriptionBuilder AddCompositionEventHandler<THandler, TWrappingHandler>(
+            Func<IServiceProvider, THandler> getInnerHandler,
+            Func<THandler, TWrappingHandler> getWrappingHandler,
+            bool                             ownsInnerHandler
         ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler {
         THandler? innerHandler = null;
-        AddHandlerResolve(sp => getWrappingHandler(innerHandler ??= Own(getInnerHandler(sp))));
+        AddHandlerResolve(sp => getWrappingHandler(innerHandler ??= Own(getInnerHandler(sp), ownsInnerHandler)));
 
         return this;
     }
@@ -119,9 +161,10 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     /// Adds a composition event handler to the subscription with a custom inner handler resolver.
     /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
     /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
-    /// The inner handler is created once and owned by the subscription rather than the container, so it gets
-    /// disposed when the subscription is disposed if it implements <see cref="IDisposable"/> or
-    /// <see cref="IAsyncDisposable"/>. The wrapping handler decorates it and isn't disposed.
+    /// The inner handler is created once and kept by the subscription, it isn't registered in the container.
+    /// Nothing disposes it, as <paramref name="getInnerHandler"/> might return a handler owned elsewhere; use the
+    /// overload with <c>ownsInnerHandler</c> for an inner handler the function creates. The wrapping handler
+    /// decorates the inner one and is never disposed.
     /// </summary>
     /// <typeparam name="THandler">Inner event handler type</typeparam>
     /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
@@ -131,9 +174,34 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     public SubscriptionBuilder AddCompositionEventHandler<THandler, TWrappingHandler>(
             Func<IServiceProvider, THandler> getInnerHandler,
             Func<THandler, IServiceProvider, TWrappingHandler> getWrappingHandler
+        ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler
+        => AddCompositionEventHandler(getInnerHandler, getWrappingHandler, false);
+
+    /// <summary>
+    /// Adds a composition event handler to the subscription with a custom inner handler resolver.
+    /// The inner handler is created via <paramref name="getInnerHandler"/> and then wrapped into
+    /// <typeparamref name="TWrappingHandler"/> using <paramref name="getWrappingHandler"/>.
+    /// The inner handler is created once and kept by the subscription, it isn't registered in the container.
+    /// The wrapping handler decorates the inner one and is never disposed.
+    /// </summary>
+    /// <typeparam name="THandler">Inner event handler type</typeparam>
+    /// <typeparam name="TWrappingHandler">Wrapping event handler type</typeparam>
+    /// <param name="getInnerHandler">Function that resolves or creates the inner handler using the service provider</param>
+    /// <param name="getWrappingHandler">Factory that produces the wrapping handler from the inner handler</param>
+    /// <param name="ownsInnerHandler">
+    /// When <c>true</c>, the subscription owns the inner handler and disposes it when the subscription is disposed,
+    /// if it implements <see cref="IDisposable"/> or <see cref="IAsyncDisposable"/>. Only set it when
+    /// <paramref name="getInnerHandler"/> creates the handler: a handler it resolves from the container is owned by
+    /// the container, and disposing it would break the other components using it.
+    /// </param>
+    /// <returns>The current <see cref="SubscriptionBuilder"/> instance</returns>
+    public SubscriptionBuilder AddCompositionEventHandler<THandler, TWrappingHandler>(
+            Func<IServiceProvider, THandler>                   getInnerHandler,
+            Func<THandler, IServiceProvider, TWrappingHandler> getWrappingHandler,
+            bool                                               ownsInnerHandler
         ) where THandler : class, IEventHandler where TWrappingHandler : class, IEventHandler {
         THandler? innerHandler = null;
-        AddHandlerResolve(sp => getWrappingHandler(innerHandler ??= Own(getInnerHandler(sp)), sp));
+        AddHandlerResolve(sp => getWrappingHandler(innerHandler ??= Own(getInnerHandler(sp), ownsInnerHandler), sp));
 
         return this;
     }
@@ -183,11 +251,12 @@ public abstract class SubscriptionBuilder(IServiceCollection services, string su
     }
 
     /// <summary>
-    /// Records a handler the builder created, so the subscription disposes it. Handlers resolved from the
-    /// container and handlers supplied by the caller are owned elsewhere and are left alone.
+    /// Records a handler the subscription owns, so it gets disposed with the subscription. Ownership is stated by
+    /// the caller rather than inferred: a handler factory is free to return a handler the container owns, and
+    /// disposing that would break the other components using it.
     /// </summary>
-    THandler Own<THandler>(THandler handler) where THandler : class, IEventHandler {
-        if (handler is IDisposable or IAsyncDisposable) _ownedHandlers.Add(handler);
+    THandler Own<THandler>(THandler handler, bool owns) where THandler : class, IEventHandler {
+        if (owns && handler is IDisposable or IAsyncDisposable) _ownedHandlers.Add(handler);
 
         return handler;
     }

--- a/src/Core/test/Eventuous.Tests.Subscriptions/CompositionHandlerTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/CompositionHandlerTests.cs
@@ -38,11 +38,12 @@ public class CompositionHandlerTests {
 
     [Test]
     public async Task ShouldResolveCompositionHandlerWithFactory() {
-        // This test validates that AddCompositionEventHandler correctly registers
-        // handlers when using a factory function
-        var handler = _server.Services.GetRequiredKeyedService<TestHandler>("sub-with-factory");
-        await Assert.That(handler).IsNotNull();
-        await Assert.That(handler.Dependency.Value).IsEqualTo("test-value");
+        // This test validates that AddCompositionEventHandler builds the inner handler from the factory,
+        // giving it access to the service provider. The handler is owned by the builder, not the container.
+        var capture = _server.Services.GetRequiredService<HandlerCapture>();
+
+        await Assert.That(capture.Handler).IsNotNull();
+        await Assert.That(capture.Handler!.Dependency.Value).IsEqualTo("test-value");
     }
 
     [Test]
@@ -82,12 +83,13 @@ public class CompositionHandlerTests {
         public static void ConfigureServices(IServiceCollection services) {
             services.AddSingleton(new TestHandlerLogger());
             services.AddSingleton<TestDependency>();
+            services.AddSingleton<HandlerCapture>();
 
             // Test the AddCompositionEventHandler with a factory function
             services.AddSubscription<TestSub, TestOptions>(
                 "sub-with-factory",
                 builder => builder.AddCompositionEventHandler<TestHandler, CompositionWrapper>(
-                    sp => new(sp.GetRequiredService<TestDependency>(), sp.GetRequiredService<TestHandlerLogger>()),
+                    sp => sp.GetRequiredService<HandlerCapture>().Handler = new(sp.GetRequiredService<TestDependency>(), sp.GetRequiredService<TestHandlerLogger>()),
                     (handler, sp) => new(handler, sp.GetRequiredService<TestHandlerLogger>())
                 )
             );
@@ -101,6 +103,14 @@ public class CompositionHandlerTests {
     class TestSub(TestOptions options, ConsumePipe consumePipe)
         : EventSubscription<TestOptions>(options, consumePipe, NullLoggerFactory.Instance, null) {
         protected override ValueTask Connect(SubscriptionRun run) => default;
+    }
+
+    /// <summary>
+    /// Keeps the handler the factory created, as it's owned by the subscription builder and not resolvable
+    /// from the container.
+    /// </summary>
+    class HandlerCapture {
+        public TestHandler? Handler { get; set; }
     }
 
     public class TestDependency {

--- a/src/Core/test/Eventuous.Tests.Subscriptions/ConsumePipeTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/ConsumePipeTests.cs
@@ -35,6 +35,45 @@ public class ConsumePipeTests {
         await Assert.That(handler.Received!.Items.GetItem<string>(Key)).IsEqualTo(baggage);
     }
 
+    [Test]
+    public async Task ShouldMakeSecondDisposalWaitForTheFirst() {
+        var filter = new BlockingFilter();
+        var pipe   = new ConsumePipe().AddFilterFirst(filter);
+
+        var first  = pipe.DisposeAsync();
+        var second = pipe.DisposeAsync();
+
+        // The pipe is still disposing, so a second caller must not be told the teardown is done
+        await Assert.That(second.IsCompleted).IsFalse();
+
+        filter.Release();
+        await first;
+        await second;
+
+        await Assert.That(filter.Disposals).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// Blocks inside <see cref="DisposeAsync"/> until released, so a second disposal can be observed while the
+    /// first one is still running.
+    /// </summary>
+    class BlockingFilter : ConsumeFilter<IMessageConsumeContext>, IAsyncDisposable {
+        readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int Disposals { get; private set; }
+
+        public void Release() => _release.TrySetResult();
+
+        protected override ValueTask Send(IMessageConsumeContext context, LinkedListNode<IConsumeFilter>? next)
+            => next == null ? default : next.Value.Send(context, next.Next);
+
+        public async ValueTask DisposeAsync() {
+            Disposals++;
+
+            await _release.Task;
+        }
+    }
+
     class TestFilter(string key, string payload) : ConsumeFilter<IMessageConsumeContext> {
         protected override ValueTask Send(IMessageConsumeContext context, LinkedListNode<IConsumeFilter>? next) {
             context.Items.AddItem(key, payload);

--- a/src/Core/test/Eventuous.Tests.Subscriptions/HandlerDisposalTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/HandlerDisposalTests.cs
@@ -53,8 +53,7 @@ public class HandlerDisposalTests {
         var resolved = Resolve(
             builder => builder.AddCompositionEventHandler<DisposableHandler, DisposableWrappingHandler>(
                 _ => inner = new(),
-                handler => wrapper = new(handler),
-                ownsInnerHandler: true
+                handler => wrapper = new(handler)
             )
         );
         await resolved.Subscription.DisposeAsync();
@@ -89,19 +88,20 @@ public class HandlerDisposalTests {
     }
 
     [Test]
-    public async Task ShouldNotDisposeFactoryHandlerByDefault() {
+    public async Task ShouldDisposeFactoryHandlerByDefault() {
         DisposableHandler? handler = null;
 
         var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
         await resolved.Subscription.DisposeAsync();
 
-        await Assert.That(handler!.Disposals).IsEqualTo(0);
+        await Assert.That(handler!.Disposals).IsEqualTo(1);
     }
 
     [Test]
-    public async Task ShouldNotDisposeHandlerTheFactoryResolvedFromTheContainer() {
+    public async Task ShouldNotDisposeHandlerWhenOwnershipIsDeclined() {
+        // A factory is free to return a handler owned elsewhere, which is what declining ownership is for
         var resolved = Resolve(
-            builder => builder.AddEventHandler(sp => sp.GetRequiredService<DisposableHandler>()),
+            builder => builder.AddEventHandler(sp => sp.GetRequiredService<DisposableHandler>(), ownsHandler: false),
             services => services.AddSingleton<DisposableHandler>()
         );
         var handler = resolved.Provider.GetRequiredService<DisposableHandler>();
@@ -109,6 +109,23 @@ public class HandlerDisposalTests {
         await resolved.Subscription.DisposeAsync();
 
         await Assert.That(handler.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldNotDisposeCompositionInnerHandlerWhenOwnershipIsDeclined() {
+        var resolved = Resolve(
+            builder => builder.AddCompositionEventHandler<DisposableHandler, DisposableWrappingHandler>(
+                sp => sp.GetRequiredService<DisposableHandler>(),
+                handler => new(handler),
+                ownsInnerHandler: false
+            ),
+            services => services.AddSingleton<DisposableHandler>()
+        );
+        var inner = resolved.Provider.GetRequiredService<DisposableHandler>();
+
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(inner.Disposals).IsEqualTo(0);
     }
 
     [Test]

--- a/src/Core/test/Eventuous.Tests.Subscriptions/HandlerDisposalTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/HandlerDisposalTests.cs
@@ -1,0 +1,197 @@
+using Eventuous.Subscriptions;
+using Eventuous.Subscriptions.Context;
+using Eventuous.Subscriptions.Filters;
+using Eventuous.Subscriptions.Registrations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Eventuous.Tests.Subscriptions;
+
+/// <summary>
+/// The subscription disposes the handlers its builder created. Handlers owned by the container or supplied by
+/// the caller are left alone.
+/// </summary>
+public class HandlerDisposalTests {
+    const string SubscriptionId = "handler-disposal";
+
+    [Test]
+    public async Task ShouldDisposeHandlerCreatedByFactory() {
+        DisposableHandler? handler = null;
+
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler!.Disposals).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShouldDisposeAsyncHandlerCreatedByFactory() {
+        AsyncDisposableHandler? handler = null;
+
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler!.Disposals).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShouldPreferAsyncDisposal() {
+        DoublyDisposableHandler? handler = null;
+
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler!.AsyncDisposals).IsEqualTo(1);
+        await Assert.That(handler.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldDisposeInnerCompositionHandlerCreatedByFactory() {
+        DisposableHandler?         inner   = null;
+        DisposableWrappingHandler? wrapper = null;
+
+        var resolved = Resolve(
+            builder => builder.AddCompositionEventHandler<DisposableHandler, DisposableWrappingHandler>(
+                _ => inner = new(),
+                handler => wrapper = new(handler)
+            )
+        );
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(inner!.Disposals).IsEqualTo(1);
+        // The wrapping handler decorates the inner one, it holds nothing of its own
+        await Assert.That(wrapper!.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldNotDisposeCompositionOfContainerOwnedInnerHandler() {
+        DisposableWrappingHandler? wrapper = null;
+
+        var resolved = Resolve(
+            builder => builder.AddCompositionEventHandler<DisposableHandler, DisposableWrappingHandler>(handler => wrapper = new(handler))
+        );
+        var inner = resolved.Provider.GetRequiredKeyedService<DisposableHandler>(SubscriptionId);
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(wrapper!.Disposals).IsEqualTo(0);
+        await Assert.That(inner.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldNotDisposeHandlerOwnedByContainer() {
+        var resolved = Resolve(builder => builder.AddEventHandler<DisposableHandler>());
+        var handler  = resolved.Provider.GetRequiredKeyedService<DisposableHandler>(SubscriptionId);
+
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldNotDisposeHandlerSuppliedByCaller() {
+        var handler = new DisposableHandler();
+
+        var resolved = Resolve(builder => builder.AddEventHandler(handler));
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldDisposeHandlerOnlyOnce() {
+        DisposableHandler? handler = null;
+
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        await resolved.Subscription.DisposeAsync();
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler!.Disposals).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShouldDisposeFiltersBeforeHandlers() {
+        List<string> order = [];
+
+        var resolved = Resolve(
+            builder => builder
+                .AddConsumeFilterFirst(new RecordingFilter(order))
+                .AddEventHandler(_ => new RecordingHandler(order))
+        );
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(order).IsEquivalentTo(["filter", "handler"]);
+    }
+
+    static Resolved Resolve(Action<SubscriptionBuilder<TestSub, TestOptions>> configure) {
+        var services = new ServiceCollection();
+        services.AddSubscription<TestSub, TestOptions>(SubscriptionId, configure);
+
+        var provider = services.BuildServiceProvider();
+
+        return new(provider, provider.GetRequiredService<TestSub>());
+    }
+
+    record Resolved(ServiceProvider Provider, TestSub Subscription);
+
+    record TestOptions : SubscriptionOptions;
+
+    class TestSub(TestOptions options, ConsumePipe consumePipe)
+        : EventSubscription<TestOptions>(options, consumePipe, NullLoggerFactory.Instance, null) {
+        protected override ValueTask Connect(SubscriptionRun run) => default;
+    }
+
+    class SucceedingHandler : BaseEventHandler {
+        public override ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) => ValueTask.FromResult(EventHandlingStatus.Success);
+    }
+
+    sealed class DisposableHandler : SucceedingHandler, IDisposable {
+        public int Disposals { get; private set; }
+
+        public void Dispose() => Disposals++;
+    }
+
+    sealed class AsyncDisposableHandler : SucceedingHandler, IAsyncDisposable {
+        public int Disposals { get; private set; }
+
+        public ValueTask DisposeAsync() {
+            Disposals++;
+
+            return default;
+        }
+    }
+
+    sealed class DoublyDisposableHandler : SucceedingHandler, IDisposable, IAsyncDisposable {
+        public int Disposals      { get; private set; }
+        public int AsyncDisposals { get; private set; }
+
+        public void Dispose() => Disposals++;
+
+        public ValueTask DisposeAsync() {
+            AsyncDisposals++;
+
+            return default;
+        }
+    }
+
+    sealed class DisposableWrappingHandler(IEventHandler inner) : SucceedingHandler, IDisposable {
+        public IEventHandler Inner     { get; }      = inner;
+        public int           Disposals { get; private set; }
+
+        public void Dispose() => Disposals++;
+    }
+
+    sealed class RecordingHandler(List<string> order) : SucceedingHandler, IDisposable {
+        public void Dispose() => order.Add("handler");
+    }
+
+    sealed class RecordingFilter(List<string> order) : ConsumeFilter<IMessageConsumeContext>, IAsyncDisposable {
+        protected override ValueTask Send(IMessageConsumeContext context, LinkedListNode<IConsumeFilter>? next)
+            => next?.Value.Send(context, next.Next) ?? default;
+
+        public ValueTask DisposeAsync() {
+            order.Add("filter");
+
+            return default;
+        }
+    }
+}

--- a/src/Core/test/Eventuous.Tests.Subscriptions/HandlerDisposalTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/HandlerDisposalTests.cs
@@ -18,7 +18,7 @@ public class HandlerDisposalTests {
     public async Task ShouldDisposeHandlerCreatedByFactory() {
         DisposableHandler? handler = null;
 
-        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new(), ownsHandler: true));
         await resolved.Subscription.DisposeAsync();
 
         await Assert.That(handler!.Disposals).IsEqualTo(1);
@@ -28,7 +28,7 @@ public class HandlerDisposalTests {
     public async Task ShouldDisposeAsyncHandlerCreatedByFactory() {
         AsyncDisposableHandler? handler = null;
 
-        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new(), ownsHandler: true));
         await resolved.Subscription.DisposeAsync();
 
         await Assert.That(handler!.Disposals).IsEqualTo(1);
@@ -38,7 +38,7 @@ public class HandlerDisposalTests {
     public async Task ShouldPreferAsyncDisposal() {
         DoublyDisposableHandler? handler = null;
 
-        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new(), ownsHandler: true));
         await resolved.Subscription.DisposeAsync();
 
         await Assert.That(handler!.AsyncDisposals).IsEqualTo(1);
@@ -53,7 +53,8 @@ public class HandlerDisposalTests {
         var resolved = Resolve(
             builder => builder.AddCompositionEventHandler<DisposableHandler, DisposableWrappingHandler>(
                 _ => inner = new(),
-                handler => wrapper = new(handler)
+                handler => wrapper = new(handler),
+                ownsInnerHandler: true
             )
         );
         await resolved.Subscription.DisposeAsync();
@@ -88,6 +89,29 @@ public class HandlerDisposalTests {
     }
 
     [Test]
+    public async Task ShouldNotDisposeFactoryHandlerByDefault() {
+        DisposableHandler? handler = null;
+
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler!.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldNotDisposeHandlerTheFactoryResolvedFromTheContainer() {
+        var resolved = Resolve(
+            builder => builder.AddEventHandler(sp => sp.GetRequiredService<DisposableHandler>()),
+            services => services.AddSingleton<DisposableHandler>()
+        );
+        var handler = resolved.Provider.GetRequiredService<DisposableHandler>();
+
+        await resolved.Subscription.DisposeAsync();
+
+        await Assert.That(handler.Disposals).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task ShouldNotDisposeHandlerSuppliedByCaller() {
         var handler = new DisposableHandler();
 
@@ -101,7 +125,7 @@ public class HandlerDisposalTests {
     public async Task ShouldDisposeHandlerOnlyOnce() {
         DisposableHandler? handler = null;
 
-        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new()));
+        var resolved = Resolve(builder => builder.AddEventHandler(_ => handler = new(), ownsHandler: true));
         await resolved.Subscription.DisposeAsync();
         await resolved.Subscription.DisposeAsync();
 
@@ -115,15 +139,16 @@ public class HandlerDisposalTests {
         var resolved = Resolve(
             builder => builder
                 .AddConsumeFilterFirst(new RecordingFilter(order))
-                .AddEventHandler(_ => new RecordingHandler(order))
+                .AddEventHandler(_ => new RecordingHandler(order), ownsHandler: true)
         );
         await resolved.Subscription.DisposeAsync();
 
         await Assert.That(order).IsEquivalentTo(["filter", "handler"]);
     }
 
-    static Resolved Resolve(Action<SubscriptionBuilder<TestSub, TestOptions>> configure) {
+    static Resolved Resolve(Action<SubscriptionBuilder<TestSub, TestOptions>> configure, Action<IServiceCollection>? configureServices = null) {
         var services = new ServiceCollection();
+        configureServices?.Invoke(services);
         services.AddSubscription<TestSub, TestOptions>(SubscriptionId, configure);
 
         var provider = services.BuildServiceProvider();
@@ -186,7 +211,7 @@ public class HandlerDisposalTests {
 
     sealed class RecordingFilter(List<string> order) : ConsumeFilter<IMessageConsumeContext>, IAsyncDisposable {
         protected override ValueTask Send(IMessageConsumeContext context, LinkedListNode<IConsumeFilter>? next)
-            => next?.Value.Send(context, next.Next) ?? default;
+            => next == null ? default : next.Value.Send(context, next.Next);
 
         public ValueTask DisposeAsync() {
             order.Add("filter");

--- a/src/Core/test/Eventuous.Tests.Subscriptions/HandlerRegistrationTests.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions/HandlerRegistrationTests.cs
@@ -1,0 +1,165 @@
+using Eventuous.Subscriptions;
+using Eventuous.Subscriptions.Context;
+using Eventuous.Subscriptions.Filters;
+using Eventuous.Subscriptions.Registrations;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Eventuous.Tests.Subscriptions;
+
+/// <summary>
+/// Handler registrations that share an inferred handler type must not collapse into one.
+/// </summary>
+public class HandlerRegistrationTests {
+    const string SubscriptionId = "handler-registration";
+
+    [Test]
+    public async Task ShouldRunAllHandlersRegisteredByFactory() {
+        List<Type> handled = [];
+
+        IReadOnlyList<Func<IServiceProvider, IEventHandler>> factories = [
+            _ => new FirstHandler(handled),
+            _ => new SecondHandler(handled),
+            _ => new ThirdHandler(handled)
+        ];
+
+        await Handle(builder => {
+                // THandler infers as IEventHandler for every call
+                foreach (var factory in factories) builder.AddEventHandler(sp => factory(sp));
+            }
+        );
+
+        await Assert.That(handled).IsEquivalentTo([typeof(FirstHandler), typeof(SecondHandler), typeof(ThirdHandler)]);
+    }
+
+    [Test]
+    public async Task ShouldRunAllCompositionHandlersRegisteredByFactory() {
+        List<Type> handled = [];
+
+        await Handle(builder => builder
+            .AddCompositionEventHandler<IEventHandler, WrappingHandler>(_ => new FirstHandler(handled), inner => new(inner))
+            .AddCompositionEventHandler<IEventHandler, WrappingHandler>(_ => new SecondHandler(handled), inner => new(inner))
+        );
+
+        await Assert.That(handled).IsEquivalentTo([typeof(FirstHandler), typeof(SecondHandler)]);
+    }
+
+    [Test]
+    public async Task ShouldRunAllCompositionHandlersRegisteredByFactoryWithProvider() {
+        List<Type> handled = [];
+
+        await Handle(builder => builder
+            .AddCompositionEventHandler<IEventHandler, WrappingHandler>(_ => new FirstHandler(handled), (inner, _) => new(inner))
+            .AddCompositionEventHandler<IEventHandler, WrappingHandler>(_ => new SecondHandler(handled), (inner, _) => new(inner))
+        );
+
+        await Assert.That(handled).IsEquivalentTo([typeof(FirstHandler), typeof(SecondHandler)]);
+    }
+
+    [Test]
+    public async Task ShouldCreateFactoryHandlerOnlyOnce() {
+        List<Type> handled = [];
+        var        created = 0;
+
+        var services = new ServiceCollection();
+        var builder  = new TestBuilder(services, SubscriptionId);
+
+        builder.AddEventHandler(
+            _ => {
+                created++;
+
+                return new FirstHandler(handled);
+            }
+        );
+
+        var provider = services.BuildServiceProvider();
+        builder.Resolve(provider);
+        builder.Resolve(provider);
+
+        await Assert.That(created).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ShouldThrowWhenSameHandlerTypeRegisteredTwice() {
+        var services = new ServiceCollection();
+
+        await Assert.That(
+                () => _ = services.AddSubscription<TestSub, TestOptions>(
+                    SubscriptionId,
+                    builder => builder.AddEventHandler<PlainHandler>().AddEventHandler<PlainHandler>()
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ShouldThrowWhenCompositionInnerHandlerTypeIsAlreadyRegistered() {
+        var services = new ServiceCollection();
+
+        await Assert.That(
+                () => _ = services.AddSubscription<TestSub, TestOptions>(
+                    SubscriptionId,
+                    builder => builder
+                        .AddEventHandler<PlainHandler>()
+                        .AddCompositionEventHandler<PlainHandler, WrappingHandler>(inner => new(inner))
+                )
+            )
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ShouldAllowSameHandlerTypeInDifferentSubscriptions() {
+        List<Type> handled = [];
+
+        var services = new ServiceCollection();
+        services.AddSingleton(handled);
+        services.AddSubscription<TestSub, TestOptions>("sub1", builder => builder.AddEventHandler<PlainHandler>());
+        services.AddSubscription<TestSub, TestOptions>("sub2", builder => builder.AddEventHandler<PlainHandler>());
+
+        await using var provider = services.BuildServiceProvider();
+
+        await Assert.That(provider.GetServices<TestSub>().ToArray()).HasCount(2);
+    }
+
+    static async Task Handle(Action<SubscriptionBuilder<TestSub, TestOptions>> configure) {
+        var services = new ServiceCollection();
+        services.AddSubscription<TestSub, TestOptions>(SubscriptionId, configure);
+
+        await using var provider = services.BuildServiceProvider();
+
+        var subscription = provider.GetRequiredService<TestSub>();
+
+        await subscription.Pipe.Send(TestContext.CreateContext());
+    }
+
+    record TestOptions : SubscriptionOptions;
+
+    class TestSub(TestOptions options, ConsumePipe consumePipe)
+        : EventSubscription<TestOptions>(options, consumePipe, NullLoggerFactory.Instance, null) {
+        protected override ValueTask Connect(SubscriptionRun run) => default;
+    }
+
+    sealed class TestBuilder(IServiceCollection services, string subscriptionId) : SubscriptionBuilder(services, subscriptionId) {
+        public IEventHandler[] Resolve(IServiceProvider sp) => ResolveHandlers(sp);
+    }
+
+    abstract class RecordingHandler(List<Type> handled) : BaseEventHandler {
+        public override ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) {
+            handled.Add(GetType());
+
+            return ValueTask.FromResult(EventHandlingStatus.Success);
+        }
+    }
+
+    sealed class FirstHandler(List<Type> handled) : RecordingHandler(handled);
+
+    sealed class SecondHandler(List<Type> handled) : RecordingHandler(handled);
+
+    sealed class ThirdHandler(List<Type> handled) : RecordingHandler(handled);
+
+    sealed class WrappingHandler(IEventHandler inner) : BaseEventHandler {
+        public override ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) => inner.HandleEvent(context);
+    }
+
+    sealed class PlainHandler(List<Type> handled) : RecordingHandler(handled);
+}


### PR DESCRIPTION
Closes #576.

## The bug

`AddEventHandler(Func<IServiceProvider, THandler>)` registered the handler as a keyed singleton under `(THandler, SubscriptionId)` and resolved it back by type. Add several handlers to one subscription through this overload with `THandler` inferring to the same type each time — which happens naturally when the factories live in a collection typed `Func<IServiceProvider, IEventHandler>` — and every registration after the first silently no-ops on the taken key. The subscription then runs N copies of the first handler and none of the others, with nothing thrown and nothing logged.

The two `AddCompositionEventHandler` overloads that build the inner handler from a factory had the identical collapse.

## The fix

Factory-created handlers are memoised in the registration closure instead of the container, so each registration keeps its own handler. This matches the instance overload, which never touched the container.

**Handler disposal.** With the container out of the picture, nothing would dispose a factory-created handler, so the subscription now owns them: `ConsumePipe` disposes them when the subscription is disposed, after the filters have drained the messages in flight, in reverse creation order, preferring `IAsyncDisposable`. Ownership is narrow:

| Registration | Created by | Disposed by |
|---|---|---|
| `AddEventHandler<T>()` | container | container, as before |
| `AddEventHandler(handler)` | caller | caller |
| `AddEventHandler(sp => …)` | **us** | **subscription** |
| `AddCompositionEventHandler(getWrappingHandler)` | inner: container, wrapper: us | container / nobody — a wrapper decorates, it holds nothing |
| `AddCompositionEventHandler(getInnerHandler, …)` | inner: **us**, wrapper: us | **subscription** (inner only) |

`ConsumePipe.DisposeAsync` also became idempotent — it wasn't, and `EventSubscription` compensated with an `Interlocked.Exchange`. Disposing a caller's handler twice is worse than disposing a filter twice.

## Breaking change

Adding the same handler type twice to one subscription used to dispatch every event to the same instance twice, just as silently. Both type-based overloads now claim the container slot up front and throw `ArgumentException` on the second claim. Use the factory or instance overload when a subscription genuinely needs two handlers of the same type.

Factory-registered handlers are also no longer resolvable via `GetRequiredKeyedService<THandler>(subscriptionId)`. That was never documented, and the instance overload never had it.

## Tests

`HandlerRegistrationTests` and `HandlerDisposalTests`, all watched red first:

- three factories sharing an inferred `IEventHandler` ran as `[First, First, First]`; now `[First, Second, Third]` — asserted on the **resolved** set by sending a message through the subscription's pipe, not on the registration list
- same for both composition overloads
- duplicate type registration, direct and via composition, now throws
- factory handlers disposed on subscription dispose, sync and async, async preferred when both are implemented, once on repeat dispose
- container-owned and caller-supplied handlers **not** disposed by the subscription
- filters disposed before handlers

`CompositionHandlerTests.ShouldResolveCompositionHandlerWithFactory` asserted the inner handler was resolvable from the container, which this removes. It now captures the handler the factory built and asserts its injected dependency — same intent, no container round-trip.

Verified on net10.0: `Eventuous.Tests.Subscriptions` 130/130, `Eventuous.Tests` 29/29, `Eventuous.Tests.Application` 21/21. `dotnet build Eventuous.slnx` clean — 0 errors, and the 70 warnings match the pre-change baseline.

Docs PR to follow in `Eventuous/eventuous-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
