### PR TITLE
fix(postgres): fail loudly instead of silently dropping racing appends

### DIFF
--- a/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Append.cs
+++ b/src/Core/test/Eventuous.Tests.Persistence.Base/Store/Append.cs
@@ -123,4 +123,48 @@ public abstract class StoreAppendTests<T> where T : StoreFixtureBase {
         var results = await _fixture.AppendEventsToMultipleStreams([]);
         await Assert.That(results).HasCount().EqualTo(0);
     }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldNotLoseConcurrentAppends(CancellationToken cancellationToken) {
+        const int writers = 20;
+
+        var stream = Helpers.GetStreamName();
+        await _fixture.AppendEvent(stream, Helpers.CreateEvent(), ExpectedStreamVersion.NoStream);
+
+        var results   = await Task.WhenAll(Enumerable.Range(0, writers).Select(_ => TryAppend(stream, ExpectedStreamVersion.Any)));
+        var succeeded = results.Count(x => x);
+
+        var stored = await _fixture.EventStore.ReadEvents(stream, StreamReadPosition.Start, writers * 2, true, cancellationToken);
+
+        await Assert.That(succeeded).IsGreaterThan(0);
+        await Assert.That(stored.Length).IsEqualTo(1 + succeeded);
+    }
+
+    [Test]
+    [Category("Store")]
+    public async Task ShouldRejectConcurrentAppendsWithSameVersion(CancellationToken cancellationToken) {
+        const int writers = 20;
+
+        var stream = Helpers.GetStreamName();
+        await _fixture.AppendEvent(stream, Helpers.CreateEvent(), ExpectedStreamVersion.NoStream);
+
+        var results   = await Task.WhenAll(Enumerable.Range(0, writers).Select(_ => TryAppend(stream, new(0))));
+        var succeeded = results.Count(x => x);
+
+        var stored = await _fixture.EventStore.ReadEvents(stream, StreamReadPosition.Start, writers * 2, true, cancellationToken);
+
+        await Assert.That(succeeded).IsEqualTo(1);
+        await Assert.That(stored.Length).IsEqualTo(1 + succeeded);
+    }
+
+    async Task<bool> TryAppend(StreamName stream, ExpectedStreamVersion version) {
+        try {
+            await _fixture.AppendEvent(stream, Helpers.CreateEvent(), version);
+
+            return true;
+        } catch (AppendToStreamException) {
+            return false;
+        }
+    }
 }

--- a/src/Postgres/src/Eventuous.Postgresql/Scripts/2_AppendEvents.sql
+++ b/src/Postgres/src/Eventuous.Postgresql/Scripts/2_AppendEvents.sql
@@ -11,6 +11,7 @@ declare
     _current_version integer;
     _stream_id integer;
     _position bigint;
+    _constraint_name text;
 begin
     if _created is null then
         _created = now() at time zone 'utc';
@@ -24,8 +25,7 @@ begin
     select m.message_id, m.message_type, _stream_id,
            _current_version + (row_number() over ()) :: int,
            m.json_data, m.json_metadata, _created
-    from unnest(_messages) m
-    on conflict do nothing;
+    from unnest(_messages) m;
 
     select m.stream_position, m.global_position into _current_version, _position
         from __schema__.messages m
@@ -38,6 +38,15 @@ begin
     end if;
 
     return query select _current_version, _position;
+exception
+    when unique_violation then
+        get stacked diagnostics _constraint_name = constraint_name;
+        -- Should not happen since check_stream locks the stream row, but a writer racing us
+        -- must get a concurrency conflict, never a silent no-op reported as success
+        if _constraint_name = 'uq_messages_stream_id_and_stream_position' then
+            raise exception 'WrongExpectedVersion %, concurrent append detected', _expected_version;
+        end if;
+        raise;
 end;
 
 $$ language 'plpgsql';

--- a/src/Postgres/src/Eventuous.Postgresql/Scripts/3_CheckStream.sql
+++ b/src/Postgres/src/Eventuous.Postgresql/Scripts/3_CheckStream.sql
@@ -8,23 +8,30 @@ declare
     _current_version integer;
     _stream_id integer;
 begin
-    select s.version, s.stream_id into _current_version, _stream_id 
+    -- The row lock is held until the end of the caller's transaction,
+    -- serialising concurrent appends to the same stream
+    select s.version, s.stream_id into _current_version, _stream_id
                               from __schema__.streams s
-                              where s.stream_name = _stream_name;
+                              where s.stream_name = _stream_name
+                              for update;
     if _stream_id is null then -- Stream doesn't exist
-        if _expected_version = -2 -- Any
-        or _expected_version = -1 then -- NoStream
-            insert into __schema__.streams (stream_name, version) values (_stream_name, -1);
-            select s.stream_id, s.version into _stream_id, _current_version 
-                                      from __schema__.streams s
-                                      where stream_name = _stream_name;
-        else
+        if _expected_version != -2 -- Any
+        and _expected_version != -1 then -- NoStream
             raise exception 'StreamNotFound';
         end if;
-    else -- Stream exists
-        if _expected_version != -2 and _expected_version != _current_version then
-            raise exception 'WrongExpectedVersion %, current version %', _expected_version, _current_version;
-        end if;
+
+        -- A concurrent transaction may create the same stream; do nothing then,
+        -- and the re-read below locks the winner's row and gets its version
+        insert into __schema__.streams (stream_name, version) values (_stream_name, -1)
+            on conflict (stream_name) do nothing;
+        select s.stream_id, s.version into _stream_id, _current_version
+                                  from __schema__.streams s
+                                  where stream_name = _stream_name
+                                  for update;
+    end if;
+
+    if _expected_version != -2 and _expected_version != _current_version then
+        raise exception 'WrongExpectedVersion %, current version %', _expected_version, _current_version;
     end if;
 
     return query select _stream_id, _current_version;


### PR DESCRIPTION
Fixes #553

## Problem

`CommandService` could report success while the events were missing from the stream under concurrent writes to the same aggregate with the Postgres store:

1. `check_stream` read `streams.version` without a row lock, so concurrent writers both passed the expected-version check with the same current version.
2. `append_events` inserted messages with `on conflict do nothing`, so the losing writer's rows were silently dropped when they hit the `(stream_id, stream_position)` unique constraint.
3. The function then returned the stream's max position, so the loser saw success with the winner's version.

Reproduced with 20 parallel `ExpectedStreamVersion.Any` appends: all 20 reported success, 10 events were lost.

## Fix

- `3_CheckStream.sql`: the stream row is selected `FOR UPDATE` — the lock is held to the end of the append transaction, serialising concurrent appends to the same stream. The stream-creation race is handled with `insert … on conflict (stream_name) do nothing` followed by a locked re-read, and the expected-version check runs after the lock is acquired. Concurrent `Any` appends now all succeed (queued behind the lock); stale expected versions fail with `WrongExpectedVersion`.
- `2_AppendEvents.sql`: removed `on conflict do nothing`. As defence in depth, a residual stream-position conflict raises `WrongExpectedVersion` (mapped by `PostgresStore.IsConflict` to `AppendToStreamException`/`OptimisticConcurrencyException`); any other unique violation is re-raised as-is. This mirrors the SQL Server implementation, which already handled the race this way.

## Tests

Two new tests in the shared `StoreAppendTests` base, so all stores enforce the invariant:

- `ShouldNotLoseConcurrentAppends` — every append that reports success must be durable (fails pre-fix on Postgres: 10 of 20 events lost).
- `ShouldRejectConcurrentAppendsWithSameVersion` — of N concurrent appends with the same expected version, exactly one succeeds and the rest throw `AppendToStreamException`.

Verified: full Postgres suite 49/49, Sqlite and KurrentDB append tests green. SQL Server tests are excluded on macOS and will run in CI.

## Deployment note

The functions are `create or replace`, so existing databases pick up the fix only when the schema scripts re-run — users with `InitializeDatabase = false` need to apply them manually. Worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)