### PR TITLE
fix: dispose CodeQL-flagged locals, correct the blob projector README

### DIFF
--- a/src/Azure/src/Eventuous.Azure.Storage.Blobs/README.md
+++ b/src/Azure/src/Eventuous.Azure.Storage.Blobs/README.md
@@ -70,23 +70,28 @@ Note, this means the idempotency is weaker as only the last message ID is checke
 
 ### Custom blob naming
 
-By default, blob names are generated using `GetBlobName(string id)` which creates names in the format `{id}/{T}.json`, where `id` defaults to the stream ID from `context.Stream.GetId()`.
+By default, blob names are generated using `GetBlobName(string id)` which creates names in the format `{id}/{StateType}.json`, where `id` defaults to the stream ID from `context.Stream.GetId()`.
 
 You can customize blob naming in two ways:
 
 **1. Override the virtual methods globally for all events:**
 
 ```csharp
-protected override string GetBlobName(string id, IMessageConsumeContext context) {
-    // Use stream name and type in the path
-    var streamName = context.Stream.ToString();
-    return $"projections/{streamName}/{id}.json";
-}
+public class BookingProjection : BlobStorageProjector<BookingState> {
+    // ...
 
-protected override string GetBlobName(string id) {
-    return $"{id}/{typeof(T).Name}.json";
+    protected override string GetBlobName(string id) => $"bookings/{id}.json";
 }
 ```
+
+When the blob name depends on the event, override the overload that takes the consume context instead:
+
+```csharp
+protected override string GetBlobName(string id, IMessageConsumeContext context)
+    => $"projections/{context.Stream}/{id}.json";
+```
+
+The default implementation of the two-argument overload calls the one-argument overload, so overriding the two-argument version replaces the naming completely — a one-argument override is then never called.
 
 **2. Override blob ID per event handler using `getBlobId`:**
 

--- a/src/Azure/test/Eventuous.Tests.Azure.Storage.Blobs/BlobStorageProjectorTests.cs
+++ b/src/Azure/test/Eventuous.Tests.Azure.Storage.Blobs/BlobStorageProjectorTests.cs
@@ -37,7 +37,8 @@ public class BlobStorageProjectorTests(IntegrationFixture fixture) {
     async Task SetupExistingBlob<TState>(string containerName, string blobName, TState initialState) {
         var blobClient = GetContainer(containerName).GetBlobClient(blobName);
         var json = JsonSerializer.SerializeToUtf8Bytes(initialState);
-        await blobClient.UploadAsync(new MemoryStream(json), overwrite: true);
+        using var stream = new MemoryStream(json);
+        await blobClient.UploadAsync(stream, overwrite: true);
     }
 
     /// <summary>
@@ -71,7 +72,8 @@ public class BlobStorageProjectorTests(IntegrationFixture fixture) {
         var modifiedState = new ConcurrentState { Value = 999 };
         var modifiedJson  = JsonSerializer.SerializeToUtf8Bytes(modifiedState);
         var blobClient    = GetContainer(containerName).GetBlobClient(blobName);
-        await blobClient.UploadAsync(new MemoryStream(modifiedJson), overwrite: true);
+        using var stream  = new MemoryStream(modifiedJson);
+        await blobClient.UploadAsync(stream, overwrite: true);
     };
 
     // ========== SYNC STATE HANDLER TESTS ==========

--- a/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticSerializer.cs
+++ b/src/Experimental/src/Eventuous.ElasticSearch/Store/ElasticSerializer.cs
@@ -11,8 +11,9 @@ public class ElasticSerializer(IElasticsearchSerializer builtIn, JsonSerializerO
     readonly ITypeMapper           _typeMapper = typeMapper ?? TypeMap.Instance;
 
     public object Deserialize(Type type, Stream stream) {
-        var reader = new BinaryReader(stream);
-        var obj    = JsonSerializer.Deserialize(reader.ReadBytes((int)stream.Length), type, _options);
+        // Read the stream directly: a BinaryReader here would either close the caller's stream when
+        // disposed, or leak its buffers when not, and it only added a full copy of the payload
+        var obj = JsonSerializer.Deserialize(stream, type, _options);
 
         if (type != typeof(PersistedEvent)) return obj!;
 
@@ -31,7 +32,8 @@ public class ElasticSerializer(IElasticsearchSerializer builtIn, JsonSerializerO
             return;
         }
 
-        var writer = new Utf8JsonWriter(stream);
+        // Disposing the writer returns its pooled buffers and flushes; it doesn't close the caller's stream
+        using var writer = new Utf8JsonWriter(stream);
         JsonSerializer.Serialize(writer, data, _options);
     }
 


### PR DESCRIPTION
Clears the four `cs/local-not-disposed` alerts on the Code Quality rule page, and fixes two code samples in the blob projector README that don't compile. Two alerts came from #550 (blob storage projection); the two Elastic ones are pre-existing and just share the rule page.

## What the rule flags

Sources are any `ObjectCreation` of a **library** `IDisposable` type (user-defined types are excluded — "user types often have spurious IDisposable declarations"), with only `Task` and `WebControl` whitelisted. Passing the object to a library method is **not** a sink, because CodeQL can't see the callee body to know whether it disposes the argument. That's why `UploadAsync(new MemoryStream(...))` trips it.

Every object creation added by 0f19628 and 1c2fa15 was checked against that definition; the two MemoryStreams are the only hits from the PR.

## Disposal changes

**`BlobStorageProjectorTests.cs`** — hoisted both upload streams into `using var`, matching what `BlobStorageProjector` itself already does.

Not real leaks: a `MemoryStream` over a `byte[]` owns no unmanaged resources. The fix is still correct — the Azure SDK does not dispose caller-supplied streams, so ownership genuinely was ours.

**`ElasticSerializer.Serialize` (`Utf8JsonWriter`)** — a real, if soft, leak. `Utf8JsonWriter` over a `Stream` rents buffers from `ArrayPool<byte>.Shared` and only `Dispose` returns them. Disposal flushes and does *not* close the underlying stream, so it's safe on a serializer contract.

**`ElasticSerializer.Deserialize` (`BinaryReader`)** — this one can't be fixed by adding `using`. `BinaryReader.Dispose()` closes the underlying stream unless constructed with `leaveOpen: true`, and closing the Elasticsearch client's stream from inside a serializer would be a genuine bug. The reader also existed only to copy the whole payload into a `byte[]`, so it's removed in favour of deserializing straight from the stream.

Side benefit: the old code called `(int)stream.Length`, which requires a seekable stream. The new path doesn't. Behaviour is otherwise identical for a stream positioned at 0.

## README fix

The "Custom blob naming" section in `Eventuous.Azure.Storage.Blobs/README.md` had two problems:

- `typeof(T)` doesn't compile in the example's context — `T` is the base class's type parameter and isn't in scope inside a concrete projector deriving from `BlobStorageProjector<T>`.
- Overriding both `GetBlobName` overloads is misleading: the default two-argument implementation delegates to the one-argument one, so a one-argument override is never called once the two-argument one is replaced.

The overrides are now shown as the alternatives they are, with a note on which wins when both are present. The same two bugs were mirrored on the docs site and are fixed in Eventuous/eventuous-docs#10.

## Verification

- `Eventuous.Tests.Azure.Storage.Blobs` — 21/21 passed against Azurite (net10.0).
- `Eventuous.ElasticSearch` — builds clean, 0 warnings.

## Reviewer note

There are **no tests for `ElasticSerializer`** (`src/Experimental/test/` holds only Spyglass projects), so that change is verified by compilation and reading only. The `Deserialize` rewrite is the riskier of the two and deserves a close look — happy to add a `PersistedEvent` round-trip test if you'd rather not merge it uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)