### PR TITLE
fix(subscriptions): release relational gaps once the skip timeout expires

### DIFF
--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapAgeReleaseWhileRunningTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapAgeReleaseWhileRunningTest.cs
@@ -1,0 +1,47 @@
+// Copyright (C) Eventuous HQ OÜ. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class GapAgeReleaseWhileRunningTest() : SubscriptionTestBase(Fixture) {
+    static readonly TombstonesFixture Fixture = new(ConfigureOptions);
+
+    const int AgeThresholdMs = 2000;
+
+    /// <summary>
+    /// The age threshold has to release a gap that was first detected while the event following it was still
+    /// young, not only one that was already old when the subscription started. With no skip timeout and no
+    /// remediation configured — the defaults — it is the only thing that ever lets the subscription past a
+    /// position no transaction will fill.
+    /// </summary>
+    [Test]
+    public async Task ShouldReleaseGapThatAgesOutWhileSubscribed(CancellationToken cancellationToken) {
+        await Fixture.ArrangePermanentGap(new("test-stream-gap-ages-out"));
+
+        await Fixture.StartSubscription();
+
+        // The event after the gap is younger than the threshold, so the subscription holds at the gap
+        await Task.Delay(AgeThresholdMs / 4, cancellationToken);
+        await Assert.That(Fixture.Handler.Handled.Count).IsEqualTo(2);
+
+        // Once that event is older than GapAgeThresholdMs the gap is abandoned and the rest is handled
+        var handled = await Fixture.WaitForHandled(5, TimeSpan.FromSeconds(10), cancellationToken);
+        await Assert.That(handled).IsEqualTo(5);
+
+        await Fixture.StopSubscription();
+
+        var tombstonesCount = await Fixture.CountTombstones();
+        await Assert.That(tombstonesCount).IsEqualTo(0);
+    }
+
+    static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
+        options.GapAgeThresholdMs    = AgeThresholdMs;
+        options.GapSkipTimeoutMs     = null; // the default: never abandon a position on elapsed time alone
+        options.GapHandlingTimeoutMs = null; // the default: no remediation
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapRemediationBeforeSkipTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapRemediationBeforeSkipTest.cs
@@ -1,0 +1,46 @@
+// Copyright (C) Eventuous HQ OÜ. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class GapRemediationBeforeSkipTest() : SubscriptionTestBase(Fixture) {
+    static readonly TombstonesFixture Fixture = new(ConfigureOptions);
+
+    [Test]
+    public async Task ShouldCreateTombstoneBeforeSkippingGap(CancellationToken cancellationToken) {
+        var streamName = new StreamName("test-stream-gap-remediation");
+
+        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(2)], ExpectedStreamVersion.NoStream);
+
+        await Fixture.InsertGap(streamName, 1);
+
+        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(3)], ExpectedStreamVersion.Any);
+
+        await Fixture.StartSubscription();
+
+        await Fixture.Handler.AssertThat()
+            .Timebox(TimeSpan.FromSeconds(10))
+            .Exactly(5)
+            .Match(_ => true)
+            .Validate(cancellationToken);
+
+        await Fixture.StopSubscription();
+
+        // The tombstone resolves the gap safely: it can only be inserted once the position is proven dead,
+        // so it must be attempted before the skip timeout is allowed to advance the subscription past it.
+        var tombstonesCount = await Fixture.CountTombstones();
+        await Assert.That(tombstonesCount).IsEqualTo(1);
+    }
+
+    static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
+        // Both timeouts expire on the same poll, so remediation only runs if it takes precedence over the skip
+        options.GapHandlingTimeoutMs = 500;
+        options.GapSkipTimeoutMs     = 500;
+        options.GapAgeThresholdMs    = null; // the gap must not be released by age
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapRemediationBeforeSkipTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapRemediationBeforeSkipTest.cs
@@ -11,36 +11,36 @@ namespace Eventuous.Tests.Postgres.Subscriptions;
 public class GapRemediationBeforeSkipTest() : SubscriptionTestBase(Fixture) {
     static readonly TombstonesFixture Fixture = new(ConfigureOptions);
 
+    const int TimeoutMs = 2000;
+
+    /// <summary>
+    /// Both timeouts expire on the same poll, so remediation only runs if it takes precedence over the skip.
+    /// The tombstone resolves the position safely — it conflicts with a committed row and blocks on an
+    /// in-flight one — where skipping abandons it on elapsed time alone.
+    /// </summary>
     [Test]
     public async Task ShouldCreateTombstoneBeforeSkippingGap(CancellationToken cancellationToken) {
-        var streamName = new StreamName("test-stream-gap-remediation");
-
-        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(2)], ExpectedStreamVersion.NoStream);
-
-        await Fixture.InsertGap(streamName, 1);
-
-        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(3)], ExpectedStreamVersion.Any);
+        await Fixture.ArrangePermanentGap(new("test-stream-gap-remediation"));
 
         await Fixture.StartSubscription();
 
-        await Fixture.Handler.AssertThat()
-            .Timebox(TimeSpan.FromSeconds(10))
-            .Exactly(5)
-            .Match(_ => true)
-            .Validate(cancellationToken);
+        // Well inside both timeouts: nothing has been remediated or skipped yet
+        await Task.Delay(TimeoutMs / 4, cancellationToken);
+        await Assert.That(Fixture.Handler.Handled.Count).IsEqualTo(2);
+        await Assert.That(await Fixture.CountTombstones()).IsEqualTo(0);
+
+        var handled = await Fixture.WaitForHandled(5, TimeSpan.FromSeconds(10), cancellationToken);
+        await Assert.That(handled).IsEqualTo(5);
 
         await Fixture.StopSubscription();
 
-        // The tombstone resolves the gap safely: it can only be inserted once the position is proven dead,
-        // so it must be attempted before the skip timeout is allowed to advance the subscription past it.
         var tombstonesCount = await Fixture.CountTombstones();
         await Assert.That(tombstonesCount).IsEqualTo(1);
     }
 
     static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
-        // Both timeouts expire on the same poll, so remediation only runs if it takes precedence over the skip
-        options.GapHandlingTimeoutMs = 500;
-        options.GapSkipTimeoutMs     = 500;
+        options.GapHandlingTimeoutMs = TimeoutMs;
+        options.GapSkipTimeoutMs     = TimeoutMs;
         options.GapAgeThresholdMs    = null; // the gap must not be released by age
     }
 }

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapSkipTimeoutTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapSkipTimeoutTest.cs
@@ -11,25 +11,25 @@ namespace Eventuous.Tests.Postgres.Subscriptions;
 public class GapSkipTimeoutTest() : SubscriptionTestBase(Fixture) {
     static readonly TombstonesFixture Fixture = new(ConfigureOptions);
 
+    const int SkipTimeoutMs = 2000;
+
+    /// <summary>
+    /// The skip timeout has to both hold the subscription for its configured duration and then let it past,
+    /// so this asserts the hold before asserting the release: releasing immediately would satisfy the second
+    /// assertion on its own.
+    /// </summary>
     [Test]
-    public async Task ShouldSkipGapAfterSkipTimeout(CancellationToken cancellationToken) {
-        var streamName = new StreamName("test-stream-gap-skip");
-
-        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(2)], ExpectedStreamVersion.NoStream);
-
-        // The rolled back append burnt a global position that no transaction will ever fill,
-        // so the gap can only be released by the skip timeout.
-        await Fixture.InsertGap(streamName, 1);
-
-        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(3)], ExpectedStreamVersion.Any);
+    public async Task ShouldSkipGapOnlyAfterSkipTimeout(CancellationToken cancellationToken) {
+        await Fixture.ArrangePermanentGap(new("test-stream-gap-skip"));
 
         await Fixture.StartSubscription();
 
-        await Fixture.Handler.AssertThat()
-            .Timebox(TimeSpan.FromSeconds(10))
-            .Exactly(5)
-            .Match(_ => true)
-            .Validate(cancellationToken);
+        // Well inside the timeout, so the subscription is still holding at the gap
+        await Task.Delay(SkipTimeoutMs / 4, cancellationToken);
+        await Assert.That(Fixture.Handler.Handled.Count).IsEqualTo(2);
+
+        var handled = await Fixture.WaitForHandled(5, TimeSpan.FromSeconds(10), cancellationToken);
+        await Assert.That(handled).IsEqualTo(5);
 
         await Fixture.StopSubscription();
 
@@ -38,8 +38,8 @@ public class GapSkipTimeoutTest() : SubscriptionTestBase(Fixture) {
     }
 
     static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
-        options.GapSkipTimeoutMs     = 500;  // the gap must hold the subscription for this long, then be skipped
-        options.GapAgeThresholdMs    = null; // never release a gap by age, so the skip timeout is the only way out
+        options.GapSkipTimeoutMs     = SkipTimeoutMs;
+        options.GapAgeThresholdMs    = null; // the gap must not be released by age
         options.GapHandlingTimeoutMs = null; // no tombstones
     }
 }

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapSkipTimeoutTest.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/GapSkipTimeoutTest.cs
@@ -1,0 +1,45 @@
+// Copyright (C) Eventuous HQ OÜ. All rights reserved
+// Licensed under the Apache License, Version 2.0.
+
+using Eventuous.Postgresql.Subscriptions;
+using Eventuous.Tests.Persistence.Base.Fixtures;
+using Eventuous.Tests.Subscriptions.Base;
+
+namespace Eventuous.Tests.Postgres.Subscriptions;
+
+[NotInParallel]
+public class GapSkipTimeoutTest() : SubscriptionTestBase(Fixture) {
+    static readonly TombstonesFixture Fixture = new(ConfigureOptions);
+
+    [Test]
+    public async Task ShouldSkipGapAfterSkipTimeout(CancellationToken cancellationToken) {
+        var streamName = new StreamName("test-stream-gap-skip");
+
+        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(2)], ExpectedStreamVersion.NoStream);
+
+        // The rolled back append burnt a global position that no transaction will ever fill,
+        // so the gap can only be released by the skip timeout.
+        await Fixture.InsertGap(streamName, 1);
+
+        await Fixture.AppendEvents(streamName, [.. Fixture.CreateEvents(3)], ExpectedStreamVersion.Any);
+
+        await Fixture.StartSubscription();
+
+        await Fixture.Handler.AssertThat()
+            .Timebox(TimeSpan.FromSeconds(10))
+            .Exactly(5)
+            .Match(_ => true)
+            .Validate(cancellationToken);
+
+        await Fixture.StopSubscription();
+
+        var tombstonesCount = await Fixture.CountTombstones();
+        await Assert.That(tombstonesCount).IsEqualTo(0);
+    }
+
+    static void ConfigureOptions(PostgresAllStreamSubscriptionOptions options) {
+        options.GapSkipTimeoutMs     = 500;  // the gap must hold the subscription for this long, then be skipped
+        options.GapAgeThresholdMs    = null; // never release a gap by age, so the skip timeout is the only way out
+        options.GapHandlingTimeoutMs = null; // no tombstones
+    }
+}

--- a/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/TombstonesFixture.cs
+++ b/src/Postgres/test/Eventuous.Tests.Postgres/Subscriptions/TombstonesFixture.cs
@@ -5,6 +5,7 @@ using Eventuous.Postgresql;
 using Eventuous.Postgresql.Extensions;
 using Eventuous.Postgresql.Subscriptions;
 using Eventuous.Sql.Base;
+using Eventuous.Tests.Persistence.Base.Fixtures;
 using Eventuous.Tests.Subscriptions.Base;
 
 namespace Eventuous.Tests.Postgres.Subscriptions;
@@ -16,6 +17,30 @@ public class TombstonesFixture(
     protected internal new TestEventHandler Handler => base.Handler;
     protected internal new ValueTask StartSubscription() => base.StartSubscription();
     protected internal new ValueTask StopSubscription() => base.StopSubscription();
+
+    /// <summary>
+    /// Two events, then a global position burnt by a rolled back append, then three more events. The burnt
+    /// position is never filled, so only gap handling decides whether the last three are ever seen.
+    /// </summary>
+    public async Task ArrangePermanentGap(StreamName streamName) {
+        await this.AppendEvents(streamName, [.. this.CreateEvents(2)], ExpectedStreamVersion.NoStream);
+        await InsertGap(streamName, 1);
+        await this.AppendEvents(streamName, [.. this.CreateEvents(3)], ExpectedStreamVersion.Any);
+    }
+
+    /// <summary>
+    /// Polls the handled messages until <paramref name="count"/> arrive or the timeout expires, and returns
+    /// how many actually arrived so the caller can assert on it.
+    /// </summary>
+    public async Task<int> WaitForHandled(int count, TimeSpan timeout, CancellationToken cancellationToken) {
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (Handler.Handled.Count < count && DateTime.UtcNow < deadline) {
+            await Task.Delay(50, cancellationToken);
+        }
+
+        return Handler.Handled.Count;
+    }
 
     public async Task InsertGap(StreamName streamName, int expectedVersion) {
         await using var conn = await DataSource.OpenConnectionAsync();

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
@@ -74,7 +74,7 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
 
     // ReSharper disable once CognitiveComplexity
 
-    private record DetectedGap(long Position, DateTime FirstSeen);
+    private record DetectedGap(long Position, DateTime FirstSeen, bool RemediationAttempted = false);
 
     /// <summary>
     /// The polling loop. Its only clean exit is a stop request; every other exit is a fault the pump in
@@ -130,6 +130,7 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
 
                     if (gapAge.TotalMilliseconds >= Options.GapHandlingTimeoutMs.Value) {
                         await HandleGapTimeout(gap.Position, start, cancellationToken).NoContext();
+                        gap = gap with { RemediationAttempted = true };
                     }
                 }
 
@@ -188,7 +189,10 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
         if (previousGap?.Position == expectedNext) {
             if (Options.GapSkipTimeoutMs == null) return previousGap;
 
-            return DateTime.UtcNow - previousGap.FirstSeen < TimeSpan.FromMilliseconds(Options.GapSkipTimeoutMs.Value) ? previousGap : null;
+            if (DateTime.UtcNow - previousGap.FirstSeen < TimeSpan.FromMilliseconds(Options.GapSkipTimeoutMs.Value)) return previousGap;
+
+            // Remediation resolves the position safely, unlike skipping it, so it gets its chance first.
+            return Options.GapHandlingTimeoutMs != null && !previousGap.RemediationAttempted ? previousGap : null;
         }
 
         var newGapAge = DateTime.UtcNow - persistedEvent.Created;

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
@@ -183,6 +183,15 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
 
         if (persistedEvent.GlobalPosition <= expectedNext) return null;
 
+        // Evaluated on every poll rather than only when the gap is first seen, and ahead of the held-gap
+        // branch below, which returns without reaching it. A gap whose following event has aged past the
+        // threshold is abandoned however long it has been held; with neither timeout configured this is the
+        // only thing that releases a position no transaction will ever fill.
+        if (Options.GapAgeThresholdMs != null
+         && (DateTime.UtcNow - persistedEvent.Created).TotalMilliseconds >= Options.GapAgeThresholdMs.Value) {
+            return null;
+        }
+
         // The gap we are already holding. Keep the original FirstSeen, so the skip timeout can actually expire:
         // reporting it as a new gap would restart the timer on every poll and hold the subscription forever
         // on a position no transaction will ever fill (a rolled back append still consumes the sequence value).
@@ -195,11 +204,7 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
             return Options.GapHandlingTimeoutMs != null && !previousGap.RemediationAttempted ? previousGap : null;
         }
 
-        var newGapAge = DateTime.UtcNow - persistedEvent.Created;
-
-        return Options.GapAgeThresholdMs == null || newGapAge.TotalMilliseconds < Options.GapAgeThresholdMs.Value
-            ? new DetectedGap(expectedNext, DateTime.UtcNow)
-            : null;
+        return new DetectedGap(expectedNext, DateTime.UtcNow);
     }
 
     /// <summary>

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionBase.cs
@@ -180,21 +180,22 @@ public abstract class SqlSubscriptionBase<TOptions, TConnection>(
     DetectedGap? DetectGap(long start, PersistedEvent persistedEvent, DetectedGap? previousGap) {
         var expectedNext = start < 0 ? 1 : start + 1; // global position identity starts at 1
 
-        if (persistedEvent.GlobalPosition > expectedNext) {
-            if (previousGap != null) {
-                if (Options.GapSkipTimeoutMs == null || (DateTime.UtcNow - previousGap.FirstSeen) < TimeSpan.FromMilliseconds(Options.GapSkipTimeoutMs.Value)) {
-                    return previousGap;
-                }
-            }
+        if (persistedEvent.GlobalPosition <= expectedNext) return null;
 
-            var newGapAge = DateTime.UtcNow - persistedEvent.Created;
+        // The gap we are already holding. Keep the original FirstSeen, so the skip timeout can actually expire:
+        // reporting it as a new gap would restart the timer on every poll and hold the subscription forever
+        // on a position no transaction will ever fill (a rolled back append still consumes the sequence value).
+        if (previousGap?.Position == expectedNext) {
+            if (Options.GapSkipTimeoutMs == null) return previousGap;
 
-            if (Options.GapAgeThresholdMs == null || newGapAge.TotalMilliseconds < Options.GapAgeThresholdMs.Value) {
-                return new(expectedNext, DateTime.UtcNow);
-            }
+            return DateTime.UtcNow - previousGap.FirstSeen < TimeSpan.FromMilliseconds(Options.GapSkipTimeoutMs.Value) ? previousGap : null;
         }
 
-        return null;
+        var newGapAge = DateTime.UtcNow - persistedEvent.Created;
+
+        return Options.GapAgeThresholdMs == null || newGapAge.TotalMilliseconds < Options.GapAgeThresholdMs.Value
+            ? new DetectedGap(expectedNext, DateTime.UtcNow)
+            : null;
     }
 
     /// <summary>

--- a/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionOptionsBase.cs
+++ b/src/Relational/src/Eventuous.Sql.Base/Subscriptions/SqlSubscriptionOptionsBase.cs
@@ -31,22 +31,28 @@ public abstract record SqlSubscriptionOptionsBase : SubscriptionWithCheckpointOp
     public RetryOptions Retry { get; set; } = new();
 
     /// <summary>
-    /// Gap age threshold in milliseconds. If != null, gaps older than this threshold will be ignored entirely,
-    /// allowing the subscription to skip past old missing positions. This is useful for scenarios where
-    /// old tombstones may have been deleted and should not be recreated during replay. Default is 1 hour.
+    /// Gap age threshold in milliseconds. If != null, a gap is ignored entirely when the event that follows it is
+    /// older than this threshold, so replaying history doesn't wait for transactions that finished long ago.
+    /// It's also what lets a subscription eventually move past a position no transaction will ever fill.
+    /// Default is 1 hour.
     /// </summary>
     public int? GapAgeThresholdMs { get; set; } = 60 * 60 * 1000;
 
     /// <summary>
-    /// Gap skip timeout in milliseconds. If != null, a detected gap will only hold the subscription from
-    /// advancing for this duration. Default value is 5 sec.
+    /// Gap skip timeout in milliseconds. If != null, a detected gap stops holding the subscription after this
+    /// duration, and the subscription advances past the missing position. The position is abandoned on elapsed
+    /// time alone, so an append taking longer than this to commit will have its event skipped. Prefer
+    /// <see cref="GapHandlingTimeoutMs"/>, which resolves a gap without that risk and takes precedence over this
+    /// timeout; set this only when advancing matters more than never missing an event.
+    /// Default is null (never abandon a position on time alone).
     /// </summary>
-    public int? GapSkipTimeoutMs { get; set; } = 5000;
+    public int? GapSkipTimeoutMs { get; set; }
 
     /// <summary>
     /// Gap handling timeout in milliseconds. If != null, when a gap in the global position sequence is detected
     /// and it persists for at least this duration, the subscription will attempt to handle it in a provider-specific
-    /// way (e.g. creating tombstones). Default is null (don't create tombstones).
+    /// way (e.g. creating tombstones). Unlike <see cref="GapSkipTimeoutMs"/>, this resolves the position rather than
+    /// abandoning it, and so runs before any skip. Default is null (don't create tombstones).
     /// </summary>
     public int? GapHandlingTimeoutMs { get; set; }
 


### PR DESCRIPTION
Follows up on #424, refs #222.

## The problem

Gap detection holds an all-stream subscription when it sees a hole in the global position sequence, which is what stops concurrent appends from being skipped — transaction (a) takes position 5, (b) takes 6 and commits first, and the subscription waits for 5 rather than running past it. That part works and is covered by `SubscriptionGapsDetection.Postgres_ShouldNotSkipEvents`.

Some positions are never filled, though: a rolled back append still consumes the identity value. Releasing such a gap was broken. `GapSkipTimeoutMs` never fired — `DetectGap` rebuilt the gap with `FirstSeen = DateTime.UtcNow` on every poll, restarting the timer before it could elapse — so release fell to `GapAgeThresholdMs`, default one hour and measured against the `Created` timestamp of the event *after* the gap. A subscription at the head stalled for up to an hour on a permanent gap.

This lives in the shared relational base, so Postgres, SQL Server and SQLite are all affected.

## The fix

**Preserve a held gap's `FirstSeen`** so the skip timeout can expire, and match held gaps by position so an unrelated gap's timer doesn't survive the subscription moving on.

**Evaluate `GapAgeThresholdMs` on every poll, ahead of the held-gap branch.** It previously sat below that branch, which returns without reaching it, so it only ran on the poll that first observed a gap. Age release deliberately precedes remediation: the option exists so replays don't recreate tombstones that were deliberately deleted.

**Let remediation resolve a gap before anything abandons it.** The two escape hatches are not equally safe. `try_insert_tombstone` inserts at the gap position with `overriding system value` and `on conflict do nothing` against the unique `global_position`: a committed row makes it a no-op, an in-flight row makes it *block* until that transaction resolves. It cannot displace a real event. `GapSkipTimeoutMs` has no such interlock — it advances on elapsed time alone, so an append slower than the timeout has its event skipped.

Previously the release cleared `gap` before the remediation check in `PollOnce`, which is gated on a non-null gap, so setting `GapHandlingTimeoutMs` at or above `GapSkipTimeoutMs` silently produced no tombstones and skipped a position it could have resolved. Remediation is now tracked on `DetectedGap.RemediationAttempted` and takes precedence.

**`GapSkipTimeoutMs` now defaults to `null`**, making time-based skipping opt-in. Note this is only safe *together with* the age-threshold reordering above — without it, a null skip timeout returns unconditionally at the held-gap branch and stalls indefinitely.

The XML docs described behaviour the code did not have, and have been corrected.

## Tests

- `GapSkipTimeoutTest` — asserts the hold at a quarter of the timeout, then the release. Before the fix: stalled the full 10s deadline with the checkpoint parked at `Position = 2`.
- `GapRemediationBeforeSkipTest` — both timeouts equal, so remediation only runs if it takes precedence. Before the fix: `Expected to be 1 but found 0` tombstones.
- `GapAgeReleaseWhileRunningTest` — a gap detected while the following event is young, ageing out while subscribed, both timeouts null. Before the reordering: `Expected to be 5 but found 2`. `GapIgnoreTest` did not cover this, as it only tests a gap already old at startup.

Each was verified to fail before its fix and pass after. Locally on net10.0: Postgres 52/52, SQLite 43/43, 0 warnings. SQL Server is excluded on macOS and runs in CI.

## Follow-ups, not in this PR

- `ExecutePollCycle` does `Task.Delay(InitialDelayMs * retryCount++)` — the first retry waits 0ms and the delay then grows unbounded. `Eventuous.Sql.Base` has no test project of its own to cover it.
- SQL Server and SQLite inherit this gap detection but override neither `HandleGapTimeout` nor `ShouldSkipEvent`, so they have no safe resolution available — only the opt-in time-based skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)