### PR TITLE
fix(test): stop parallel tests racing the shared Bogus Noda cache

### DIFF
--- a/src/Core/test/Eventuous.Tests/Fixtures/NaiveFixture.cs
+++ b/src/Core/test/Eventuous.Tests/Fixtures/NaiveFixture.cs
@@ -8,7 +8,10 @@ using Testing;
 public class NaiveFixture {
     protected IEventStore EventStore { get; } = new InMemoryEventStore();
 
-    static readonly Faker<Commands.BookRoom> Faker = new Faker<Commands.BookRoom>()
+    // A fresh Faker per call rather than one shared instance: f.Noda() caches its dataset in that
+    // Faker's Bogus.Premium context, a plain Dictionary, so tests running in parallel would race
+    // its first write and corrupt it. Same shape as DomainFixture in the other test suites.
+    static Faker<Commands.BookRoom> Faker => new Faker<Commands.BookRoom>()
         .CustomInstantiator(
             f => {
                 var checkin  = f.Noda().LocalDate.Soon();


### PR DESCRIPTION
Fixes #566.

## What was wrong

`NaiveFixture` held a single `static readonly Faker<Commands.BookRoom>`. `f.Noda()` resolves its dataset through `Bogus.Premium.ContextHelper`, which caches into `((IHasContext)faker).Context` — a plain `Dictionary<string, object>` that belongs to that one `Faker` instance. TUnit runs tests in parallel, so several could hit the cache while it was still empty and corrupt it:

```
InvalidOperationException: Operations that change non-concurrent collections must have exclusive access.
  at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value)
  at Bogus.Premium.ContextHelper.GetOrSet[T](String key, Faker f, Func`1 factory)
  at Bogus.NodaTimeExtensions.Noda(Faker faker)
  at Eventuous.Tests.Fixtures.NaiveFixture..cctor b__6_0(Faker f)
```

## The fix

Build the `Faker` per call (`=>`) instead of once (`=`), so each generation gets its own context dictionary and there is nothing to share.

This is already how `DomainFixture` is written in `Eventuous.Tests.Persistence.Base`, `Eventuous.Tests.Redis`, `Eventuous.Tests.KurrentDB` and `Eventuous.Tests.Projections.MongoDB` — all four use an expression-bodied property. `NaiveFixture` was the only fixture with a shared instance, which is why it was the only one flaking. The other suites needed no change.

## Verification

Decompiled Bogus 35.6.5 to confirm the cache is per-`Faker`: `ContextHelper.GetOrSet` writes to `((IHasContext)f).Context`, an instance auto-property initialised to `new Dictionary<string, object>()`, and `Faker<T>.FakerHub` is an instance field. Concurrent `Faker` construction is safe — `Bogus.Database.Data` is a `Lazy<ConcurrentDictionary<..>>` with `ExecutionAndPublication`.

A standalone harness comparing the two shapes over 200 cold rounds of 32 threads each:

| shape | result |
| --- | --- |
| `static readonly Faker<T> Faker = new(...)` | failed **70/200** rounds |
| `static Faker<T> Faker => new(...)` | **0/200** |

`Eventuous.Tests` on `net10.0` then ran 12 consecutive times, 29 tests each, all green. The reported rate was roughly 1 in 10 runs, so the repeat runs are corroboration; the harness numbers and the removal of the shared instance are the actual evidence.

## Not changed

`src/Experimental/src/ElasticPlayground/Generator.cs` has the same shared-static-`Faker` shape, but it is a manual playground whose scenarios run sequentially on one thread, so it is not at risk. Left alone to keep this diff to the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
