### PR TITLE
fix(sql): scope stream subscription end-of-stream measure to the subscribed stream (#586)

### DIFF
--- a/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionMeasureBase.cs
+++ b/src/Core/test/Eventuous.Tests.Subscriptions.Base/SubscriptionMeasureBase.cs
@@ -36,6 +36,43 @@ public abstract class SubscriptionMeasureBase<TContainer, TSubscription, TSubscr
         await Assert.That(measured.Position).IsEqualTo(last);
     }
 
+    /// <summary>
+    /// For a stream subscription, the measure must report the tail of the subscribed stream only. Reproduces GitHub
+    /// #586, where the relational implementation returned <c>MAX(stream_position)</c> across every stream in the
+    /// store, so any longer stream inflated the gap of a fully caught-up subscription.
+    /// </summary>
+    protected async Task ShouldMeasureEndOfSubscribedStream(StreamName streamName, CancellationToken cancellationToken) {
+        const int otherStreamLength      = 20;
+        const int subscribedStreamLength = 5;
+
+        var measure = fixture.GetMeasure();
+
+        // Invoked before the subscription has ever connected, as the metrics observer does. The subscribed stream
+        // doesn't exist yet, which must read as an empty stream rather than EndOfStream.Invalid.
+        var empty = await measure(cancellationToken);
+        await Assert.That(empty.SubscriptionId).IsEqualTo(fixture.SubscriptionId);
+        await Assert.That(empty.Position).IsEqualTo(0ul);
+
+        // A longer, unrelated stream: its tail must not leak into the subscribed stream's measure.
+        await fixture.AppendEvents(new($"other-{Guid.NewGuid():N}"), [.. fixture.CreateEvents(otherStreamLength)], ExpectedStreamVersion.NoStream);
+
+        var events = fixture.CreateEvents(subscribedStreamLength).ToList();
+        await fixture.AppendEvents(streamName, [.. events], ExpectedStreamVersion.NoStream);
+
+        var measured = await measure(cancellationToken);
+        await Assert.That(measured.SubscriptionId).IsEqualTo(fixture.SubscriptionId);
+        await Assert.That(measured.Position).IsEqualTo((ulong)(subscribedStreamLength - 1));
+
+        await fixture.StartSubscription();
+        await fixture.Handler.AssertCollection(TimeSpan.FromSeconds(2), [.. events]).Validate(cancellationToken);
+        await fixture.StopSubscription();
+
+        // Once caught up, the gap the metrics derive from this measure and the checkpoint must be zero.
+        var checkpoint = await fixture.CheckpointStore.GetLastCheckpoint(fixture.SubscriptionId, cancellationToken);
+        var caughtUp   = await measure(cancellationToken);
+        await Assert.That(caughtUp.Position - checkpoint.Position!.Value).IsEqualTo(0ul);
+    }
+
     async Task GenerateAndHandleCommands(int count) {
         var commands = Enumerable
             .Range(0, count)

--- a/src/Diagnostics/test/Eventuous.Tests.OpenTelemetry/Fakes/TestHandler.cs
+++ b/src/Diagnostics/test/Eventuous.Tests.OpenTelemetry/Fakes/TestHandler.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Eventuous.Tests.OpenTelemetry.Fakes;
 
-class TestHandler(MessageCounter counter, ILogger<TestHandler> log) : BaseEventHandler {
+public class TestHandler(MessageCounter counter, ILogger<TestHandler> log) : BaseEventHandler {
     public override async ValueTask<EventHandlingStatus> HandleEvent(IMessageConsumeContext context) {
         await Task.Delay(10, context.CancellationToken);
         counter.Increment();

--- a/src/Diagnostics/test/Eventuous.Tests.OpenTelemetry/MetricsTests.cs
+++ b/src/Diagnostics/test/Eventuous.Tests.OpenTelemetry/MetricsTests.cs
@@ -62,6 +62,67 @@ public abstract class MetricsTestsBase(IMetricsSubscriptionFixtureBase fixture) 
     MetricValue[]? _values;
 }
 
+/// <summary>
+/// Observes <c>eventuous.subscription.gap.count</c> through the real pipeline — the meter registered by
+/// <c>AddEventuousSubscriptions</c>, the measure resolved from DI, the checkpoint-commit listener and the gap
+/// arithmetic in <see cref="SubscriptionMetrics"/> — rather than calling the subscription's measure directly.
+/// Reproduces GitHub #586 at the metric level: a longer, unrelated stream must not inflate the gap reported for a
+/// caught-up stream subscription.
+/// </summary>
+public abstract class SubscriptionGapMetricsTestsBase(IMetricsSubscriptionFixtureBase fixture) {
+    protected async Task ShouldReportZeroGapWhenCaughtUp(CancellationToken cancellationToken) {
+        var other = new StreamName($"other-{Guid.NewGuid():N}");
+        await fixture.Producer.Produce(other, TestEvent.CreateMany(fixture.Count * 2), new(), cancellationToken: cancellationToken);
+        await fixture.Producer.Produce(fixture.Stream, TestEvent.CreateMany(fixture.Count), new(), cancellationToken: cancellationToken);
+
+        await WaitUntil(() => fixture.Counter.Count >= fixture.Count, TimeSpan.FromSeconds(30), cancellationToken);
+        await Assert.That(fixture.Counter.Count).IsEqualTo(fixture.Count);
+
+        // The checkpoint behind the gap commits on a batch or a delay, so the gauge converges on zero rather than
+        // reading it the moment the last event is handled.
+        var gap = await WaitForGapCount(0, TimeSpan.FromSeconds(15), cancellationToken);
+
+        await Assert.That(gap).IsNotNull();
+        await Assert.That(gap!.Value).IsEqualTo(0d);
+        await gap.CheckTag(SubscriptionMetrics.SubscriptionIdTag, fixture.SubscriptionId);
+        await gap.CheckTag(fixture.DefaultTagKey, fixture.DefaultTagValue);
+    }
+
+    /// <summary>
+    /// Polls the exporter until the gap gauge reads <paramref name="expected"/> or the timeout elapses, returning the
+    /// last observation either way so a failure shows the value that was actually reported.
+    /// </summary>
+    async Task<MetricValue?> WaitForGapCount(double expected, TimeSpan timeout, CancellationToken cancellationToken) {
+        MetricValue? gap      = null;
+        var          deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline) {
+            fixture.Exporter.Collect(Timeout.Infinite);
+            gap = fixture.Exporter.CollectValues().FirstOrDefault(x => x.Name == SubscriptionMetrics.GapCountMetricName);
+            TestContext.Current?.OutputWriter.WriteLine($"Gap: {gap?.Value.ToString() ?? "not reported"}");
+
+            if (gap?.Value == expected) break;
+
+            await Task.Delay(200, cancellationToken);
+        }
+
+        return gap;
+    }
+
+    static async Task WaitUntil(Func<bool> condition, TimeSpan timeout, CancellationToken cancellationToken) {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (!condition() && DateTime.UtcNow < deadline) {
+            await Task.Delay(100, cancellationToken);
+        }
+    }
+
+    [After(Test)]
+    public void Teardown() => _es.Dispose();
+
+    readonly TestEventListener _es = new(null, "OpenTelemetry");
+}
+
 static class TagExtensions {
     extension(MetricValue metric) {
         public async Task CheckTag(string tag, string expectedValue) {

--- a/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Metrics/MetricsTests.cs
+++ b/src/KurrentDB/test/Eventuous.Tests.KurrentDB/Metrics/MetricsTests.cs
@@ -11,3 +11,12 @@ public class MetricsTests(MetricsFixture fixture) : MetricsTestsBase(fixture) {
         await ShouldMeasureSubscriptionGapCountBase();
     }
 }
+
+[ClassDataSource<MetricsFixture>]
+[NotInParallel]
+public class SubscriptionGapMetricsTests(MetricsFixture fixture) : SubscriptionGapMetricsTestsBase(fixture) {
+    [Test]
+    public async Task ShouldReportZeroGapWhenCaughtUp_Esdb(CancellationToken cancellationToken) {
+        await ShouldReportZeroGapWhenCaughtUp(cancellationToken);
+    }
+}

--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresAllStreamSubscription.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresAllStreamSubscription.cs
@@ -38,6 +38,9 @@ public class PostgresAllStreamSubscription(
         => connection.GetCommand(Schema.ReadAllForwards)
             .Add("_from_position", NpgsqlDbType.Bigint, start + 1)
             .Add("_count", NpgsqlDbType.Integer, Options.MaxPageSize);
+
+    protected override NpgsqlCommand PrepareEndOfStreamCommand(NpgsqlConnection connection)
+        => connection.GetCommand($"select max(global_position) from {Schema.Name}.messages");
 }
 
 public record PostgresAllStreamSubscriptionOptions : PostgresSubscriptionBaseOptions;

--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresStreamSubscription.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresStreamSubscription.cs
@@ -40,6 +40,19 @@ public class PostgresStreamSubscription(
             .Add("_from_position", NpgsqlDbType.Integer, (int)start + 1)
             .Add("_count", NpgsqlDbType.Integer, Options.MaxPageSize);
 
+    // Filtered by name rather than the id resolved in BeforeSubscribe, so the measure is valid before the
+    // subscription connects; a stream that doesn't exist yet reads as empty.
+    protected override NpgsqlCommand PrepareEndOfStreamCommand(NpgsqlConnection connection)
+        => connection.GetCommand(
+                $"""
+                 select max(m.stream_position)
+                 from {Schema.Name}.messages m
+                 inner join {Schema.Name}.streams s on s.stream_id = m.stream_id
+                 where s.stream_name = @_stream_name
+                 """
+            )
+            .Add("_stream_name", NpgsqlDbType.Varchar, _streamName);
+
     protected override async Task BeforeSubscribe(CancellationToken cancellationToken) {
         await using var connection = await DataSource.OpenConnectionAsync(cancellationToken).NoContext();
 

--- a/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresSubscriptionBase.cs
+++ b/src/Postgres/src/Eventuous.Postgresql/Subscriptions/PostgresSubscriptionBase.cs
@@ -45,9 +45,6 @@ public abstract class PostgresSubscriptionBase<T>(
 
     protected override bool IsTransient(Exception exception) => exception is PostgresException { IsTransient: true };
 
-    protected override string GetEndOfStream { get; } = $"select max(stream_position) from {options.Schema}.messages";
-    protected override string GetEndOfAll    { get; } = $"select max(global_position) from {options.Schema}.messages";
-
     protected override async ValueTask HandleGapTimeout(long gapPosition, long currentStart, CancellationToken cancellationToken) {
         try {
             await using var connection = await DataSource.OpenConnectionAsync(cancellationToken).NoContext();

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionMeasureTests.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/SubscriptionMeasureTests.cs
@@ -18,3 +18,18 @@ public class SubscriptionMeasure()
         await ShouldMeasureEndOfStream(cancellationToken);
     }
 }
+
+[ClassDataSource<StreamNameFixture>(Shared = SharedType.None)]
+[NotInParallel]
+public class StreamSubscriptionMeasure(StreamNameFixture streamNameFixture)
+    : SubscriptionMeasureBase<PostgreSqlContainer, PostgresStreamSubscription, PostgresStreamSubscriptionOptions, PostgresCheckpointStore>(
+        new SubscriptionFixture<PostgresStore, PostgresStreamSubscription, PostgresStreamSubscriptionOptions, TestEventHandler>(
+            opt => opt.Stream = streamNameFixture.StreamName,
+            false
+        )
+    ) {
+    [Test]
+    public async Task Postgres_ShouldMeasureEndOfSubscribedStream(CancellationToken cancellationToken) {
+        await ShouldMeasureEndOfSubscribedStream(streamNameFixture.StreamName, cancellationToken);
+    }
+}

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
@@ -1,7 +1,6 @@
 // Copyright (C) Eventuous HQ OÜ. All rights reserved
 // Licensed under the Apache License, Version 2.0.
 
-using System.Data;
 using System.Data.Common;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -321,26 +320,23 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
     GetSubscriptionEndOfStream IMeasuredSubscription.GetMeasure() => GetSubscriptionEndOfStream;
 
     /// <summary>
-    /// Get SQL statement to get the end of the stream
+    /// Prepares a command that returns the position the subscription gap is measured against: the last global
+    /// position for an <see cref="SubscriptionKind.All"/> subscription, or the last position within the subscribed
+    /// stream for a <see cref="SubscriptionKind.Stream"/> one. The position is read from the first column of the
+    /// first row and may be <c>NULL</c> when there is nothing to measure yet.
     /// </summary>
-    protected abstract string GetEndOfStream { get; }
-
-    /// <summary>
-    /// Get SQL statement to get the end of the global log
-    /// </summary>
-    protected abstract string GetEndOfAll { get; }
+    /// <param name="connection">Connection that can be used to create the command</param>
+    /// <remarks>
+    /// The measure is also handed to the metrics observer, which can invoke it before the subscription has ever
+    /// connected, so the command must not depend on state resolved in <see cref="BeforeSubscribe"/>.
+    /// </remarks>
+    protected abstract DbCommand PrepareEndOfStreamCommand(TConnection connection);
 
     async ValueTask<EndOfStream> GetSubscriptionEndOfStream(CancellationToken cancellationToken) {
         try {
             await using var connection = await OpenConnection(cancellationToken).NoContext();
-            await using var cmd        = connection.CreateCommand();
-            cmd.CommandType = CommandType.Text;
-
-            cmd.CommandText = Kind switch {
-                SubscriptionKind.All    => GetEndOfAll,
-                SubscriptionKind.Stream => GetEndOfStream
-            };
-            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).NoContext();
+            await using var cmd        = PrepareEndOfStreamCommand(connection);
+            await using var reader     = await cmd.ExecuteReaderAsync(cancellationToken).NoContext();
 
             // MAX(...) returns NULL on an empty table, and providers may return the position column as either
             // Int32 or Int64, so guard against DBNull and convert rather than calling the strict GetInt64.

--- a/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerAllStreamSubscription.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerAllStreamSubscription.cs
@@ -37,6 +37,9 @@ public class SqlServerAllStreamSubscription(
         => connection.GetStoredProcCommand(Schema.ReadAllForwards)
             .Add("@from_position", SqlDbType.BigInt, start + 1)
             .Add("@count", SqlDbType.Int, Options.MaxPageSize);
+
+    protected override SqlCommand PrepareEndOfStreamCommand(SqlConnection connection)
+        => connection.GetTextCommand($"SELECT MAX(GlobalPosition) FROM {Schema.SchemaName}.Messages");
 }
 
 public record SqlServerAllStreamSubscriptionOptions : SqlServerSubscriptionBaseOptions;

--- a/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerStreamSubscription.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerStreamSubscription.cs
@@ -40,6 +40,19 @@ public class SqlServerStreamSubscription(
             .Add("@from_position", SqlDbType.Int, (int)start + 1)
             .Add("@count", SqlDbType.Int, Options.MaxPageSize);
 
+    // Filtered by name rather than the id resolved in BeforeSubscribe, so the measure is valid before the
+    // subscription connects; a stream that doesn't exist yet reads as empty.
+    protected override SqlCommand PrepareEndOfStreamCommand(SqlConnection connection)
+        => connection.GetTextCommand(
+                $"""
+                 SELECT MAX(m.StreamPosition)
+                 FROM {Schema.SchemaName}.Messages m
+                 INNER JOIN {Schema.SchemaName}.Streams s ON s.StreamId = m.StreamId
+                 WHERE s.StreamName = @stream_name
+                 """
+            )
+            .Add("@stream_name", SqlDbType.NVarChar, _streamName);
+
     protected override async Task BeforeSubscribe(CancellationToken cancellationToken) {
         await using var connection = await OpenConnection(cancellationToken).NoContext();
 

--- a/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerSubscriptionBase.cs
+++ b/src/SqlServer/src/Eventuous.SqlServer/Subscriptions/SqlServerSubscriptionBase.cs
@@ -31,8 +31,6 @@ public abstract class SqlServerSubscriptionBase<T> : SqlSubscriptionBase<T, SqlC
         );
         var connectionString = connectionOptions?.ConnectionString ?? options.ConnectionString;
         _connectionString = Ensure.NotEmptyString(connectionString);
-        GetEndOfStream    = $"SELECT MAX(StreamPosition) FROM {options.Schema}.Messages";
-        GetEndOfAll       = $"SELECT MAX(GlobalPosition) FROM {options.Schema}.Messages";
     }
 
     protected override async ValueTask<SqlConnection> OpenConnection(CancellationToken cancellationToken)
@@ -51,9 +49,6 @@ public abstract class SqlServerSubscriptionBase<T> : SqlSubscriptionBase<T, SqlC
                 sqlException.Number == 3980 && sqlException.Message.Contains("Operation cancelled by user."),
             _ => false
         };
-
-    protected override string GetEndOfStream { get; }
-    protected override string GetEndOfAll    { get; }
 }
 
 public abstract record SqlServerSubscriptionBaseOptions : SqlSubscriptionOptionsBase {

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Metrics/MetricsTests.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Metrics/MetricsTests.cs
@@ -11,3 +11,12 @@ public class MetricsTests(MetricsFixture fixture) : MetricsTestsBase(fixture) {
         await ShouldMeasureSubscriptionGapCountBase();
     }
 }
+
+[ClassDataSource<MetricsFixture>]
+[NotInParallel]
+public class SubscriptionGapMetricsTests(MetricsFixture fixture) : SubscriptionGapMetricsTestsBase(fixture) {
+    [Test]
+    public async Task ShouldReportZeroGapWhenCaughtUp_SqlServer(CancellationToken cancellationToken) {
+        await ShouldReportZeroGapWhenCaughtUp(cancellationToken);
+    }
+}

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/ConnectionStringTests.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/ConnectionStringTests.cs
@@ -145,6 +145,14 @@ public class TestSubscription(
 
         return command;
     }
+
+    protected override SqlCommand PrepareEndOfStreamCommand(SqlConnection connection) {
+        var command = connection.CreateCommand();
+        command.CommandType = CommandType.Text;
+        command.CommandText = "SELECT MAX(GlobalPosition) FROM dbo.Messages";
+
+        return command;
+    }
 }
 
 /// <summary>

--- a/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/SubscriptionMeasureTests.cs
+++ b/src/SqlServer/test/Eventuous.Tests.SqlServer/Subscriptions/SubscriptionMeasureTests.cs
@@ -17,3 +17,18 @@ public class SubscriptionMeasure()
         await ShouldMeasureEndOfStream(cancellationToken);
     }
 }
+
+[ClassDataSource<StreamNameFixture>(Shared = SharedType.None)]
+[NotInParallel]
+public class StreamSubscriptionMeasure(StreamNameFixture streamNameFixture)
+    : SubscriptionMeasureBase<MsSqlContainer, SqlServerStreamSubscription, SqlServerStreamSubscriptionOptions, SqlServerCheckpointStore>(
+        new SubscriptionFixture<SqlServerStreamSubscription, SqlServerStreamSubscriptionOptions, TestEventHandler>(
+            opt => opt.Stream = streamNameFixture.StreamName,
+            false
+        )
+    ) {
+    [Test]
+    public async Task SqlServer_ShouldMeasureEndOfSubscribedStream(CancellationToken cancellationToken) {
+        await ShouldMeasureEndOfSubscribedStream(streamNameFixture.StreamName, cancellationToken);
+    }
+}

--- a/src/Sqlite/src/Eventuous.Sqlite/Subscriptions/SqliteAllStreamSubscription.cs
+++ b/src/Sqlite/src/Eventuous.Sqlite/Subscriptions/SqliteAllStreamSubscription.cs
@@ -47,6 +47,9 @@ public class SqliteAllStreamSubscription(
             )
             .Add("@from_position", start + 1)
             .Add("@count", Options.MaxPageSize);
+
+    protected override SqliteCommand PrepareEndOfStreamCommand(SqliteConnection connection)
+        => connection.GetTextCommand($"SELECT MAX(global_position) FROM {Schema.MessagesTable}");
 }
 
 public record SqliteAllStreamSubscriptionOptions : SqliteSubscriptionBaseOptions;

--- a/src/Sqlite/src/Eventuous.Sqlite/Subscriptions/SqliteStreamSubscription.cs
+++ b/src/Sqlite/src/Eventuous.Sqlite/Subscriptions/SqliteStreamSubscription.cs
@@ -49,6 +49,19 @@ public class SqliteStreamSubscription(
             .Add("@from_position", (int)start + 1)
             .Add("@count", Options.MaxPageSize);
 
+    // Filtered by name rather than the id resolved in BeforeSubscribe, so the measure is valid before the
+    // subscription connects; a stream that doesn't exist yet reads as empty.
+    protected override SqliteCommand PrepareEndOfStreamCommand(SqliteConnection connection)
+        => connection.GetTextCommand(
+                $"""
+                 SELECT MAX(m.stream_position)
+                 FROM {Schema.MessagesTable} m
+                 INNER JOIN {Schema.StreamsTable} s ON s.stream_id = m.stream_id
+                 WHERE s.stream_name = @stream_name
+                 """
+            )
+            .Add("@stream_name", _streamName);
+
     protected override async Task BeforeSubscribe(CancellationToken cancellationToken) {
         await using var connection = await OpenConnection(cancellationToken).NoContext();
 

--- a/src/Sqlite/src/Eventuous.Sqlite/Subscriptions/SqliteSubscriptionBase.cs
+++ b/src/Sqlite/src/Eventuous.Sqlite/Subscriptions/SqliteSubscriptionBase.cs
@@ -31,8 +31,6 @@ public abstract class SqliteSubscriptionBase<T> : SqlSubscriptionBase<T, SqliteC
         );
         var connectionString = connectionOptions?.ConnectionString ?? options.ConnectionString;
         _connectionString = Ensure.NotEmptyString(connectionString);
-        GetEndOfStream    = $"SELECT MAX(stream_position) FROM {Schema.MessagesTable}";
-        GetEndOfAll       = $"SELECT MAX(global_position) FROM {Schema.MessagesTable}";
     }
 
     protected override async ValueTask<SqliteConnection> OpenConnection(CancellationToken cancellationToken)
@@ -42,9 +40,6 @@ public abstract class SqliteSubscriptionBase<T> : SqlSubscriptionBase<T, SqliteC
 
     protected override bool IsStopping(Exception exception)
         => exception is OperationCanceledException;
-
-    protected override string GetEndOfStream { get; }
-    protected override string GetEndOfAll    { get; }
 }
 
 public abstract record SqliteSubscriptionBaseOptions : SqlSubscriptionOptionsBase {

--- a/src/Sqlite/test/Eventuous.Tests.Sqlite/Metrics/MetricsFixture.cs
+++ b/src/Sqlite/test/Eventuous.Tests.Sqlite/Metrics/MetricsFixture.cs
@@ -1,0 +1,75 @@
+using Eventuous.Diagnostics;
+using Eventuous.Diagnostics.OpenTelemetry;
+using Eventuous.Producers;
+using Eventuous.Sql.Base.Producers;
+using Eventuous.Sqlite;
+using Eventuous.Sqlite.Subscriptions;
+using Eventuous.Subscriptions.Checkpoints;
+using Eventuous.Subscriptions.Registrations;
+using Eventuous.TestHelpers.TUnit.Logging;
+using Eventuous.Tests.OpenTelemetry.Fakes;
+using Eventuous.Tests.OpenTelemetry.Fixtures;
+using Eventuous.Tests.Sqlite.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Metrics;
+
+namespace Eventuous.Tests.Sqlite.Metrics;
+
+/// <summary>
+/// SQLite counterpart of <see cref="MetricsSubscriptionFixtureBase{TContainer,TProducer,TSubscription,TSubscriptionOptions}"/>,
+/// built on the container-less <see cref="SqliteStoreFixtureBase"/>.
+/// </summary>
+public class MetricsFixture : SqliteStoreFixtureBase, IMetricsSubscriptionFixtureBase {
+    static readonly KeyValuePair<string, string> DefaultTag = new("test", "foo");
+
+    readonly string _schemaName = GetSchemaName();
+
+    static MetricsFixture() => EventuousDiagnostics.AddDefaultTag(DefaultTag.Key, DefaultTag.Value);
+
+    public MetricsFixture() => TypeMapper.RegisterKnownEventTypes(typeof(TestEvent).Assembly);
+
+    public int            Count           => 100;
+    public StreamName     Stream          { get; }              = new($"test-{Guid.NewGuid():N}");
+    public string         DefaultTagKey   => DefaultTag.Key;
+    public string         DefaultTagValue => DefaultTag.Value;
+    public string         SubscriptionId  => "test-sub";
+    public IProducer      Producer        { get; private set; } = null!;
+    public MessageCounter Counter         { get; private set; } = null!;
+    public TestExporter   Exporter        { get; }              = new();
+
+    protected override void SetupServices(IServiceCollection services) {
+        services.AddEventuousSqlite(ConnectionString, _schemaName, true);
+        services.AddEventStore<SqliteStore>();
+        services.AddProducer<UniversalProducer>();
+        services.AddSingleton<MessageCounter>();
+
+        services.AddSubscription<SqliteStreamSubscription, SqliteStreamSubscriptionOptions>(
+            SubscriptionId,
+            builder => builder
+                .Configure(
+                    options => {
+                        options.Schema           = _schemaName;
+                        options.ConnectionString = ConnectionString;
+                        options.Stream           = Stream;
+                    }
+                )
+                .UseCheckpointStore<NoOpCheckpointStore>()
+                .AddEventHandler<TestHandler>()
+        );
+
+        services.AddOpenTelemetry().WithMetrics(builder => builder.AddEventuousSubscriptions().AddReader(new BaseExportingMetricReader(Exporter)));
+    }
+
+    protected override void GetDependencies(IServiceProvider provider) {
+        provider.AddEventuousLogs();
+        Producer = provider.GetRequiredService<UniversalProducer>();
+        Counter  = provider.GetRequiredService<MessageCounter>();
+    }
+
+    public override async ValueTask DisposeAsync() {
+        await base.DisposeAsync();
+        Exporter.Dispose();
+    }
+}

--- a/src/Sqlite/test/Eventuous.Tests.Sqlite/Metrics/MetricsTests.cs
+++ b/src/Sqlite/test/Eventuous.Tests.Sqlite/Metrics/MetricsTests.cs
@@ -1,13 +1,13 @@
 using Eventuous.Tests.OpenTelemetry;
 
-namespace Eventuous.Tests.Postgres.Metrics;
+namespace Eventuous.Tests.Sqlite.Metrics;
 
 [ClassDataSource<MetricsFixture>]
 [NotInParallel]
 public class MetricsTests(MetricsFixture fixture) : MetricsTestsBase(fixture) {
     [Test]
     [Retry(3)]
-    public async Task ShouldMeasureSubscriptionGapCountBase_Postgres() {
+    public async Task ShouldMeasureSubscriptionGapCountBase_Sqlite() {
         await ShouldMeasureSubscriptionGapCountBase();
     }
 }
@@ -16,7 +16,7 @@ public class MetricsTests(MetricsFixture fixture) : MetricsTestsBase(fixture) {
 [NotInParallel]
 public class SubscriptionGapMetricsTests(MetricsFixture fixture) : SubscriptionGapMetricsTestsBase(fixture) {
     [Test]
-    public async Task ShouldReportZeroGapWhenCaughtUp_Postgres(CancellationToken cancellationToken) {
+    public async Task ShouldReportZeroGapWhenCaughtUp_Sqlite(CancellationToken cancellationToken) {
         await ShouldReportZeroGapWhenCaughtUp(cancellationToken);
     }
 }

--- a/src/Sqlite/test/Eventuous.Tests.Sqlite/Subscriptions/SubscriptionFixture.cs
+++ b/src/Sqlite/test/Eventuous.Tests.Sqlite/Subscriptions/SubscriptionFixture.cs
@@ -4,6 +4,7 @@ using Eventuous.Sqlite;
 using Eventuous.Sqlite.Subscriptions;
 using Eventuous.Subscriptions;
 using Eventuous.Subscriptions.Checkpoints;
+using Eventuous.Subscriptions.Diagnostics;
 using Eventuous.Sut.Domain;
 using Eventuous.TestHelpers;
 using Eventuous.TestHelpers.TUnit.Logging;
@@ -100,6 +101,11 @@ public partial class SubscriptionFixture<TSubscription, TSubscriptionOptions, TE
     internal ValueTask StartSubscription() => Subscription.SubscribeWithLog(Log);
 
     internal ValueTask StopSubscription() => Subscription.UnsubscribeWithLog(Log);
+
+    /// <summary>
+    /// Returns the subscription's end-of-stream measure delegate (requires an <see cref="IMeasuredSubscription"/>).
+    /// </summary>
+    internal GetSubscriptionEndOfStream GetMeasure() => ((IMeasuredSubscription)Subscription).GetMeasure();
 
     public async Task<ulong> GetLastPosition() {
         await using var connection = await ConnectionFactory.GetConnection(ConnectionString, default);

--- a/src/Sqlite/test/Eventuous.Tests.Sqlite/Subscriptions/SubscriptionMeasureTests.cs
+++ b/src/Sqlite/test/Eventuous.Tests.Sqlite/Subscriptions/SubscriptionMeasureTests.cs
@@ -1,0 +1,101 @@
+using Eventuous.Sqlite.Subscriptions;
+using Eventuous.Sut.App;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+using static Eventuous.Sut.Domain.BookingEvents;
+
+// ReSharper disable UnusedType.Global
+
+namespace Eventuous.Tests.Sqlite.Subscriptions;
+
+/// <summary>
+/// SQLite counterpart of <see cref="SubscriptionMeasureBase{TContainer,TSubscription,TSubscriptionOptions,TCheckpointStore}"/>,
+/// written against the standalone SQLite fixture since it isn't container-backed.
+/// </summary>
+[NotInParallel]
+public class SubscriptionMeasure() : SubscriptionTestBase(Fixture) {
+    static readonly SubscriptionFixture<SqliteAllStreamSubscription, SqliteAllStreamSubscriptionOptions, TestEventHandler> Fixture
+        = new(_ => { }, false);
+
+    [Test]
+    public async Task Sqlite_ShouldMeasureEndOfStream(CancellationToken cancellationToken) {
+        var measure = Fixture.GetMeasure();
+
+        // An empty store must yield a valid measure at position zero, not EndOfStream.Invalid.
+        var empty = await measure(cancellationToken);
+        await Assert.That(empty.SubscriptionId).IsEqualTo(Fixture.SubscriptionId);
+        await Assert.That(empty.Position).IsEqualTo(0ul);
+
+        // After appending events, the measure must report the global end position.
+        await GenerateAndHandleCommands(10);
+        var last = await Fixture.GetLastPosition();
+
+        var measured = await measure(cancellationToken);
+        await Assert.That(measured.SubscriptionId).IsEqualTo(Fixture.SubscriptionId);
+        await Assert.That(measured.Position).IsEqualTo(last);
+    }
+
+    static async Task GenerateAndHandleCommands(int count) {
+        var commands = Enumerable
+            .Range(0, count)
+            .Select(_ => DomainFixture.CreateImportBooking())
+            .ToList();
+
+        var service = new BookingService(Fixture.EventStore);
+
+        foreach (var cmd in commands) {
+            var result = await service.Handle(cmd, default);
+            result.ThrowIfError();
+        }
+    }
+}
+
+/// <summary>
+/// For a stream subscription, the measure must report the tail of the subscribed stream only (GitHub #586).
+/// </summary>
+[NotInParallel]
+public class StreamSubscriptionMeasure() : SubscriptionTestBase(Fixture) {
+    static readonly StreamName StreamName = new(Guid.NewGuid().ToString());
+
+    static readonly SubscriptionFixture<SqliteStreamSubscription, SqliteStreamSubscriptionOptions, TestEventHandler> Fixture
+        = new(opt => opt.Stream = StreamName, false);
+
+    [Test]
+    public async Task Sqlite_ShouldMeasureEndOfSubscribedStream(CancellationToken cancellationToken) {
+        const int otherStreamLength      = 20;
+        const int subscribedStreamLength = 5;
+
+        var measure = Fixture.GetMeasure();
+
+        // Invoked before the subscription has ever connected, as the metrics observer does. The subscribed stream
+        // doesn't exist yet, which must read as an empty stream rather than EndOfStream.Invalid.
+        var empty = await measure(cancellationToken);
+        await Assert.That(empty.SubscriptionId).IsEqualTo(Fixture.SubscriptionId);
+        await Assert.That(empty.Position).IsEqualTo(0ul);
+
+        // A longer, unrelated stream: its tail must not leak into the subscribed stream's measure.
+        await AppendEvents(new($"other-{Guid.NewGuid():N}"), otherStreamLength);
+        var events = await AppendEvents(StreamName, subscribedStreamLength);
+
+        var measured = await measure(cancellationToken);
+        await Assert.That(measured.SubscriptionId).IsEqualTo(Fixture.SubscriptionId);
+        await Assert.That(measured.Position).IsEqualTo((ulong)(subscribedStreamLength - 1));
+
+        await Fixture.StartSubscription();
+        await Fixture.Handler.AssertCollection(TimeSpan.FromSeconds(5), [.. events]).Validate(cancellationToken);
+        await Fixture.StopSubscription();
+
+        // Once caught up, the gap the metrics derive from this measure and the checkpoint must be zero.
+        var checkpoint = await Fixture.CheckpointStore.GetLastCheckpoint(Fixture.SubscriptionId, cancellationToken);
+        var caughtUp   = await measure(cancellationToken);
+        await Assert.That(caughtUp.Position - checkpoint.Position!.Value).IsEqualTo(0ul);
+    }
+
+    static async Task<List<BookingImported>> AppendEvents(StreamName streamName, int count) {
+        var events       = Enumerable.Range(0, count).Select(_ => Helpers.CreateEvent()).ToList();
+        var streamEvents = events.Select(x => new NewStreamEvent(Guid.NewGuid(), x, new()));
+        await Fixture.EventStore.AppendEvents(streamName, ExpectedStreamVersion.NoStream, [.. streamEvents], default);
+
+        return events;
+    }
+}


### PR DESCRIPTION
Closes #586

## Problem

For relational stream subscriptions (SQL Server, PostgreSQL, SQLite), the end-of-stream measure behind the subscription gap metric was a constant MAX(stream_position) over the whole messages table, with no stream filter. The checkpoint it is compared against is a position within the subscribed stream, so:

- eventuous.subscription.gap.count was inflated by (longest stream length - subscribed stream length) and never reached zero for a caught-up subscription.
- StartFrom = Latest could seed a stream subscription checkpoint from an unrelated stream.

SubscriptionKind.All was unaffected.

## Fix

- SqlSubscriptionBase: the GetEndOfStream / GetEndOfAll string properties are replaced by a single protected abstract DbCommand PrepareEndOfStreamCommand(TConnection connection) hook, mirroring the existing PrepareCommand. The Kind switch in the base is gone; each concrete subscription prepares its own command.
- All-stream subscriptions keep MAX(global_position).
- Stream subscriptions return MAX(stream_position) joined to the streams table and filtered on stream_name.

**Deviation from the issue suggestion:** the stream filter uses the stream name from options rather than the stream id resolved in BeforeSubscribe. The measure is registered in DI and polled by SubscriptionMetrics from an observable gauge, which can happen before the subscription has ever connected; filtering by name makes the measure correct at any time instead of returning EndOfStream.Invalid until connect. A stream that does not exist yet reads as empty (position 0), consistent with the empty-store semantics established in #551.

Side effect: SQL Server and PostgreSQL now build the measure SQL from the resolved Schema (the same one PrepareCommand uses) instead of options.Schema, so it follows connection-options schema overrides like polling does.

**Breaking for direct subclasses of SqlSubscriptionBase / the provider bases:** GetEndOfStream and GetEndOfAll are removed in favour of PrepareEndOfStreamCommand. No references in eventuous-docs or eventuous-plugin.

## Tests

Measure level (unit check of the PrepareEndOfStreamCommand contract):

- SubscriptionMeasureBase.ShouldMeasureEndOfSubscribedStream: 20 events to an unrelated stream, 5 to the subscribed one, assert the measure reports position 4 (was 19), then catch up and assert the gap is zero. Also calls the measure before the subscription connects to cover the DI/metrics path.
- Wired for PostgreSQL and SQL Server via new StreamSubscriptionMeasure test classes.
- SQLite gets its own SubscriptionMeasureTests (stream scenario plus the all-stream scenario from #551 it was missing) and a GetMeasure() on its fixture.
- The test-only TestSubscription in ConnectionStringTests implements the new hook.

Metric level (added after review, so a regression in the metrics pipeline itself is caught):

- SubscriptionGapMetricsTestsBase.ShouldReportZeroGapWhenCaughtUp observes the exported eventuous.subscription.gap.count gauge through AddEventuousSubscriptions and SubscriptionMetrics (the DI-registered measure, the checkpoint-commit listener, the gap arithmetic and the tags) rather than computing the gap from the delegate. It produces a longer unrelated stream next to the subscribed one, waits for the subscription to catch up, then polls the gauge until it reads zero (checkpoints commit on a batch or a delay).
- Wired for PostgreSQL, SQL Server, KurrentDB and SQLite. SQLite gets a container-less MetricsFixture on SqliteStoreFixtureBase plus the existing gap-count test for parity; TestHandler in the OpenTelemetry test fakes is now public for that.

## Verification

- Measure level, RED on SQLite and PostgreSQL against the unfixed code: Expected 4 but received 19. GREEN: SQLite measure 2/2, PostgreSQL measure 2/2; full subscription suites SQLite 13/13, PostgreSQL 16/16 (including SubscribeToAllFromEnd, which seeds from the measure).
- Metric level, RED against the unfixed library: the gauge reads 100 (other stream tail 199 minus checkpoint 99) and the test fails. GREEN locally: SQLite, PostgreSQL and KurrentDB metrics tests 2/2 each.
- Full solution build: 0 errors, no warnings in the touched projects.
- SQL Server tests are excluded on macOS at the assembly level, so they did not run locally; the SQL Server project builds clean and this PR relies on CI for execution (first run: sqlserver shard 54/54, 0 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)